### PR TITLE
Fix build-cli CI check falsely failing on expected exit code 1

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -72,6 +72,9 @@ jobs:
           # and exit 1 until a real command surface (and --help) lands.
           & $exePath | Out-Null
           Write-Output "✅ CLI executable runs (usage/placeholder mode, exit code $LASTEXITCODE expected)"
+          # Reset $LASTEXITCODE: the placeholder CLI's exit 1 above is expected
+          # behavior, not a step failure — don't let it fail this workflow step.
+          $global:LASTEXITCODE = 0
         } else {
           Write-Error "❌ powerpointcli.exe not found at $exePath"
           exit 1


### PR DESCRIPTION
Closes the pre-existing build-cli failure that's been on main for the last 5 commits. The placeholder CLI intentionally exits 1 when run with no args (documented in the step's own comments); \\0\ wasn't being reset after that expected call, so the step failed the check even though behavior was correct.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>