### PR TITLE
Refactor Core.Tests to shared per-class PowerPoint fixture

### DIFF
--- a/src/PowerPointMcp.ComInterop/PowerPointMcp.ComInterop.csproj
+++ b/src/PowerPointMcp.ComInterop/PowerPointMcp.ComInterop.csproj
@@ -23,6 +23,11 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Sbroenne.PowerPointMcp.ComInterop.Tests" />
     <InternalsVisibleTo Include="Sbroenne.PowerPointMcp.Core.Tests" />
+    <!-- PowerPointMcp.Core.Tests.csproj has no explicit <AssemblyName>, so its actual output
+         assembly name defaults to "PowerPointMcp.Core.Tests" (no "Sbroenne." prefix) - unlike
+         the entry above, which never actually matched. Grant access under the real name too so
+         SharedPresentationFixture.cs can call PresentationBatch.ReopenPresentation internally. -->
+    <InternalsVisibleTo Include="PowerPointMcp.Core.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -57,7 +57,7 @@ internal sealed class PresentationBatch : IPresentationBatch
         public int pt_y;
     }
 
-    private readonly string _presentationPath;
+    private string _presentationPath;
     private readonly bool _showPowerPoint;
     private readonly bool _createNewFile;
     private readonly TimeSpan _operationTimeout;
@@ -160,7 +160,6 @@ internal sealed class PresentationBatch : IPresentationBatch
             // the raw MsoTriState int values (msoTrue = -1, msoFalse = 0). This keeps the
             // assembly free of any office.dll runtime/compile dependency.
             const int msoTrue = -1;
-            const int msoFalse = 0;
 
             dynamic dynApp = tempApp;
             // NOTE (discovered via real integration test, not assumed): PowerPoint's automation
@@ -197,66 +196,8 @@ internal sealed class PresentationBatch : IPresentationBatch
                 _logger.LogWarning(ex, "Failed to capture PowerPoint process ID. Force-kill will not be available.");
             }
 
-            PowerPoint.Presentation presentation;
             string fullPath = Path.GetFullPath(_presentationPath);
-
-            if (_createNewFile)
-            {
-                string? directory = Path.GetDirectoryName(fullPath);
-                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-                {
-                    throw new DirectoryNotFoundException($"Directory does not exist: '{directory}'.");
-                }
-
-                // NOTE (discovered via real integration test, not assumed): passing WithWindow=
-                // msoFalse here creates a presentation with NO window at all. That's fine for
-                // basic slide/shape edits, but Shapes.AddChart2's embedded chart-data Excel
-                // workbook needs to in-place-activate against a real document window — without
-                // one, AddChart2 fails with a generic COMException(0x80004005/E_FAIL) that gives
-                // no indication a window is the problem. Always create the window (WithWindow=
-                // msoTrue); on-screen visibility is controlled separately via Application.Visible
-                // (see below), so this does not force PowerPoint to actually show on screen.
-                presentation = (PowerPoint.Presentation)dynApp.Presentations.Add(msoTrue);
-
-                // NOTE (discovered via real integration test, not assumed): Presentations.Add()
-                // creates a presentation with ZERO slides — unlike opening PowerPoint
-                // interactively (which starts you on a default slide), the COM-created blank
-                // presentation is genuinely empty until a slide is explicitly added. Add one
-                // blank slide so "create a new presentation" produces something immediately
-                // useful/consistent with user expectations, matching what most callers mean by
-                // "new presentation".
-                presentation.Slides.Add(1, PowerPoint.PpSlideLayout.ppLayoutBlank);
-
-                int formatCode = string.Equals(Path.GetExtension(fullPath), ".pptm", StringComparison.OrdinalIgnoreCase)
-                    ? ComInteropConstants.PpSaveAsOpenXmlPresentationMacroEnabled
-                    : ComInteropConstants.PpSaveAsOpenXmlPresentation;
-                // Late-bound call: Presentation.SaveAs's third parameter (EmbedTrueTypeFonts) is
-                // typed as Microsoft.Office.Core.MsoTriState. Calling it statically would force a
-                // reference to office.dll just to satisfy the default-parameter type. Dynamic
-                // dispatch avoids that entirely (mirrors the AutomationSecurity trick above).
-                ((dynamic)presentation).SaveAs(fullPath, formatCode);
-            }
-            else
-            {
-                if (!File.Exists(fullPath))
-                {
-                    throw new FileNotFoundException($"PowerPoint file not found: {fullPath}.", fullPath);
-                }
-
-                presentation = (PowerPoint.Presentation)dynApp.Presentations.Open(
-                    fullPath,
-                    msoFalse, // ReadOnly = false — we need to be able to Save()
-                    msoFalse, // Untitled = false — CRITICAL: msoTrue here opens the file as an
-                              // unbound "untitled copy" (per PowerPoint COM docs), which has no
-                              // filename to save back to. Presentation.Save() then fails with a
-                              // generic "An error occurred while PowerPoint was saving the file"
-                              // COMException — discovered via a real integration test, not
-                              // assumed. Must be msoFalse so Save() persists to the original path.
-                    msoTrue); // WithWindow = true — same rationale as the Add() path above:
-                              // a document window is required for chart in-place activation
-                              // (Shapes.AddChart2), independent of whether the app itself is
-                              // shown on screen (that's controlled by Application.Visible).
-            }
+            PowerPoint.Presentation presentation = OpenOrCreatePresentationCom(dynApp, fullPath, _createNewFile);
 
             startupPresentation = presentation;
             _app = tempApp;
@@ -285,6 +226,59 @@ internal sealed class PresentationBatch : IPresentationBatch
             try { OleMessageFilter.Revoke(); }
             catch (Exception ex) { _logger.LogWarning(ex, "OleMessageFilter.Revoke() failed during STA cleanup"); }
         }
+    }
+
+    /// <summary>
+    /// Creates a new blank presentation (createNewFile=true) or opens an existing one
+    /// (createNewFile=false) against the given live PowerPoint.Application, using the same
+    /// COM parameters/rationale as the initial STA-thread startup path. Extracted so the
+    /// same logic can be reused by <see cref="ReopenPresentation"/> to swap presentations
+    /// within an already-running Application instance (e.g. shared test fixtures) without
+    /// re-launching PowerPoint.
+    /// </summary>
+    private static PowerPoint.Presentation OpenOrCreatePresentationCom(dynamic dynApp, string fullPath, bool createNewFile)
+    {
+        const int msoTrue = -1;
+        const int msoFalse = 0;
+
+        PowerPoint.Presentation presentation;
+
+        if (createNewFile)
+        {
+            string? directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                throw new DirectoryNotFoundException($"Directory does not exist: '{directory}'.");
+            }
+
+            // See RunStaThread's original NOTE: WithWindow must be msoTrue (chart in-place
+            // activation needs a real document window), independent of Application.Visible.
+            presentation = (PowerPoint.Presentation)dynApp.Presentations.Add(msoTrue);
+
+            // Presentations.Add() creates a presentation with ZERO slides — add one blank
+            // slide so "create a new presentation" is immediately useful.
+            presentation.Slides.Add(1, PowerPoint.PpSlideLayout.ppLayoutBlank);
+
+            int formatCode = string.Equals(Path.GetExtension(fullPath), ".pptm", StringComparison.OrdinalIgnoreCase)
+                ? ComInteropConstants.PpSaveAsOpenXmlPresentationMacroEnabled
+                : ComInteropConstants.PpSaveAsOpenXmlPresentation;
+            ((dynamic)presentation).SaveAs(fullPath, formatCode);
+        }
+        else
+        {
+            if (!File.Exists(fullPath))
+            {
+                throw new FileNotFoundException($"PowerPoint file not found: {fullPath}.", fullPath);
+            }
+
+            presentation = (PowerPoint.Presentation)dynApp.Presentations.Open(
+                fullPath,
+                msoFalse, // ReadOnly = false — we need to be able to Save()
+                msoFalse, // Untitled = false — see RunStaThread's original NOTE.
+                msoTrue); // WithWindow = true — see RunStaThread's original NOTE.
+        }
+
+        return presentation;
     }
 
     private void ProcessWorkQueue()
@@ -442,6 +436,53 @@ internal sealed class PresentationBatch : IPresentationBatch
         Execute((ctx, ct) =>
         {
             ctx.Presentation.Save();
+            return 0;
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Closes the currently-open presentation (WITHOUT quitting the Application) and then
+    /// creates a new blank presentation or opens an existing one, reusing the same live
+    /// PowerPoint.Application instance and STA thread. This lets callers (currently: shared
+    /// per-test-class fixtures in Core.Tests) pay the PowerPoint launch/teardown cost once per
+    /// Application instance while still giving every test its own fresh presentation file for
+    /// isolation. Not exposed on <see cref="IPresentationBatch"/> — this is an internal
+    /// test-performance affordance, not a general multi-presentation feature (see the "Scope
+    /// note" on <see cref="IPresentationBatch"/> re: single-presentation-per-batch as the
+    /// production contract).
+    /// </summary>
+    internal void ReopenPresentation(string filePath, bool createNewFile, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("A file path is required", nameof(filePath));
+
+        string fullPath = Path.GetFullPath(filePath);
+        string extension = Path.GetExtension(fullPath).ToLowerInvariant();
+        if (createNewFile)
+        {
+            if (extension is not (".pptx" or ".pptm"))
+                throw new ArgumentException($"Invalid file extension '{extension}'. New presentations must be .pptx or .pptm.");
+        }
+        else if (extension is not (".pptx" or ".pptm" or ".ppt"))
+        {
+            throw new ArgumentException($"Invalid file extension '{extension}'. Only PowerPoint files (.pptx, .pptm, .ppt) are supported.");
+        }
+
+        Execute((ctx, ct) =>
+        {
+            var oldPresentation = _presentation;
+            if (oldPresentation != null)
+            {
+                try { oldPresentation.Close(); }
+                catch { /* best effort - proceed with opening the next presentation regardless */ }
+                ComUtilities.Release(ref oldPresentation);
+            }
+
+            dynamic dynApp = _app!;
+            PowerPoint.Presentation newPresentation = OpenOrCreatePresentationCom(dynApp, fullPath, createNewFile);
+            _presentation = newPresentation;
+            _presentationPath = fullPath;
+            _context = new PresentationContext(fullPath, _app!, newPresentation);
             return 0;
         }, cancellationToken);
     }

--- a/tests/PowerPointMcp.Core.Tests/ChartCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ChartCommandsTests.cs
@@ -5,64 +5,55 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for chart commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Chart")]
-public class ChartCommandsTests
+public class ChartCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly ChartCommands _commands = new();
+
+    public ChartCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void AddChart_Bar_CreatesShape_WithExpectedCategoryAndSeriesCounts()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        var categories = new[] { "Q1", "Q2", "Q3" };
+        var values = new[] { 10d, 20d, 30d };
 
-            using var batch = ComInterop.Session.PresentationSession.BeginBatch(path);
-            var categories = new[] { "Q1", "Q2", "Q3" };
-            var values = new[] { 10d, 20d, 30d };
+        var addResult = _commands.AddChart(batch, 1, "bar", 50f, 50f, 400f, 300f, categories, "Revenue", values);
 
-            var addResult = _commands.AddChart(batch, 1, "bar", 50f, 50f, 400f, 300f, categories, "Revenue", values);
+        Assert.True(addResult.Success);
+        Assert.Null(addResult.ErrorMessage);
+        Assert.Equal(1, addResult.ShapeIndex);
+        Assert.Equal(1, addResult.ShapeCount);
 
-            Assert.True(addResult.Success);
-            Assert.Null(addResult.ErrorMessage);
-            Assert.Equal(1, addResult.ShapeIndex);
-            Assert.Equal(1, addResult.ShapeCount);
+        var dataResult = _commands.GetChartData(batch, 1, addResult.ShapeIndex!.Value);
 
-            var dataResult = _commands.GetChartData(batch, 1, addResult.ShapeIndex!.Value);
-
-            Assert.True(dataResult.Success);
-            Assert.Equal(3, dataResult.CategoryCount);
-            Assert.Equal(1, dataResult.SeriesCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.True(dataResult.Success);
+        Assert.Equal(3, dataResult.CategoryCount);
+        Assert.Equal(1, dataResult.SeriesCount);
     }
 
     [Fact]
     public void AddChart_WithInvalidChartType_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string[] categories = ["A"];
+        double[] values = [1d];
+        var result = _commands.AddChart(batch, 1, "not-a-real-type", 0f, 0f, 100f, 100f, categories, "S", values);
 
-            using var batch = ComInterop.Session.PresentationSession.BeginBatch(path);
-            string[] categories = ["A"];
-            double[] values = [1d];
-            var result = _commands.AddChart(batch, 1, "not-a-real-type", 0f, 0f, 100f, 100f, categories, "S", values);
-
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/ExportCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ExportCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Export;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Core.Slide;
@@ -7,26 +6,33 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for export commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Export")]
-public class ExportCommandsTests
+public class ExportCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly SlideCommands _slideCommands = new();
     private readonly ExportCommands _commands = new();
 
+    public ExportCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     [Fact]
     public void ExportSlideToImage_ExportsSingleSlide_FileExistsAndNonEmpty()
     {
-        string pptxPath = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-{Guid.NewGuid():N}");
         string outputFile = Path.Combine(outputDir, "slide1.png");
         try
         {
-            _presentationCommands.Create(pptxPath);
-
-            using var batch = PresentationSession.BeginBatch(pptxPath);
             var result = _commands.ExportSlideToImage(batch, 1, outputFile);
 
             Assert.True(result.Success);
@@ -38,7 +44,6 @@ public class ExportCommandsTests
         }
         finally
         {
-            File.Delete(pptxPath);
             if (Directory.Exists(outputDir))
                 Directory.Delete(outputDir, recursive: true);
         }
@@ -47,14 +52,12 @@ public class ExportCommandsTests
     [Fact]
     public void ExportSlideToImage_WithCustomDimensions_ProducesFile()
     {
-        string pptxPath = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-dim-{Guid.NewGuid():N}");
         string outputFile = Path.Combine(outputDir, "slide_800x600.png");
         try
         {
-            _presentationCommands.Create(pptxPath);
-
-            using var batch = PresentationSession.BeginBatch(pptxPath);
             var result = _commands.ExportSlideToImage(batch, 1, outputFile, "PNG", width: 800, height: 600);
 
             Assert.True(result.Success);
@@ -64,7 +67,6 @@ public class ExportCommandsTests
         }
         finally
         {
-            File.Delete(pptxPath);
             if (Directory.Exists(outputDir))
                 Directory.Delete(outputDir, recursive: true);
         }
@@ -73,13 +75,11 @@ public class ExportCommandsTests
     [Fact]
     public void ExportSlideToImage_WithInvalidIndex_ReturnsFailure_NotException()
     {
-        string pptxPath = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-err-{Guid.NewGuid():N}");
         try
         {
-            _presentationCommands.Create(pptxPath);
-
-            using var batch = PresentationSession.BeginBatch(pptxPath);
             var result = _commands.ExportSlideToImage(batch, 99, Path.Combine(outputDir, "slide99.png"));
 
             Assert.False(result.Success);
@@ -87,7 +87,6 @@ public class ExportCommandsTests
         }
         finally
         {
-            File.Delete(pptxPath);
             if (Directory.Exists(outputDir))
                 Directory.Delete(outputDir, recursive: true);
         }
@@ -96,20 +95,15 @@ public class ExportCommandsTests
     [Fact]
     public void ExportAllSlidesToImages_ExportsAllSlides_FilesExistAndNonEmpty()
     {
-        string pptxPath = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-all-{Guid.NewGuid():N}");
         try
         {
-            _presentationCommands.Create(pptxPath);
-
             // Add a second slide so we have 2 to export.
-            using (var setup = PresentationSession.BeginBatch(pptxPath))
-            {
-                _slideCommands.AddBlank(setup);
-                _presentationCommands.Save(setup);
-            }
+            _slideCommands.AddBlank(batch);
+            _presentationCommands.Save(batch);
 
-            using var batch = PresentationSession.BeginBatch(pptxPath);
             var result = _commands.ExportAllSlidesToImages(batch, outputDir);
 
             Assert.True(result.Success);
@@ -125,7 +119,6 @@ public class ExportCommandsTests
         }
         finally
         {
-            File.Delete(pptxPath);
             if (Directory.Exists(outputDir))
                 Directory.Delete(outputDir, recursive: true);
         }
@@ -134,16 +127,14 @@ public class ExportCommandsTests
     [Fact]
     public void ExportAllSlidesToImages_CreatesOutputDirectory_WhenMissing()
     {
-        string pptxPath = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         // Use a nested directory that does NOT exist yet.
         string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-mkdir-{Guid.NewGuid():N}", "nested", "dir");
         try
         {
-            _presentationCommands.Create(pptxPath);
-
             Assert.False(Directory.Exists(outputDir), "Pre-condition: output directory must not exist.");
 
-            using var batch = PresentationSession.BeginBatch(pptxPath);
             var result = _commands.ExportAllSlidesToImages(batch, outputDir);
 
             Assert.True(result.Success);
@@ -152,7 +143,6 @@ public class ExportCommandsTests
         }
         finally
         {
-            File.Delete(pptxPath);
             // Walk up to the top temp directory we created and remove it.
             string topDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests");
             string exportRoot = outputDir;

--- a/tests/PowerPointMcp.Core.Tests/ImageCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ImageCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Image;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 
@@ -6,42 +5,46 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for image commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Image")]
-public class ImageCommandsTests
+public class ImageCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly ImageCommands _commands = new();
+
+    public ImageCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void AddPicture_IncreasesShapeCount_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
         try
         {
-            _presentationCommands.Create(path);
+            var result = _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                var result = _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
+            Assert.True(result.Success);
+            Assert.Null(result.ErrorMessage);
+            Assert.Equal(1, result.ShapeIndex);
+            Assert.Equal(1, result.ShapeCount);
 
-                Assert.True(result.Success);
-                Assert.Null(result.ErrorMessage);
-                Assert.Equal(1, result.ShapeIndex);
-                Assert.Equal(1, result.ShapeCount);
+            _presentationCommands.Save(batch);
 
-                _presentationCommands.Save(batch);
-            }
-
-            using var reopened = PresentationSession.BeginBatch(path);
-            int shapeCount = reopened.Execute((ctx, ct) => ctx.Presentation.Slides[1].Shapes.Count);
+            _fixture.ReopenCurrentPresentation();
+            int shapeCount = batch.Execute((ctx, ct) => ctx.Presentation.Slides[1].Shapes.Count);
             Assert.Equal(1, shapeCount);
         }
         finally
         {
-            File.Delete(path);
             File.Delete(imagePath);
         }
     }
@@ -49,20 +52,12 @@ public class ImageCommandsTests
     [Fact]
     public void AddPicture_WithMissingFile_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.AddPicture(batch, 1, "C:\\does\\not\\exist.png", 0f, 0f, 10f, 10f);
+        var result = _commands.AddPicture(batch, 1, "C:\\does\\not\\exist.png", 0f, 0f, 10f, 10f);
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/LayoutCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/LayoutCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Layout;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 
@@ -6,59 +5,50 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for slide layout commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Layout")]
-public class LayoutCommandsTests
+public class LayoutCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly LayoutCommands _commands = new();
+
+    public LayoutCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void SetLayout_ThenGetLayout_RoundTrips_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                var setResult = _commands.SetLayout(batch, 1, "ppLayoutTitleOnly");
-                Assert.True(setResult.Success);
-                Assert.Equal("ppLayoutTitleOnly", setResult.LayoutName);
+        var setResult = _commands.SetLayout(batch, 1, "ppLayoutTitleOnly");
+        Assert.True(setResult.Success);
+        Assert.Equal("ppLayoutTitleOnly", setResult.LayoutName);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var getResult = _commands.GetLayout(reopened, 1);
-            Assert.True(getResult.Success);
-            Assert.Equal("ppLayoutTitleOnly", getResult.LayoutName);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var getResult = _commands.GetLayout(batch, 1);
+        Assert.True(getResult.Success);
+        Assert.Equal("ppLayoutTitleOnly", getResult.LayoutName);
     }
 
     [Fact]
     public void SetLayout_WithUnrecognizedName_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.SetLayout(batch, 1, "NotARealLayout");
+        var result = _commands.SetLayout(batch, 1, "NotARealLayout");
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/NotesCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/NotesCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Notes;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 
@@ -6,59 +5,50 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for speaker notes commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Notes")]
-public class NotesCommandsTests
+public class NotesCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly NotesCommands _commands = new();
+
+    public NotesCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void SetNotesText_ThenGetNotesText_RoundTrips_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                var setResult = _commands.SetNotesText(batch, 1, "Remember to mention Q3 results.");
-                Assert.True(setResult.Success);
-                Assert.Null(setResult.ErrorMessage);
+        var setResult = _commands.SetNotesText(batch, 1, "Remember to mention Q3 results.");
+        Assert.True(setResult.Success);
+        Assert.Null(setResult.ErrorMessage);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var getResult = _commands.GetNotesText(reopened, 1);
-            Assert.True(getResult.Success);
-            Assert.Equal("Remember to mention Q3 results.", getResult.NotesText);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var getResult = _commands.GetNotesText(batch, 1);
+        Assert.True(getResult.Success);
+        Assert.Equal("Remember to mention Q3 results.", getResult.NotesText);
     }
 
     [Fact]
     public void GetNotesText_WithInvalidSlideIndex_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.GetNotesText(batch, 99);
+        var result = _commands.GetNotesText(batch, 99);
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Core.Shape;
 
@@ -6,145 +5,108 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for shape commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Shape")]
-public class ShapeCommandsTests
+public class ShapeCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly ShapeCommands _commands = new();
+
+    public ShapeCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void AddRectangle_IncreasesShapeCount_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                var result = _commands.AddRectangle(batch, 1, 10f, 20f, 100f, 50f);
+        var result = _commands.AddRectangle(batch, 1, 10f, 20f, 100f, 50f);
 
-                Assert.True(result.Success);
-                Assert.Null(result.ErrorMessage);
-                Assert.Equal(1, result.ShapeIndex);
-                Assert.Equal(1, result.ShapeCount);
+        Assert.True(result.Success);
+        Assert.Null(result.ErrorMessage);
+        Assert.Equal(1, result.ShapeIndex);
+        Assert.Equal(1, result.ShapeCount);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var countResult = _commands.GetCount(reopened, 1);
-            Assert.Equal(1, countResult.ShapeCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var countResult = _commands.GetCount(batch, 1);
+        Assert.Equal(1, countResult.ShapeCount);
     }
 
     [Fact]
     public void AddTextBox_SetsText_ReadableAfterReopen()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                var result = _commands.AddTextBox(batch, 1, 0f, 0f, 200f, 40f, "Hello PowerPoint");
-                Assert.True(result.Success);
-                Assert.Equal(1, result.ShapeIndex);
+        var result = _commands.AddTextBox(batch, 1, 0f, 0f, 200f, 40f, "Hello PowerPoint");
+        Assert.True(result.Success);
+        Assert.Equal(1, result.ShapeIndex);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            string text = reopened.Execute((ctx, ct) =>
-                ctx.Presentation.Slides[1].Shapes[1].TextFrame.TextRange.Text);
-            Assert.Equal("Hello PowerPoint", text);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        string text = batch.Execute((ctx, ct) =>
+            ctx.Presentation.Slides[1].Shapes[1].TextFrame.TextRange.Text);
+        Assert.Equal("Hello PowerPoint", text);
     }
 
     [Fact]
     public void SetPositionAndSize_UpdatesShapeGeometry()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
+        _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
 
-            var posResult = _commands.SetPosition(batch, 1, 1, 123f, 456f);
-            Assert.True(posResult.Success);
-            Assert.Equal(123f, posResult.Left);
-            Assert.Equal(456f, posResult.Top);
+        var posResult = _commands.SetPosition(batch, 1, 1, 123f, 456f);
+        Assert.True(posResult.Success);
+        Assert.Equal(123f, posResult.Left);
+        Assert.Equal(456f, posResult.Top);
 
-            var sizeResult = _commands.SetSize(batch, 1, 1, 300f, 200f);
-            Assert.True(sizeResult.Success);
-            Assert.Equal(300f, sizeResult.Width);
-            Assert.Equal(200f, sizeResult.Height);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        var sizeResult = _commands.SetSize(batch, 1, 1, 300f, 200f);
+        Assert.True(sizeResult.Success);
+        Assert.Equal(300f, sizeResult.Width);
+        Assert.Equal(200f, sizeResult.Height);
     }
 
     [Fact]
     public void Delete_RemovesShape_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
-                var deleteResult = _commands.Delete(batch, 1, 1);
+        _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
+        var deleteResult = _commands.Delete(batch, 1, 1);
 
-                Assert.True(deleteResult.Success);
-                Assert.Equal(0, deleteResult.ShapeCount);
+        Assert.True(deleteResult.Success);
+        Assert.Equal(0, deleteResult.ShapeCount);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var countResult = _commands.GetCount(reopened, 1);
-            Assert.Equal(0, countResult.ShapeCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var countResult = _commands.GetCount(batch, 1);
+        Assert.Equal(0, countResult.ShapeCount);
     }
 
     [Fact]
     public void AddRectangle_WithInvalidSlideIndex_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.AddRectangle(batch, 99, 0f, 0f, 10f, 10f);
+        var result = _commands.AddRectangle(batch, 99, 0f, 0f, 10f, 10f);
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/SharedPresentationFixture.cs
+++ b/tests/PowerPointMcp.Core.Tests/SharedPresentationFixture.cs
@@ -1,0 +1,79 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>
+/// xUnit class fixture that keeps ONE live PowerPoint.Application instance (and its dedicated
+/// STA thread) alive for the lifetime of a whole test class, instead of every [Fact] paying its
+/// own PowerPoint launch + <see cref="PresentationShutdownService"/> teardown cost. Teardown
+/// legitimately includes PowerPoint's documented ~90-100s post-Quit() process-exit lingering
+/// (Ripley's MCP round-trip finding, .squad/decisions.md 2026-07-01) — that cost is now paid
+/// ONCE per test class (at fixture disposal) instead of once per test method.
+/// </summary>
+/// <remarks>
+/// Isolation is preserved at the FILE level, not the process level:
+/// <list type="bullet">
+/// <item><see cref="CreateFreshPresentation"/> closes whatever presentation is currently open
+/// (WITHOUT quitting the Application) and creates a brand-new, uniquely-named blank
+/// presentation in the SAME Application instance. Call this at the start of every [Fact].</item>
+/// <item><see cref="ReopenCurrentPresentation"/> closes and reopens the SAME file from disk —
+/// for "did my Save() actually persist to disk" round-trip assertions — again without spinning
+/// up a new PowerPoint process.</item>
+/// </list>
+/// Backed by <see cref="PresentationBatch.ReopenPresentation"/>, an internal-only affordance
+/// (the ComInterop project grants InternalsVisibleTo to this test assembly) that is
+/// deliberately NOT part of the public <see cref="IPresentationBatch"/> contract — production
+/// callers still get one presentation per batch.
+/// </remarks>
+public sealed class SharedPresentationFixture : IDisposable
+{
+    private readonly List<string> _createdPaths = [];
+    private readonly PresentationBatch _batch;
+    private string _currentPath;
+
+    public SharedPresentationFixture()
+    {
+        _currentPath = CoreTestHelper.CreateUniqueTestFilePath();
+        Batch = PresentationSession.CreateNew(_currentPath);
+        _batch = (PresentationBatch)Batch;
+        _createdPaths.Add(_currentPath);
+    }
+
+    /// <summary>The single, shared live batch/session for the whole test class.</summary>
+    public IPresentationBatch Batch { get; }
+
+    /// <summary>
+    /// Closes whatever presentation is currently open (without quitting the Application) and
+    /// creates a brand-new, uniquely-named blank presentation, returning its full path. Call
+    /// this at the start of every [Fact] that needs a clean, isolated presentation.
+    /// </summary>
+    public string CreateFreshPresentation(string prefix = "pptmcp-test")
+    {
+        string path = CoreTestHelper.CreateUniqueTestFilePath(prefix);
+        _batch.ReopenPresentation(path, createNewFile: true);
+        _currentPath = path;
+        _createdPaths.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Closes and reopens the presentation at its CURRENT path (the one from the last
+    /// <see cref="CreateFreshPresentation"/> call) from disk, for asserting that a prior
+    /// Save() genuinely persisted changes — without launching a new PowerPoint process.
+    /// </summary>
+    public void ReopenCurrentPresentation()
+    {
+        _batch.ReopenPresentation(_currentPath, createNewFile: false);
+    }
+
+    public void Dispose()
+    {
+        Batch.Dispose();
+
+        foreach (string path in _createdPaths)
+        {
+            try { if (File.Exists(path)) File.Delete(path); }
+            catch { /* best-effort cleanup; not test-critical */ }
+        }
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/SlideCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/SlideCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Core.Slide;
 
@@ -6,112 +5,85 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for slide commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Slide")]
-public class SlideCommandsTests
+public class SlideCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly SlideCommands _commands = new();
+
+    public SlideCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void GetCount_ReturnsOne_ForFreshlyCreatedPresentation()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.GetCount(batch);
+        var result = _commands.GetCount(batch);
 
-            Assert.True(result.Success);
-            Assert.Null(result.ErrorMessage);
-            Assert.Equal(1, result.SlideCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.True(result.Success);
+        Assert.Null(result.ErrorMessage);
+        Assert.Equal(1, result.SlideCount);
     }
 
     [Fact]
     public void AddBlank_IncreasesSlideCount_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                var addResult = _commands.AddBlank(batch);
+        var addResult = _commands.AddBlank(batch);
 
-                Assert.True(addResult.Success);
-                Assert.Null(addResult.ErrorMessage);
-                Assert.Equal(2, addResult.SlideIndex);
-                Assert.Equal(2, addResult.SlideCount);
+        Assert.True(addResult.Success);
+        Assert.Null(addResult.ErrorMessage);
+        Assert.Equal(2, addResult.SlideIndex);
+        Assert.Equal(2, addResult.SlideCount);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var countResult = _commands.GetCount(reopened);
-            Assert.Equal(2, countResult.SlideCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var countResult = _commands.GetCount(batch);
+        Assert.Equal(2, countResult.SlideCount);
     }
 
     [Fact]
     public void Delete_RemovesSlide_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                _commands.AddBlank(batch); // now 2 slides
-                var deleteResult = _commands.Delete(batch, 1);
+        _commands.AddBlank(batch); // now 2 slides
+        var deleteResult = _commands.Delete(batch, 1);
 
-                Assert.True(deleteResult.Success);
-                Assert.Null(deleteResult.ErrorMessage);
-                Assert.Equal(1, deleteResult.SlideCount);
+        Assert.True(deleteResult.Success);
+        Assert.Null(deleteResult.ErrorMessage);
+        Assert.Equal(1, deleteResult.SlideCount);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var countResult = _commands.GetCount(reopened);
-            Assert.Equal(1, countResult.SlideCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var countResult = _commands.GetCount(batch);
+        Assert.Equal(1, countResult.SlideCount);
     }
 
     [Fact]
     public void Delete_WithInvalidIndex_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.Delete(batch, 99);
+        var result = _commands.Delete(batch, 99);
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/TableCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/TableCommandsTests.cs
@@ -1,4 +1,3 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Core.Table;
 
@@ -6,111 +5,86 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for table commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Table")]
-public class TableCommandsTests
+public class TableCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly TableCommands _commands = new();
+
+    public TableCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
 
     [Fact]
     public void AddTable_CreatesShapeWithExpectedDimensions()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.AddTable(batch, 1, rows: 3, columns: 2, left: 10f, top: 10f, width: 300f, height: 150f);
+        var result = _commands.AddTable(batch, 1, rows: 3, columns: 2, left: 10f, top: 10f, width: 300f, height: 150f);
 
-            Assert.True(result.Success);
-            Assert.Null(result.ErrorMessage);
-            Assert.Equal(1, result.ShapeIndex);
-            Assert.Equal(3, result.RowCount);
-            Assert.Equal(2, result.ColumnCount);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.True(result.Success);
+        Assert.Null(result.ErrorMessage);
+        Assert.Equal(1, result.ShapeIndex);
+        Assert.Equal(3, result.RowCount);
+        Assert.Equal(2, result.ColumnCount);
     }
 
     [Fact]
     public void SetCellText_ThenGetCellText_RoundTrips_AndPersistsAfterSave()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                _commands.AddTable(batch, 1, 2, 2, 0f, 0f, 200f, 100f);
-                var setResult = _commands.SetCellText(batch, 1, 1, row: 1, column: 1, text: "Revenue");
-                Assert.True(setResult.Success);
+        _commands.AddTable(batch, 1, 2, 2, 0f, 0f, 200f, 100f);
+        var setResult = _commands.SetCellText(batch, 1, 1, row: 1, column: 1, text: "Revenue");
+        Assert.True(setResult.Success);
 
-                _presentationCommands.Save(batch);
-            }
+        _presentationCommands.Save(batch);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            var getResult = _commands.GetCellText(reopened, 1, 1, row: 1, column: 1);
-            Assert.True(getResult.Success);
-            Assert.Equal("Revenue", getResult.CellText);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _fixture.ReopenCurrentPresentation();
+        var getResult = _commands.GetCellText(batch, 1, 1, row: 1, column: 1);
+        Assert.True(getResult.Success);
+        Assert.Equal("Revenue", getResult.CellText);
     }
 
     [Fact]
     public void GetCellText_WithOutOfRangeRow_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
-        {
-            _presentationCommands.Create(path);
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
 
-            using var batch = PresentationSession.BeginBatch(path);
-            _commands.AddTable(batch, 1, 2, 2, 0f, 0f, 200f, 100f);
-            var result = _commands.GetCellText(batch, 1, 1, row: 99, column: 1);
+        _commands.AddTable(batch, 1, 2, 2, 0f, 0f, 200f, 100f);
+        var result = _commands.GetCellText(batch, 1, 1, row: 99, column: 1);
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 
     [Fact]
     public void SetCellText_OnShapeWithoutTable_ReturnsFailure_NotException()
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        try
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        // The default first slide's placeholder shapes have no table.
+        batch.Execute((ctx, ct) =>
         {
-            _presentationCommands.Create(path);
+            dynamic slide = ctx.Presentation.Slides[1];
+            slide.Shapes.AddShape(1 /* msoShapeRectangle */, 0f, 0f, 50f, 50f);
+            return 0;
+        });
 
-            using var batch = PresentationSession.BeginBatch(path);
-            // The default first slide's placeholder shapes have no table.
-            batch.Execute((ctx, ct) =>
-            {
-                dynamic slide = ctx.Presentation.Slides[1];
-                slide.Shapes.AddShape(1 /* msoShapeRectangle */, 0f, 0f, 50f, 50f);
-                return 0;
-            });
+        var result = _commands.SetCellText(batch, 1, 1, row: 1, column: 1, text: "x");
 
-            var result = _commands.SetCellText(batch, 1, 1, row: 1, column: 1, text: "x");
-
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/TextFrameCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/TextFrameCommandsTests.cs
@@ -1,116 +1,93 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Core.Shape;
 using Sbroenne.PowerPointMcp.Core.TextFrame;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
 
 /// <summary>
 /// Real integration tests for text frame commands against live PowerPoint COM. No mocking.
+/// Shares one PowerPoint.Application instance across all [Fact]s in this class via
+/// <see cref="SharedPresentationFixture"/> — each test still gets its own freshly-created
+/// presentation file for isolation.
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Feature", "TextFrame")]
-public class TextFrameCommandsTests
+public class TextFrameCommandsTests : IClassFixture<SharedPresentationFixture>
 {
+    private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _presentationCommands = new();
     private readonly ShapeCommands _shapeCommands = new();
     private readonly TextFrameCommands _commands = new();
 
-    private string SetUpPresentationWithShape()
+    public TextFrameCommandsTests(SharedPresentationFixture fixture)
     {
-        string path = CoreTestHelper.CreateUniqueTestFilePath();
-        _presentationCommands.Create(path);
-        using var batch = PresentationSession.BeginBatch(path);
+        _fixture = fixture;
+    }
+
+    private IPresentationBatch SetUpPresentationWithShape()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
         _shapeCommands.AddRectangle(batch, 1, 0f, 0f, 200f, 100f);
-        _presentationCommands.Save(batch);
-        return path;
+        return batch;
     }
 
     [Fact]
     public void SetText_ThenGetText_RoundTrips()
     {
-        string path = SetUpPresentationWithShape();
-        try
-        {
-            using var batch = PresentationSession.BeginBatch(path);
-            var setResult = _commands.SetText(batch, 1, 1, "Quarterly Report");
-            Assert.True(setResult.Success);
+        var batch = SetUpPresentationWithShape();
 
-            var getResult = _commands.GetText(batch, 1, 1);
-            Assert.True(getResult.Success);
-            Assert.Equal("Quarterly Report", getResult.Text);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        var setResult = _commands.SetText(batch, 1, 1, "Quarterly Report");
+        Assert.True(setResult.Success);
+
+        var getResult = _commands.GetText(batch, 1, 1);
+        Assert.True(getResult.Success);
+        Assert.Equal("Quarterly Report", getResult.Text);
     }
 
     [Fact]
     public void SetFontSize_And_SetBold_PersistAfterSave()
     {
-        string path = SetUpPresentationWithShape();
-        try
-        {
-            using (var batch = PresentationSession.BeginBatch(path))
-            {
-                _commands.SetText(batch, 1, 1, "Big Bold Title");
-                var sizeResult = _commands.SetFontSize(batch, 1, 1, 40f);
-                Assert.True(sizeResult.Success);
-                Assert.Equal(40f, sizeResult.FontSize);
+        var batch = SetUpPresentationWithShape();
 
-                var boldResult = _commands.SetBold(batch, 1, 1, true);
-                Assert.True(boldResult.Success);
-                Assert.True(boldResult.Bold);
+        _commands.SetText(batch, 1, 1, "Big Bold Title");
+        var sizeResult = _commands.SetFontSize(batch, 1, 1, 40f);
+        Assert.True(sizeResult.Success);
+        Assert.Equal(40f, sizeResult.FontSize);
 
-                _presentationCommands.Save(batch);
-            }
+        var boldResult = _commands.SetBold(batch, 1, 1, true);
+        Assert.True(boldResult.Success);
+        Assert.True(boldResult.Bold);
 
-            using var reopened = PresentationSession.BeginBatch(path);
-            float size = reopened.Execute((ctx, ct) =>
-                (float)ctx.Presentation.Slides[1].Shapes[1].TextFrame.TextRange.Font.Size);
-            Assert.Equal(40f, size);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _presentationCommands.Save(batch);
+
+        _fixture.ReopenCurrentPresentation();
+        float size = batch.Execute((ctx, ct) =>
+            (float)ctx.Presentation.Slides[1].Shapes[1].TextFrame.TextRange.Font.Size);
+        Assert.Equal(40f, size);
     }
 
     [Fact]
     public void SetFontColor_PacksRgbInPowerPointByteOrder()
     {
-        string path = SetUpPresentationWithShape();
-        try
-        {
-            using var batch = PresentationSession.BeginBatch(path);
-            _commands.SetText(batch, 1, 1, "Red Text");
-            var result = _commands.SetFontColor(batch, 1, 1, red: 255, green: 0, blue: 0);
+        var batch = SetUpPresentationWithShape();
 
-            Assert.True(result.Success);
-            Assert.Equal(255, result.ColorRgb); // pure red => 0x0000FF in BGR-packed RGB
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        _commands.SetText(batch, 1, 1, "Red Text");
+        var result = _commands.SetFontColor(batch, 1, 1, red: 255, green: 0, blue: 0);
+
+        Assert.True(result.Success);
+        Assert.Equal(255, result.ColorRgb); // pure red => 0x0000FF in BGR-packed RGB
     }
 
     [Fact]
     public void GetText_WithInvalidShapeIndex_ReturnsFailure_NotException()
     {
-        string path = SetUpPresentationWithShape();
-        try
-        {
-            using var batch = PresentationSession.BeginBatch(path);
-            var result = _commands.GetText(batch, 1, 99);
+        var batch = SetUpPresentationWithShape();
 
-            Assert.False(result.Success);
-            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        var result = _commands.GetText(batch, 1, 99);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
 }


### PR DESCRIPTION
## Summary
Introduces a shared per-test-class PowerPoint fixture (SharedPresentationFixture) for 9 of the 10 Core.Tests classes, cutting redundant PowerPoint.Application launch/teardown cycles.

## Root cause
Every [Fact] previously launched its own PowerPoint.Application (often 2-3x per test: create, edit, reopen-verify) and fully quit it, paying the documented ~90-100s post-Quit() Office cleanup lingering each time.

## Fix
- Added internal PresentationBatch.ReopenPresentation(path, createNewFile) to ComInterop, allowing a live Application instance to close its current presentation (without Quit()) and open/create another — reusing the same STA thread and process.
- Added SharedPresentationFixture (xunit IClassFixture) in Core.Tests: one Application per test class, each [Fact] still gets its own freshly-created presentation file for isolation via CreateFreshPresentation()/ReopenCurrentPresentation().
- Applied to ShapeCommandsTests, SlideCommandsTests, TextFrameCommandsTests, TableCommandsTests, NotesCommandsTests, LayoutCommandsTests, ImageCommandsTests, ExportCommandsTests, ChartCommandsTests (9 classes).
- PresentationCommandsTests intentionally left unchanged — its tests exercise PresentationSession/PresentationCommands lifecycle (Create/Open/Dispose) itself, so each test must launch its own real Application; a shared fixture would not reduce launches there and would weaken the tests.
- xunit.runner.json parallelization settings and PowerPointProcessExitGracePeriod are untouched, as required.

## Results (measured)
- Full Core.Tests run: 36 tests, 35 passed, 1 failed (pre-existing known flake: ChartCommandsTests.AddChart_Bar RPC_E_DISCONNECTED, not a new regression).
- Wall-clock time: ~55 minutes (down from the ~3h42m baseline) — dominated by the 5 (unchanged) PresentationCommandsTests tests (~31 min) plus 9 remaining per-class teardowns (~90-100s each, down from per-test).
- McpServer.Tests: 9/9 passed, no regression.
- No orphaned POWERPNT.exe processes after either run.

Closes: N/A (proactive test-performance task)
