### PR TITLE
Add out-of-process CLI daemon (PowerPointMcp.Service) — reverses 2026-07-06 'drop Service' decision

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -58,8 +58,9 @@ jobs:
 
     - name: Verify CLI build
       run: |
-        # CLI targets plain net10.0 (not net10.0-windows) per PowerPointMcp.CLI.csproj.
-        $exePath = "src/PowerPointMcp.CLI/bin/Release/net10.0/powerpointcli.exe"
+        # CLI now targets net10.0-windows (changed from plain net10.0 to support the
+        # PowerPointMcp.Service daemon's COM/Windows dependencies).
+        $exePath = "src/PowerPointMcp.CLI/bin/Release/net10.0-windows/powerpointcli.exe"
         if (Test-Path $exePath) {
           Write-Output "✅ powerpointcli.exe built successfully"
           $version = (Get-Item $exePath).VersionInfo.FileVersion

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,12 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <!-- MCP SDK -->
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <!-- CLI daemon transport (named pipes + JSON-RPC 2.0), ported from mcp-server-excel -->
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.25" />
+    <!-- Security override: StreamJsonRpc transitively pins vulnerable MessagePack versions -->
+    <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack.Annotations" Version="3.1.7" />
     <!-- Test dependencies -->
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/Sbroenne.PowerPointMcp.slnx
+++ b/Sbroenne.PowerPointMcp.slnx
@@ -7,6 +7,7 @@
     <Project Path="src/PowerPointMcp.Generators.Cli/PowerPointMcp.Generators.Cli.csproj" />
     <Project Path="src/PowerPointMcp.Generators.Shared/PowerPointMcp.Generators.Shared.csproj" />
     <Project Path="src/PowerPointMcp.McpServer/PowerPointMcp.McpServer.csproj" />
+    <Project Path="src/PowerPointMcp.Service/PowerPointMcp.Service.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/PowerPointMcp.Core.Tests/PowerPointMcp.Core.Tests.csproj" />

--- a/src/PowerPointMcp.CLI/Commands/ServiceCommands.cs
+++ b/src/PowerPointMcp.CLI/Commands/ServiceCommands.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.CLI.Infrastructure;
+using Sbroenne.PowerPointMcp.Service;
+using Spectre.Console.Cli;
+
+namespace Sbroenne.PowerPointMcp.CLI.Commands;
+
+/// <summary>Settings shared by "service" subcommands that need the pipe name.</summary>
+internal class ServicePipeSettings : CommandSettings
+{
+    [CommandOption("--pipe-name <PIPE_NAME>")]
+    [Description("Override the daemon's named pipe (defaults to a per-user pipe name).")]
+    public string? PipeName { get; init; }
+
+    /// <summary>Gets the effective pipe name, defaulting to the shared per-user CLI pipe.</summary>
+    public string ResolvedPipeName => string.IsNullOrWhiteSpace(PipeName) ? DaemonAutoStart.GetPipeName() : PipeName;
+}
+
+/// <summary>Starts the CLI daemon if it isn't already running (auto-starts, then reports status).</summary>
+internal sealed class ServiceStartCommand : AsyncCommand<ServicePipeSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, ServicePipeSettings settings, CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest { Command = "service.status", Source = "cli" }, cancellationToken);
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}
+
+/// <summary>Settings for "service stop".</summary>
+internal sealed class ServiceStopSettings : ServicePipeSettings
+{
+    [CommandOption("--force")]
+    [Description("Force-kill the daemon process if a graceful RPC shutdown doesn't respond.")]
+    public bool Force { get; init; }
+}
+
+/// <summary>Stops the running CLI daemon (graceful RPC shutdown, or force-kill with --force).</summary>
+internal sealed class ServiceStopCommand : AsyncCommand<ServiceStopSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, ServiceStopSettings settings, CancellationToken cancellationToken)
+    {
+        var pipeName = settings.ResolvedPipeName;
+        using var client = new ServiceClient(pipeName);
+
+        if (await client.PingAsync(cancellationToken))
+        {
+            var response = await client.SendAsync(new ServiceRequest { Command = "service.shutdown", Source = "cli" }, cancellationToken);
+            if (response.Success)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Daemon shutdown requested." }, ServiceProtocol.JsonOptions));
+                return 0;
+            }
+
+            if (!settings.Force)
+            {
+                return CliErrorOutput.WriteServiceError(response);
+            }
+        }
+        else if (!settings.Force)
+        {
+            return CliErrorOutput.WriteError("Daemon is not running.");
+        }
+
+        if (settings.Force && DaemonProcessTracker.TryForceStopTrackedDaemon(pipeName))
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new { success = true, message = "Daemon process force-killed." }, ServiceProtocol.JsonOptions));
+            return 0;
+        }
+
+        return CliErrorOutput.WriteError("Daemon is not running or could not be stopped.");
+    }
+}
+
+/// <summary>Reports whether the CLI daemon is running, plus its session count and uptime.</summary>
+internal sealed class ServiceStatusCommand : AsyncCommand<ServicePipeSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, ServicePipeSettings settings, CancellationToken cancellationToken)
+    {
+        var pipeName = settings.ResolvedPipeName;
+        using var client = new ServiceClient(pipeName);
+
+        if (!await client.PingAsync(cancellationToken))
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new { success = true, running = false }, ServiceProtocol.JsonOptions));
+            return 0;
+        }
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "service.status", Source = "cli" }, cancellationToken);
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}

--- a/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
+++ b/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
@@ -1,0 +1,163 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.CLI.Infrastructure;
+using Sbroenne.PowerPointMcp.Service;
+using Spectre.Console.Cli;
+
+namespace Sbroenne.PowerPointMcp.CLI.Commands;
+
+/// <summary>Settings shared by the "session open"/"session create" commands.</summary>
+internal sealed class SessionOpenSettings : CommandSettings
+{
+    [CommandArgument(0, "<FILE_PATH>")]
+    [Description("Full path to the .pptx/.pptm presentation file.")]
+    public string FilePath { get; init; } = string.Empty;
+}
+
+/// <summary>Opens an existing presentation and returns a session id for subsequent commands.</summary>
+internal sealed class SessionOpenCommand : AsyncCommand<SessionOpenSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionOpenSettings settings, CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = "session.open",
+            Args = JsonSerializer.Serialize(new { filePath = settings.FilePath }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}
+
+/// <summary>Creates a new presentation and returns a session id for subsequent commands.</summary>
+internal sealed class SessionCreateCommand : AsyncCommand<SessionOpenSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionOpenSettings settings, CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = "session.create",
+            Args = JsonSerializer.Serialize(new { filePath = settings.FilePath }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}
+
+/// <summary>Settings for the "session close" command.</summary>
+internal sealed class SessionCloseSettings : CommandSettings
+{
+    [CommandArgument(0, "<SESSION_ID>")]
+    [Description("Session id returned by 'session open'/'session create'.")]
+    public string SessionId { get; init; } = string.Empty;
+
+    [CommandOption("--save")]
+    [Description("Save the presentation before closing it.")]
+    public bool Save { get; init; }
+}
+
+/// <summary>Closes a session, disposing its PowerPoint batch (in the background).</summary>
+internal sealed class SessionCloseCommand : AsyncCommand<SessionCloseSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionCloseSettings settings, CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = "session.close",
+            SessionId = settings.SessionId,
+            Args = JsonSerializer.Serialize(new { save = settings.Save }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}
+
+/// <summary>Settings for the "session save" command.</summary>
+internal sealed class SessionSaveSettings : CommandSettings
+{
+    [CommandArgument(0, "<SESSION_ID>")]
+    [Description("Session id returned by 'session open'/'session create'.")]
+    public string SessionId { get; init; } = string.Empty;
+}
+
+/// <summary>Saves the presentation open in a session without closing it.</summary>
+internal sealed class SessionSaveCommand : AsyncCommand<SessionSaveSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionSaveSettings settings, CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = "session.save",
+            SessionId = settings.SessionId,
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}
+
+/// <summary>Lists every session currently open in the daemon.</summary>
+internal sealed class SessionListCommand : AsyncCommand
+{
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(2);
+
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    {
+        var pipeName = DaemonAutoStart.GetPipeName();
+        using var client = new ServiceClient(pipeName, connectTimeout: CommandTimeout, requestTimeout: CommandTimeout);
+
+        try
+        {
+            var response = await client.SendAsync(new ServiceRequest { Command = "session.list", Source = "cli" }, cancellationToken);
+            if (response.Success)
+            {
+                Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { sessions = Array.Empty<object>() }, ServiceProtocol.JsonOptions));
+                return 0;
+            }
+
+            return CliErrorOutput.WriteServiceError(response);
+        }
+        catch (Exception)
+        {
+            // Daemon not running — there are, by definition, no open sessions.
+            Console.WriteLine(JsonSerializer.Serialize(new { sessions = Array.Empty<object>() }, ServiceProtocol.JsonOptions));
+            return 0;
+        }
+    }
+}

--- a/src/PowerPointMcp.CLI/Infrastructure/CliErrorOutput.cs
+++ b/src/PowerPointMcp.CLI/Infrastructure/CliErrorOutput.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.CLI.Infrastructure;
+
+/// <summary>
+/// Writes structured JSON error envelopes to stdout for CLI failures. Ported from
+/// mcp-server-excel's ExcelMcp.CLI.Infrastructure.CliErrorOutput.
+/// </summary>
+internal static class CliErrorOutput
+{
+    /// <summary>Writes an error envelope for an unhandled local exception (not from the daemon).</summary>
+    public static int WriteException(Exception ex, string? errorCategory = null)
+    {
+        Console.WriteLine(Serialize(
+            ex.Message,
+            errorCategory,
+            null,
+            null,
+            ex.GetType().Name,
+            null,
+            ex.InnerException?.Message));
+        return 1;
+    }
+
+    /// <summary>Writes an error envelope from a failed <see cref="ServiceResponse"/>.</summary>
+    public static int WriteServiceError(ServiceResponse response)
+    {
+        Console.WriteLine(Serialize(
+            response.ErrorMessage,
+            response.ErrorCategory,
+            response.Command,
+            response.SessionId,
+            response.ExceptionType,
+            response.HResult,
+            response.InnerError));
+        return 1;
+    }
+
+    /// <summary>Writes a plain error envelope with just a message.</summary>
+    public static int WriteError(string errorMessage, string? errorCategory = null)
+    {
+        Console.WriteLine(Serialize(errorMessage, errorCategory, null, null, null, null, null));
+        return 1;
+    }
+
+    private static string Serialize(
+        string? errorMessage,
+        string? errorCategory,
+        string? command,
+        string? sessionId,
+        string? exceptionType,
+        string? hresult,
+        string? innerError)
+    {
+        return JsonSerializer.Serialize(new ErrorEnvelope
+        {
+            Success = false,
+            Error = errorMessage ?? "Unknown error.",
+            ErrorMessage = errorMessage ?? "Unknown error.",
+            ErrorCategory = errorCategory,
+            Command = command,
+            SessionId = sessionId,
+            IsError = true,
+            ExceptionType = exceptionType,
+            HResult = hresult,
+            InnerError = innerError
+        }, ServiceProtocol.JsonOptions);
+    }
+
+    private sealed class ErrorEnvelope
+    {
+        public bool Success { get; init; }
+
+        public string Error { get; init; } = string.Empty;
+
+        public string ErrorMessage { get; init; } = string.Empty;
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ErrorCategory { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Command { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SessionId { get; init; }
+
+        public bool IsError { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ExceptionType { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("hresult")]
+        public string? HResult { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? InnerError { get; init; }
+    }
+}

--- a/src/PowerPointMcp.CLI/Infrastructure/DaemonAutoStart.cs
+++ b/src/PowerPointMcp.CLI/Infrastructure/DaemonAutoStart.cs
@@ -1,0 +1,283 @@
+using System.Diagnostics;
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.CLI.Infrastructure;
+
+/// <summary>
+/// Ensures the CLI daemon is running before sending commands, auto-starting it if necessary.
+/// Ported from mcp-server-excel's ExcelMcp.CLI.Infrastructure.DaemonAutoStart.
+/// </summary>
+internal static class DaemonAutoStart
+{
+    internal static readonly TimeSpan InitialPingTimeout = TimeSpan.FromSeconds(2);
+    internal static readonly TimeSpan BusyDaemonConnectTimeout = TimeSpan.FromSeconds(3);
+    internal static readonly TimeSpan BusyDaemonRetryInterval = TimeSpan.FromMilliseconds(500);
+    internal static readonly TimeSpan BusyDaemonWaitTimeout = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan StartupReadyConnectTimeout = TimeSpan.FromSeconds(1);
+    internal static readonly TimeSpan StartupReadyRetryInterval = TimeSpan.FromMilliseconds(250);
+    internal static readonly TimeSpan StartupReadyTimeout = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan StartupLockTimeout = StartupReadyTimeout + TimeSpan.FromSeconds(1);
+
+    /// <summary>Gets the pipe name for the CLI daemon (supports env var override for testing).</summary>
+    public static string GetPipeName() =>
+        Environment.GetEnvironmentVariable("POWERPOINTMCP_CLI_PIPE") ?? ServiceSecurity.GetCliPipeName();
+
+    /// <summary>
+    /// Ensures the CLI daemon is running and returns a connected <see cref="ServiceClient"/>.
+    /// If the daemon is not running, starts it and waits for it to be ready.
+    /// </summary>
+    public static async Task<ServiceClient> EnsureAndConnectAsync(CancellationToken cancellationToken = default)
+    {
+        var pipeName = GetPipeName();
+
+        // Fast path: daemon already running and responsive.
+        if (await PingAsync(pipeName, InitialPingTimeout, cancellationToken))
+        {
+            return new ServiceClient(pipeName);
+        }
+
+        // Ping failed — check the OS mutex to distinguish "daemon busy" from "daemon not
+        // running". The daemon holds this mutex for its entire lifetime.
+        if (IsDaemonMutexHeld(pipeName))
+        {
+            var waitUntil = DateTime.UtcNow + BusyDaemonWaitTimeout;
+            while (DateTime.UtcNow < waitUntil)
+            {
+                await Task.Delay(BusyDaemonRetryInterval, cancellationToken);
+
+                if (!IsDaemonMutexHeld(pipeName))
+                    break;
+
+                var remaining = waitUntil - DateTime.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                    break;
+
+                if (await PingAsync(pipeName, Min(remaining, BusyDaemonConnectTimeout), cancellationToken))
+                    return new ServiceClient(pipeName);
+            }
+
+            if (IsDaemonMutexHeld(pipeName))
+            {
+                throw new TimeoutException(
+                    $"Daemon is running but not responding after {FormatDuration(BusyDaemonWaitTimeout)}. " +
+                    "Stop it with 'pptcli service stop' or terminate the stuck pptcli process, then retry.");
+            }
+
+            // Daemon exited while we waited — start a replacement.
+        }
+
+        if (!await TryStartDaemonWithStartupLockAsync(pipeName, cancellationToken))
+        {
+            if (await WaitForResponsiveDaemonAsync(pipeName, StartupReadyTimeout, cancellationToken))
+                return new ServiceClient(pipeName);
+
+            throw new TimeoutException(
+                $"Daemon startup is already in progress but did not become ready within {FormatDuration(StartupReadyTimeout)}.");
+        }
+
+        if (await PingAsync(pipeName, StartupReadyConnectTimeout, cancellationToken))
+        {
+            return new ServiceClient(pipeName);
+        }
+
+        throw new TimeoutException($"Daemon started but not responding within {FormatDuration(StartupReadyTimeout)}.");
+    }
+
+    /// <summary>
+    /// Checks whether a daemon process currently holds the daemon mutex for the given pipe name.
+    /// </summary>
+    internal static bool IsDaemonMutexHeld(string pipeName)
+    {
+        Mutex? mutex = null;
+        try
+        {
+            mutex = Mutex.OpenExisting(GetDaemonMutexName(pipeName));
+            if (mutex.WaitOne(TimeSpan.Zero))
+            {
+                mutex.ReleaseMutex();
+                DaemonProcessTracker.Clear(pipeName);
+                return false;
+            }
+
+            return true;
+        }
+        catch (AbandonedMutexException)
+        {
+            try { mutex?.ReleaseMutex(); } catch (ApplicationException) { }
+            DaemonProcessTracker.Clear(pipeName);
+            return false;
+        }
+        catch (WaitHandleCannotBeOpenedException)
+        {
+            return false; // No process has this mutex — daemon is not running.
+        }
+        catch (Exception)
+        {
+            return false; // Access denied or other error — assume not running.
+        }
+        finally
+        {
+            mutex?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Gets the OS mutex name for the CLI daemon identified by its pipe name. Used by both the
+    /// daemon (to acquire) and the client (to detect a running daemon).
+    /// </summary>
+    internal static string GetDaemonMutexName(string pipeName) =>
+        $"PowerPointMcpCli_{pipeName}";
+
+    internal static string GetDaemonStartupLockName(string pipeName) =>
+        $"{GetDaemonMutexName(pipeName)}_startup";
+
+    private static Task<bool> TryStartDaemonWithStartupLockAsync(string pipeName, CancellationToken cancellationToken)
+    {
+        return Task.Run(() =>
+        {
+            using var startupMutex = new Mutex(initiallyOwned: false, GetDaemonStartupLockName(pipeName), out _);
+            var startupLockAcquired = false;
+            try
+            {
+                try
+                {
+                    startupLockAcquired = startupMutex.WaitOne(StartupLockTimeout);
+                }
+                catch (AbandonedMutexException)
+                {
+                    startupLockAcquired = true;
+                }
+
+                if (!startupLockAcquired)
+                    return false;
+
+                // Another CLI process may have started the daemon while this process waited.
+                if (PingAsync(pipeName, InitialPingTimeout, cancellationToken).GetAwaiter().GetResult())
+                    return true;
+
+                StartDaemonAsync(pipeName, cancellationToken).GetAwaiter().GetResult();
+                return true;
+            }
+            finally
+            {
+                if (startupLockAcquired)
+                    startupMutex.ReleaseMutex();
+            }
+        }, cancellationToken);
+    }
+
+    private static async Task<bool> WaitForResponsiveDaemonAsync(string pipeName, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var waitUntil = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < waitUntil)
+        {
+            await Task.Delay(StartupReadyRetryInterval, cancellationToken);
+
+            var remaining = waitUntil - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            if (await PingAsync(pipeName, Min(remaining, StartupReadyConnectTimeout), cancellationToken))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static async Task StartDaemonAsync(string pipeName, CancellationToken cancellationToken)
+    {
+        var exePath = ResolveDaemonExecutablePath();
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = exePath,
+            Arguments = $"service run --pipe-name \"{pipeName}\"",
+            UseShellExecute = true,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            WorkingDirectory = Path.GetDirectoryName(exePath) ?? Environment.CurrentDirectory
+        };
+
+        try
+        {
+            using var daemonProcess = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Failed to start daemon process '{exePath}'.");
+
+            DaemonProcessTracker.Track(pipeName, daemonProcess.Id);
+
+            var waitUntil = DateTime.UtcNow + StartupReadyTimeout;
+            while (DateTime.UtcNow < waitUntil)
+            {
+                await Task.Delay(StartupReadyRetryInterval, cancellationToken);
+                if (daemonProcess.HasExited)
+                {
+                    if (daemonProcess.ExitCode == 0)
+                    {
+                        if (await WaitForResponsiveDaemonAsync(pipeName, waitUntil - DateTime.UtcNow, cancellationToken))
+                        {
+                            GC.KeepAlive(daemonProcess);
+                            return;
+                        }
+
+                        throw new InvalidOperationException(
+                            "Daemon process exited cleanly before becoming ready, but no responsive daemon was found. " +
+                            "This usually means a stale startup race or a daemon that shut down immediately. " +
+                            "Run 'pptcli service stop' and retry.");
+                    }
+
+                    throw new InvalidOperationException(
+                        $"Daemon process exited before becoming ready (exit code {daemonProcess.ExitCode}).");
+                }
+
+                var remaining = waitUntil - DateTime.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                    break;
+
+                if (await PingAsync(pipeName, Min(remaining, StartupReadyConnectTimeout), cancellationToken))
+                {
+                    GC.KeepAlive(daemonProcess);
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to start daemon: {ex.Message}", ex);
+        }
+
+        throw new TimeoutException($"Daemon started but not responding within {FormatDuration(StartupReadyTimeout)}.");
+    }
+
+    private static string ResolveDaemonExecutablePath()
+    {
+        var baseDirectoryCandidate = Path.Combine(AppContext.BaseDirectory, "powerpointcli.exe");
+        if (File.Exists(baseDirectoryCandidate))
+        {
+            return baseDirectoryCandidate;
+        }
+
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrWhiteSpace(processPath) && File.Exists(processPath))
+        {
+            return processPath;
+        }
+
+        throw new InvalidOperationException("Cannot determine executable path to start daemon.");
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        return duration.TotalSeconds >= 1
+            ? $"{duration.TotalSeconds:0.#} seconds"
+            : $"{duration.TotalMilliseconds:0} ms";
+    }
+
+    private static TimeSpan Min(TimeSpan left, TimeSpan right) => left <= right ? left : right;
+
+    private static async Task<bool> PingAsync(string pipeName, TimeSpan connectTimeout, CancellationToken cancellationToken)
+    {
+        var requestTimeout = connectTimeout + TimeSpan.FromSeconds(1);
+        using var client = new ServiceClient(pipeName, connectTimeout: connectTimeout, requestTimeout: requestTimeout);
+        return await client.PingAsync(cancellationToken);
+    }
+}

--- a/src/PowerPointMcp.CLI/Infrastructure/DaemonProcessTracker.cs
+++ b/src/PowerPointMcp.CLI/Infrastructure/DaemonProcessTracker.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+
+namespace Sbroenne.PowerPointMcp.CLI.Infrastructure;
+
+/// <summary>
+/// Tracks the daemon process id in a small per-pipe-name file so <c>service stop --force</c> can
+/// kill a stuck daemon that isn't responding to a graceful RPC shutdown. Simplified relative to
+/// mcp-server-excel's DaemonProcessTracker (no WinForms tray integration — see squad decision
+/// 2026-07-07 for the scope note on the tray icon being dropped for this port).
+/// </summary>
+internal static class DaemonProcessTracker
+{
+    private static string GetTrackerFilePath(string pipeName) =>
+        Path.Combine(Path.GetTempPath(), $"powerpointmcp-daemon-{pipeName}.pid");
+
+    /// <summary>Records the daemon's process id for later force-kill lookup.</summary>
+    public static void Track(string pipeName, int processId)
+    {
+        try
+        {
+            File.WriteAllText(GetTrackerFilePath(pipeName), processId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        catch (IOException)
+        {
+            // Best-effort — force-stop simply won't have a tracked PID to fall back on.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>Removes the tracked process id (daemon exited on its own).</summary>
+    public static void Clear(string pipeName)
+    {
+        try
+        {
+            File.Delete(GetTrackerFilePath(pipeName));
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Attempts to kill a previously-tracked daemon process directly, for use when a graceful
+    /// RPC shutdown does not work (daemon stuck/unresponsive).
+    /// </summary>
+    /// <returns><see langword="true"/> if a tracked process was found and killed.</returns>
+    public static bool TryForceStopTrackedDaemon(string pipeName)
+    {
+        var path = GetTrackerFilePath(pipeName);
+        try
+        {
+            if (!File.Exists(path) || !int.TryParse(File.ReadAllText(path), out var pid))
+            {
+                return false;
+            }
+
+            using var process = Process.GetProcessById(pid);
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(5000);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            // No process with that id — already gone.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        finally
+        {
+            Clear(pipeName);
+        }
+    }
+}

--- a/src/PowerPointMcp.CLI/Infrastructure/ServiceCommandBase.cs
+++ b/src/PowerPointMcp.CLI/Infrastructure/ServiceCommandBase.cs
@@ -1,24 +1,24 @@
 using System.Text.Json;
+using Sbroenne.PowerPointMcp.Service;
 using Spectre.Console.Cli;
 
 namespace Sbroenne.PowerPointMcp.CLI.Infrastructure;
 
 /// <summary>
-/// Base class for CLI commands that route to a Core service category.
+/// Base class for CLI commands that send requests to the PowerPointMCP CLI daemon.
+/// Handles common session/action validation and dispatch over the named-pipe RPC transport.
 /// </summary>
 /// <remarks>
-/// Structural port of Sbroenne.ExcelMcp.CLI.Infrastructure.ServiceCommandBase&lt;TSettings&gt;,
-/// scoped down to what the generated CLI command classes need to compile. PowerPointMcp has NO
-/// out-of-process Service/daemon (see squad decision: "SESSION OWNERSHIP — DIVERGE FROM EXCEL FOR
-/// THE MVP" — an in-process <c>PresentationSessionRegistry</c> is used instead, owned by the
-/// MCP server host). Excel's version dispatches over a named-pipe daemon (<c>DaemonAutoStart</c> +
-/// <c>ServiceBridge</c>); porting that is out of scope for this pilot. This base class still
-/// performs the same session/action validation and calls <see cref="Route"/> to prove the
-/// generated routing code round-trips correctly, but reports a clear "not yet wired" error instead
-/// of dispatching, since PowerPointMcp.CLI has no long-lived process to hold an open
-/// IPresentationBatch across separate CLI invocations. Wiring a real dispatch target (e.g. an
-/// in-process session store shared with a future daemon, or direct Core calls that open+close a
-/// batch per invocation) is a follow-up, not part of proving the source-generator pipeline.
+/// Structural port of Sbroenne.ExcelMcp.CLI.Infrastructure.ServiceCommandBase&lt;TSettings&gt;.
+/// PowerPointMCP now HAS an out-of-process daemon (<c>PowerPointMcp.Service</c>) — see squad
+/// decision 2026-07-07, which reverses the earlier "drop the Service — functional overkill" call
+/// (2026-07-06). The daemon holds one long-lived <c>IPresentationBatch</c> per session id across
+/// separate CLI process invocations, so a caller only pays PowerPoint's ~90-150s launch/teardown
+/// cost once per "session open"/"session create", not on every command. Each generated command
+/// class supplies <see cref="GetSessionId"/>/<see cref="GetAction"/>/<see cref="ValidActions"/>/
+/// <see cref="Route"/>; this base class validates them, then hands the routed
+/// <c>(command, args)</c> pair to <see cref="DaemonAutoStart.EnsureAndConnectAsync"/> +
+/// <see cref="ServiceClient.SendAsync"/>, auto-starting the daemon on first use.
 /// </remarks>
 internal abstract class ServiceCommandBase<TSettings> : AsyncCommand<TSettings>
     where TSettings : CommandSettings
@@ -35,33 +35,34 @@ internal abstract class ServiceCommandBase<TSettings> : AsyncCommand<TSettings>
     /// <summary>Routes the action to a (command, args) pair using the generated ServiceRegistry.</summary>
     protected abstract (string command, object? args) Route(TSettings settings, string action);
 
-    /// <summary>Whether this command requires a session ID. Default is true.</summary>
+    /// <summary>
+    /// Whether this command requires a session ID. Default is true. Override to return false for
+    /// commands that don't need a session.
+    /// </summary>
     protected virtual bool RequiresSession => true;
 
     /// <inheritdoc/>
-    protected sealed override Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken)
+    protected sealed override async Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken)
     {
         var sessionId = GetSessionId(settings);
         if (RequiresSession && string.IsNullOrWhiteSpace(sessionId))
         {
-            return Task.FromResult(WriteError("Session ID is required. Use --session <id>"));
+            return CliErrorOutput.WriteError("Session ID is required. Use --session <id> (see 'pptcli session open'/'pptcli session create').");
         }
 
         var rawAction = GetAction(settings);
         if (string.IsNullOrWhiteSpace(rawAction))
         {
-            return Task.FromResult(WriteError("Action is required."));
+            return CliErrorOutput.WriteError("Action is required.");
         }
 
         var action = rawAction.Trim().ToLowerInvariant();
         if (!ValidActions.Contains(action, StringComparer.OrdinalIgnoreCase))
         {
             var validList = string.Join(", ", ValidActions);
-            return Task.FromResult(WriteError($"Invalid action '{action}'. Valid actions: {validList}"));
+            return CliErrorOutput.WriteError($"Invalid action '{action}'. Valid actions: {validList}");
         }
 
-        // Route and validate parameters (proves the generated RouteFromSettings/RouteCliArgs code
-        // — including ParameterTransforms validation — works end-to-end).
         string command;
         object? args;
         try
@@ -70,20 +71,97 @@ internal abstract class ServiceCommandBase<TSettings> : AsyncCommand<TSettings>
         }
         catch (ArgumentException ex)
         {
-            return Task.FromResult(WriteError(ex.Message));
+            return CliErrorOutput.WriteError(ex.Message);
         }
 
-        // No out-of-process Service exists yet (deliberate MVP divergence from Excel) — nothing to
-        // dispatch `command`/`args` to. Report this clearly instead of pretending to execute.
-        return Task.FromResult(WriteError(
-            $"'{command}' routed successfully but PowerPointMcp.CLI has no execution backend yet " +
-            "(no out-of-process Service — MCP server owns sessions in-process). " +
-            "Use the MCP server tools for this operation."));
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = command,
+            SessionId = sessionId,
+            Args = args != null ? JsonSerializer.Serialize(args, ServiceProtocol.JsonOptions) : null,
+            Source = "cli"
+        }, cancellationToken);
+
+        var outputPath = settings.GetType().GetProperty("OutputPath")?.GetValue(settings) as string;
+
+        if (response.Success)
+        {
+            var result = !string.IsNullOrEmpty(response.Result)
+                ? response.Result
+                : JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions);
+
+            if (!string.IsNullOrEmpty(outputPath))
+            {
+                return WriteOutputToFile(result, outputPath);
+            }
+
+            Console.WriteLine(result);
+            return 0;
+        }
+
+        return CliErrorOutput.WriteServiceError(response);
     }
 
-    private static int WriteError(string message)
+    /// <summary>
+    /// Writes the result to a file. For image results containing base64 data, decodes and writes
+    /// the binary image. Otherwise writes the JSON text.
+    /// </summary>
+    private static int WriteOutputToFile(string result, string outputPath)
     {
-        Console.Error.WriteLine(JsonSerializer.Serialize(new { success = false, error = message }));
-        return 1;
+        try
+        {
+            var base64Data = TryExtractBase64Image(result);
+            if (base64Data != null)
+            {
+                var imageBytes = Convert.FromBase64String(base64Data);
+                File.WriteAllBytes(outputPath, imageBytes);
+
+                var doc = JsonDocument.Parse(result);
+                var metadata = new Dictionary<string, object?>
+                {
+                    ["success"] = true,
+                    ["outputPath"] = outputPath,
+                    ["sizeBytes"] = imageBytes.Length
+                };
+                if (doc.RootElement.TryGetProperty("width", out var w)) metadata["width"] = w.GetInt32();
+                if (doc.RootElement.TryGetProperty("height", out var h)) metadata["height"] = h.GetInt32();
+                if (doc.RootElement.TryGetProperty("mimeType", out var m)) metadata["mimeType"] = m.GetString();
+                Console.WriteLine(JsonSerializer.Serialize(metadata, ServiceProtocol.JsonOptions));
+            }
+            else
+            {
+                File.WriteAllText(outputPath, result);
+                Console.WriteLine(JsonSerializer.Serialize(
+                    new { success = true, outputPath },
+                    ServiceProtocol.JsonOptions));
+            }
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(
+                new { success = false, error = $"Failed to write output: {ex.Message}" },
+                ServiceProtocol.JsonOptions));
+            return 1;
+        }
+    }
+
+    /// <summary>Attempts to extract base64 image data from a JSON result.</summary>
+    private static string? TryExtractBase64Image(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("imageBase64", out var imageElement))
+            {
+                return imageElement.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Not valid JSON, can't extract image.
+        }
+        return null;
     }
 }

--- a/src/PowerPointMcp.CLI/PowerPointMcp.CLI.csproj
+++ b/src/PowerPointMcp.CLI/PowerPointMcp.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -26,9 +26,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PowerPointMcp.Core\PowerPointMcp.Core.csproj" />
+    <ProjectReference Include="..\PowerPointMcp.Service\PowerPointMcp.Service.csproj" />
     <!-- Source generator for CLI command classes. Emits one ServiceCommandBase<> subclass
-         per [ServiceCategory] interface in Core (currently just Notes, the source-gen pilot
-         domain) plus a CliCommandRegistration helper. -->
+         per [ServiceCategory] interface in Core (Notes, Presentation, Slide, Shape, TextFrame,
+         Table, Layout, Image, Chart) plus a CliCommandRegistration helper. -->
     <ProjectReference Include="..\PowerPointMcp.Generators.Cli\PowerPointMcp.Generators.Cli.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />

--- a/src/PowerPointMcp.CLI/Program.cs
+++ b/src/PowerPointMcp.CLI/Program.cs
@@ -1,100 +1,97 @@
-using Sbroenne.PowerPointMcp.ComInterop.Session;
-using Sbroenne.PowerPointMcp.Core.Presentation;
-using Sbroenne.PowerPointMcp.Core.Slide;
+using Sbroenne.PowerPointMcp.CLI.Commands;
+using Sbroenne.PowerPointMcp.CLI.Generated;
+using Sbroenne.PowerPointMcp.CLI.Infrastructure;
+using Sbroenne.PowerPointMcp.Service;
+using Spectre.Console.Cli;
 
-void PrintUsage()
+namespace Sbroenne.PowerPointMcp.CLI;
+
+/// <summary>Entry point for the <c>pptcli</c> command-line tool.</summary>
+public static class Program
 {
-    Console.WriteLine("Usage:");
-    Console.WriteLine("  powerpointcli create <path-to-new.pptx>");
-    Console.WriteLine("  powerpointcli slide add-blank <path-to.pptx>");
-    Console.WriteLine("  powerpointcli slide count <path-to.pptx>");
-    Console.WriteLine("  powerpointcli slide delete <path-to.pptx> <slideIndex>");
-    Console.WriteLine();
-    Console.WriteLine("This is a minimal placeholder CLI proving the ComInterop -> Core -> CLI");
-    Console.WriteLine("vertical slice end to end — not the real Generators-based CLI used by");
-    Console.WriteLine("mcp-server-excel. See plan.md for the full command roadmap (shapes, text,");
-    Console.WriteLine("tables, charts, images, notes, layouts, export/QA).");
-}
-
-if (args.Length == 0)
-{
-    PrintUsage();
-    return 1;
-}
-
-var presentationCommands = new PresentationCommands();
-var slideCommands = new SlideCommands();
-
-try
-{
-    switch (args[0])
+    /// <summary>
+    /// Runs the CLI. A special <c>service run</c> invocation launches the daemon in-process
+    /// (blocking); every other invocation goes through Spectre.Console.Cli's command app, which
+    /// dispatches to the daemon over a named pipe, auto-starting it on first use.
+    /// </summary>
+    public static async Task<int> Main(string[] args)
     {
-        case "create" when args.Length >= 2:
+        if (args.Length >= 2 && args[0] == "service" && args[1] == "run")
         {
-            var result = presentationCommands.Create(args[1]);
-            if (!result.Success)
-            {
-                Console.Error.WriteLine($"Error: {result.ErrorMessage}");
-                return 1;
-            }
-            Console.WriteLine($"Created: {result.PresentationPath}");
-            return 0;
+            return await RunDaemonAsync(args);
         }
 
-        case "slide" when args.Length >= 3 && args[1] == "add-blank":
+        var app = new CommandApp();
+        app.Configure(config =>
         {
-            using var batch = PresentationSession.BeginBatch(args[2]);
-            var result = slideCommands.AddBlank(batch);
-            if (!result.Success)
-            {
-                Console.Error.WriteLine($"Error: {result.ErrorMessage}");
-                return 1;
-            }
-            presentationCommands.Save(batch);
-            Console.WriteLine($"Added slide {result.SlideIndex}. Total slides: {result.SlideCount}");
-            return 0;
-        }
+            config.SetApplicationName("pptcli");
 
-        case "slide" when args.Length >= 3 && args[1] == "count":
-        {
-            using var batch = PresentationSession.BeginBatch(args[2]);
-            var result = slideCommands.GetCount(batch);
-            if (!result.Success)
+            config.AddBranch("session", session =>
             {
-                Console.Error.WriteLine($"Error: {result.ErrorMessage}");
-                return 1;
-            }
-            Console.WriteLine($"{result.SlideCount}");
-            return 0;
-        }
+                session.SetDescription("Open, create, save, close, or list presentation sessions held by the daemon.");
+                session.AddCommand<SessionOpenCommand>("open").WithDescription("Open an existing presentation and return a session id.");
+                session.AddCommand<SessionCreateCommand>("create").WithDescription("Create a new presentation and return a session id.");
+                session.AddCommand<SessionCloseCommand>("close").WithDescription("Close a session, optionally saving first.");
+                session.AddCommand<SessionSaveCommand>("save").WithDescription("Save the presentation open in a session.");
+                session.AddCommand<SessionListCommand>("list").WithDescription("List every session currently open in the daemon.");
+            });
 
-        case "slide" when args.Length >= 4 && args[1] == "delete":
-        {
-            if (!int.TryParse(args[3], out int slideIndex))
+            config.AddBranch("service", service =>
             {
-                Console.Error.WriteLine($"Error: '{args[3]}' is not a valid slide index.");
-                return 1;
-            }
+                service.SetDescription("Start, stop, or check the status of the pptcli background daemon.");
+                service.AddCommand<ServiceStartCommand>("start").WithDescription("Start the daemon if it isn't already running.");
+                service.AddCommand<ServiceStopCommand>("stop").WithDescription("Stop the running daemon.");
+                service.AddCommand<ServiceStatusCommand>("status").WithDescription("Report whether the daemon is running.");
+            });
 
-            using var batch = PresentationSession.BeginBatch(args[2]);
-            var result = slideCommands.Delete(batch, slideIndex);
-            if (!result.Success)
-            {
-                Console.Error.WriteLine($"Error: {result.ErrorMessage}");
-                return 1;
-            }
-            presentationCommands.Save(batch);
-            Console.WriteLine($"Deleted slide {slideIndex}. Total slides: {result.SlideCount}");
-            return 0;
-        }
+            CliCommandRegistration.RegisterCommands(config);
+        });
 
-        default:
-            PrintUsage();
-            return 1;
+        return await app.RunAsync(args);
     }
-}
-catch (Exception ex)
-{
-    Console.Error.WriteLine($"Error: {ex.Message}");
-    return 1;
+
+    /// <summary>
+    /// Runs the daemon in the current process until it shuts down (idle timeout, explicit
+    /// <c>service stop</c>, or Ctrl+C). This is the process launched by
+    /// <see cref="DaemonAutoStart"/> when no daemon is currently listening on the pipe.
+    /// </summary>
+    private static async Task<int> RunDaemonAsync(string[] args)
+    {
+        string? pipeName = null;
+        var idleTimeout = TimeSpan.FromMinutes(10);
+
+        for (var i = 2; i < args.Length; i++)
+        {
+            if (args[i] == "--pipe-name" && i + 1 < args.Length)
+            {
+                pipeName = args[++i];
+            }
+            else if (args[i] == "--idle-timeout-minutes" && i + 1 < args.Length && double.TryParse(args[i + 1], out var minutes))
+            {
+                idleTimeout = TimeSpan.FromMinutes(minutes);
+                i++;
+            }
+        }
+
+        pipeName ??= DaemonAutoStart.GetPipeName();
+
+        using var service = new PowerPointMcpService();
+
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            service.RequestShutdown();
+        };
+
+        try
+        {
+            await service.RunAsync(pipeName, idleTimeout);
+        }
+        finally
+        {
+            DaemonProcessTracker.Clear(pipeName);
+        }
+
+        return 0;
+    }
 }

--- a/src/PowerPointMcp.CLI/README.md
+++ b/src/PowerPointMcp.CLI/README.md
@@ -14,19 +14,60 @@ dotnet tool install --global Sbroenne.PowerPointMcp.CLI
 
 This installs the `pptcli` command.
 
-## Usage
+## How it works — a background daemon, not a cold start per command
+
+Launching PowerPoint and tearing it down again can take 90-150 seconds. To avoid paying that
+cost on every single CLI invocation, `pptcli` keeps one PowerPoint instance alive in a small
+background daemon (`pptcli service run`) that is auto-started the first time you open or create
+a session, and reused by every subsequent command that references the same session id — even
+though each command is a separate OS process. This mirrors the architecture used by
+`mcp-server-excel`'s CLI.
 
 ```pwsh
-pptcli create <path-to-new.pptx>
-pptcli slide add-blank <path-to.pptx>
-pptcli slide count <path-to.pptx>
-pptcli slide delete <path-to.pptx> <slideIndex>
+# Create a new presentation — this may auto-start the daemon (first PowerPoint launch cost).
+pptcli session create C:\decks\demo.pptx
+# {"success":true,"sessionId":"…","filePath":"C:\\decks\\demo.pptx"}
+
+# Every subsequent command reuses the SAME PowerPoint process via --session/-s.
+pptcli slide add-blank -s <SESSION_ID>
+pptcli slide get-count -s <SESSION_ID>
+pptcli notes set-notes-text -s <SESSION_ID> --slide-index 1 --text "Speaker notes"
+
+# Save and close when you're done with the file (closing does not stop the daemon).
+pptcli session close <SESSION_ID> --save
+
+# Check on / manage the daemon directly.
+pptcli service status
+pptcli service stop
+pptcli service stop --force   # force-kill if a graceful shutdown doesn't respond
 ```
 
-> The CLI currently exposes a focused command set proving the end-to-end
-> automation pipeline; the full surface (shapes, text, tables, charts, images,
-> notes, layouts, export) is available today via the MCP server. See the
-> [documentation](https://powerpointmcpserver.dev) for the roadmap.
+Every `[ServiceCategory]`-annotated Core domain (Presentation, Slide, Shape, TextFrame, Table,
+Chart, Image, Notes, Layout) gets a generated `pptcli <category> <action> -s <SESSION_ID> [options]`
+command automatically — run `pptcli <category> --help` to see the actions and options available
+for that domain. (Export is not yet exposed via the CLI — a known, pre-existing generator
+conflict, unrelated to session handling.)
+
+The daemon shuts down automatically after an idle period with no open sessions, or immediately
+via `pptcli service stop`.
+
+## Session commands
+
+| Command | Description |
+|---|---|
+| `pptcli session create <path>` | Create a new presentation, return a session id. |
+| `pptcli session open <path>` | Open an existing presentation, return a session id. |
+| `pptcli session save <id>` | Save the presentation without closing the session. |
+| `pptcli session close <id> [--save]` | Close a session, optionally saving first. |
+| `pptcli session list` | List every session currently open in the daemon. |
+
+## Service (daemon) commands
+
+| Command | Description |
+|---|---|
+| `pptcli service start` | Auto-start the daemon if it isn't already running. |
+| `pptcli service status` | Report whether the daemon is running, its session count, and uptime. |
+| `pptcli service stop [--force]` | Gracefully shut down the daemon (or force-kill it). |
 
 ## Links
 
@@ -34,3 +75,4 @@ pptcli slide delete <path-to.pptx> <slideIndex>
 - Source: https://github.com/sbroenne/mcp-server-powerpoint
 
 Licensed under the MIT License.
+

--- a/src/PowerPointMcp.ComInterop/Session/PresentationSessionRegistry.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationSessionRegistry.cs
@@ -1,9 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
-using Sbroenne.PowerPointMcp.ComInterop;
-using Sbroenne.PowerPointMcp.ComInterop.Session;
 
-namespace Sbroenne.PowerPointMcp.McpServer.Session;
+namespace Sbroenne.PowerPointMcp.ComInterop.Session;
 
 /// <summary>
 /// Lightweight, immutable view of a single registered presentation session.
@@ -24,12 +22,15 @@ public sealed record PresentationSessionInfo(
 /// MCP host so that one PowerPoint session can span many tool invocations.
 /// </summary>
 /// <remarks>
-/// This is the MVP replacement for mcp-server-excel's out-of-process Service + named-pipe
-/// bridge (see .squad/decisions.md — Dallas's McpServer architecture pass). Because the STA
-/// thread and work queue already live inside <c>PresentationBatch</c>, an in-process
-/// dictionary fully satisfies "one long-lived session across many tool invocations" without
-/// RPC. Disposing a batch closes PowerPoint for that presentation, so the host MUST call
-/// <see cref="DisposeAll()"/> on shutdown to guarantee no lingering POWERPNT.exe process.
+/// Used by the MCP Server as an in-process singleton (one long-lived session per tool-call
+/// sequence, no RPC needed since the MCP host and the STA thread live in the same process).
+/// Also reused by <c>PowerPointMcp.Service</c> (the CLI's out-of-process daemon, squad decision
+/// 2026-07-07 reversing the earlier "drop the Service" call) as the daemon's session table,
+/// mirroring mcp-server-excel's <c>SessionManager</c> — there each session maps to a live
+/// <c>IPresentationBatch</c> held open across separate CLI process invocations, avoiding a
+/// PowerPoint relaunch on every command. Disposing a batch closes PowerPoint for that
+/// presentation, so any host embedding this registry MUST call <see cref="DisposeAll()"/> on
+/// shutdown to guarantee no lingering POWERPNT.exe process.
 ///
 /// ASYNC CLOSE (2026-07-01, see .squad/decisions/inbox/brett-async-close.md): Parker's shutdown
 /// hardening made <c>IPresentationBatch.Dispose()</c> legitimately block for up to

--- a/src/PowerPointMcp.McpServer/PowerPointMcp.McpServer.csproj
+++ b/src/PowerPointMcp.McpServer/PowerPointMcp.McpServer.csproj
@@ -60,6 +60,10 @@
   <ItemGroup>
     <ProjectReference Include="..\PowerPointMcp.Core\PowerPointMcp.Core.csproj" />
     <ProjectReference Include="..\PowerPointMcp.ComInterop\PowerPointMcp.ComInterop.csproj" />
+    <!-- Hosts the shared PowerPointMcpService in-process (direct calls, no named pipe) so this
+         MCP server and the CLI daemon are backed by the SAME service class — mirroring
+         mcp-server-excel's ServiceBridge architecture. See Infrastructure/ServiceBridge.cs. -->
+    <ProjectReference Include="..\PowerPointMcp.Service\PowerPointMcp.Service.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerPointMcp.McpServer/Program.cs
+++ b/src/PowerPointMcp.McpServer/Program.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
-using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Service;
 
 namespace Sbroenne.PowerPointMcp.McpServer;
 
@@ -133,9 +133,15 @@ public class Program
 
         ConfigureStdioLogging(builder.Logging);
 
-        // In-process session registry: one long-lived PowerPoint session per id across many
-        // tool invocations. Disposed on host shutdown by PresentationSessionShutdownService.
-        builder.Services.AddSingleton<PresentationSessionRegistry>();
+        // In-process PowerPointMcpService: the SAME Service class the CLI daemon hosts over a
+        // named pipe, but here consumed directly, in-process, with no pipe — mirroring
+        // mcp-server-excel's ServiceBridge architecture (one shared Service class, two hosting
+        // modes). MCP tools never call the service's string-command dispatch; they only need its
+        // session registry, so that's the only thing exposed to DI. One long-lived PowerPoint
+        // session per id across many tool invocations; disposed on host shutdown by
+        // PresentationSessionShutdownService.
+        builder.Services.AddSingleton<PowerPointMcpService>();
+        builder.Services.AddSingleton(sp => sp.GetRequiredService<PowerPointMcpService>().Sessions);
         builder.Services.AddHostedService<PresentationSessionShutdownService>();
 
         var mcpBuilder = builder.Services
@@ -180,7 +186,7 @@ public class Program
 
         // Capture the singleton reference now — after RunAsync returns the host has disposed its
         // service provider, so resolving it in the finally would throw ObjectDisposedException.
-        var registry = host.Services.GetRequiredService<PresentationSessionRegistry>();
+        var service = host.Services.GetRequiredService<PowerPointMcpService>();
 
         var runToken = testShutdownCts?.Token ?? CancellationToken.None;
 
@@ -203,8 +209,8 @@ public class Program
             stdinMonitor?.Dispose();
 
             // Backstop: guarantee no lingering POWERPNT.exe even if the hosted service did not run.
-            // DisposeAll is idempotent, so double-disposal on normal shutdown is safe.
-            registry.DisposeAll();
+            // Dispose is idempotent, so double-disposal on normal shutdown is safe.
+            service.Dispose();
         }
     }
 
@@ -253,17 +259,17 @@ public class Program
 }
 
 /// <summary>
-/// Hosted service whose sole job is to dispose every open presentation session when the host
-/// stops — closing each PowerPoint process so none is orphaned after MCP client disconnect,
-/// Ctrl+C, or test shutdown.
+/// Hosted service whose sole job is to dispose the in-process <see cref="PowerPointMcpService"/>
+/// (and thereby every open presentation session) when the host stops — closing each PowerPoint
+/// process so none is orphaned after MCP client disconnect, Ctrl+C, or test shutdown.
 /// </summary>
-internal sealed class PresentationSessionShutdownService(PresentationSessionRegistry registry) : IHostedService
+internal sealed class PresentationSessionShutdownService(PowerPointMcpService service) : IHostedService
 {
     public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        registry.DisposeAll();
+        service.Dispose();
         return Task.CompletedTask;
     }
 }

--- a/src/PowerPointMcp.McpServer/Program.cs
+++ b/src/PowerPointMcp.McpServer/Program.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer;
 

--- a/src/PowerPointMcp.McpServer/Tools/ChartTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/ChartTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Chart;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/ExportTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/ExportTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Export;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/ImageTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/ImageTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Image;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/LayoutTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/LayoutTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Layout;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/NotesTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/NotesTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Notes;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Presentation;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/ShapeTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/ShapeTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Shape;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/SlideTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/SlideTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Slide;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/TableTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/TableTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.Table;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.McpServer/Tools/TextFrameTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/TextFrameTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Sbroenne.PowerPointMcp.Core.TextFrame;
-using Sbroenne.PowerPointMcp.McpServer.Session;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 

--- a/src/PowerPointMcp.Service/PowerPointMcp.Service.csproj
+++ b/src/PowerPointMcp.Service/PowerPointMcp.Service.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <AssemblyName>Sbroenne.PowerPointMcp.Service</AssemblyName>
+    <RootNamespace>Sbroenne.PowerPointMcp.Service</RootNamespace>
+
+    <PackageId>Sbroenne.PowerPointMcp.Service</PackageId>
+    <Title>PowerPoint MCP CLI Daemon</Title>
+    <Description>Out-of-process daemon holding one long-lived PowerPoint session across separate
+    CLI invocations, avoiding a PowerPoint relaunch on every command. Named-pipe + StreamJsonRpc
+    transport, ported 1:1 from mcp-server-excel's ExcelMcp.Service (see squad decision
+    2026-07-07, reversing the earlier "drop the Service" call).</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+
+    <!-- Internal daemon project, not published as a NuGet package — skip XML doc generation
+         (CS1591 is treated as an error solution-wide, see Directory.Build.props). -->
+    <NoWarn>$(NoWarn);StreamJsonRpc0003</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sbroenne.PowerPointMcp.CLI" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PowerPointMcp.ComInterop\PowerPointMcp.ComInterop.csproj" />
+    <ProjectReference Include="..\PowerPointMcp.Core\PowerPointMcp.Core.csproj" />
+    <PackageReference Include="StreamJsonRpc" />
+  </ItemGroup>
+
+</Project>

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -60,6 +60,16 @@ public sealed class PowerPointMcpService : IDisposable
     public int SessionCount => _sessions.List().Count;
 
     /// <summary>
+    /// Gets the session registry this daemon instance owns. Exposed so the MCP server can host a
+    /// <see cref="PowerPointMcpService"/> in-process and hand this SAME registry instance to its
+    /// MCP tools via dependency injection — mirroring mcp-server-excel's architecture, where one
+    /// shared Service class is consumed two ways: in-process (direct calls, no pipe) by the MCP
+    /// server, and via named-pipe/StreamJsonRpc by the separate CLI daemon process. The MCP server
+    /// never calls <see cref="ProcessAsync"/>; it only needs the underlying session store.
+    /// </summary>
+    public PresentationSessionRegistry Sessions => _sessions;
+
+    /// <summary>
     /// Runs the daemon, listening for commands on the named pipe. Blocks until shutdown is
     /// requested via <see cref="RequestShutdown"/> (explicit "service.shutdown" RPC or idle
     /// timeout).

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -1,0 +1,559 @@
+using System.Collections.Concurrent;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Chart;
+using Sbroenne.PowerPointMcp.Core.Image;
+using Sbroenne.PowerPointMcp.Core.Layout;
+using Sbroenne.PowerPointMcp.Core.Notes;
+using Sbroenne.PowerPointMcp.Core.Presentation;
+using Sbroenne.PowerPointMcp.Core.Shape;
+using Sbroenne.PowerPointMcp.Core.Slide;
+using Sbroenne.PowerPointMcp.Core.Table;
+using Sbroenne.PowerPointMcp.Core.TextFrame;
+using Sbroenne.PowerPointMcp.Generated;
+using Sbroenne.PowerPointMcp.Service.Rpc;
+using StreamJsonRpc;
+
+namespace Sbroenne.PowerPointMcp.Service;
+
+/// <summary>
+/// The PowerPointMCP CLI daemon. Holds a <see cref="PresentationSessionRegistry"/> (one
+/// long-lived <see cref="IPresentationBatch"/> per session id, reused across separate CLI
+/// process invocations) and dispatches incoming commands to Core via the generated
+/// <c>ServiceRegistry.{Category}.DispatchToCore</c> methods.
+/// </summary>
+/// <remarks>
+/// Ported from mcp-server-excel's <c>ExcelMcpService</c> (squad decision 2026-07-07, reversing
+/// the 2026-07-06 "drop the Service" call): the daemon's whole reason for existing is to avoid
+/// PowerPoint's ~90-150s launch/teardown cost on every CLI invocation — a session created by
+/// "session open"/"session create" stays alive (PowerPoint process included) until "session
+/// close"/idle-timeout/daemon shutdown, and every subsequent CLI command that references the
+/// same session id reuses the same live PowerPoint process.
+/// </remarks>
+public sealed class PowerPointMcpService : IDisposable
+{
+    private readonly PresentationSessionRegistry _sessions = new();
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly ConcurrentDictionary<Task, byte> _activeConnectionTasks = new();
+    private readonly DateTime _startTime = DateTime.UtcNow;
+    private string _pipeName = "";
+    private TimeSpan? _idleTimeout;
+    private DateTime _lastActivityTime = DateTime.UtcNow;
+    private bool _disposed;
+
+    private readonly PresentationCommands _presentationCommands = new();
+    private readonly SlideCommands _slideCommands = new();
+    private readonly ShapeCommands _shapeCommands = new();
+    private readonly TextFrameCommands _textFrameCommands = new();
+    private readonly TableCommands _tableCommands = new();
+    private readonly ChartCommands _chartCommands = new();
+    private readonly ImageCommands _imageCommands = new();
+    private readonly NotesCommands _notesCommands = new();
+    private readonly LayoutCommands _layoutCommands = new();
+
+    /// <summary>Gets the UTC time this daemon instance started.</summary>
+    public DateTime StartTime => _startTime;
+
+    /// <summary>Gets the number of currently open presentation sessions.</summary>
+    public int SessionCount => _sessions.List().Count;
+
+    /// <summary>
+    /// Runs the daemon, listening for commands on the named pipe. Blocks until shutdown is
+    /// requested via <see cref="RequestShutdown"/> (explicit "service.shutdown" RPC or idle
+    /// timeout).
+    /// </summary>
+    /// <param name="pipeName">The named pipe to listen on.</param>
+    /// <param name="idleTimeout">Shuts the daemon down after this much idle time with no open
+    /// sessions. Null disables the idle monitor.</param>
+    public async Task RunAsync(string pipeName, TimeSpan? idleTimeout = null)
+    {
+        _pipeName = pipeName;
+        _idleTimeout = idleTimeout;
+        await RunPipeServerAsync(_shutdownCts.Token);
+    }
+
+    /// <summary>Signals the pipe accept loop to stop, ending <see cref="RunAsync"/>.</summary>
+    public void RequestShutdown() => _shutdownCts.Cancel();
+
+    private void RequestShutdownAfterResponse()
+    {
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(100, CancellationToken.None);
+            RequestShutdown();
+        }, CancellationToken.None);
+    }
+
+    internal static readonly TimeSpan InitialBackoff = TimeSpan.FromMilliseconds(100);
+    internal static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(5);
+
+    /// <summary>Records client activity to keep the idle timeout monitor alive.</summary>
+    internal void RecordActivity() => _lastActivityTime = DateTime.UtcNow;
+
+    private async Task RunPipeServerAsync(CancellationToken cancellationToken)
+    {
+        using var connectionLimit = new SemaphoreSlim(10, 10);
+
+        if (_idleTimeout.HasValue)
+        {
+            _ = Task.Run(() => MonitorIdleTimeoutAsync(cancellationToken), cancellationToken);
+        }
+
+        var currentBackoff = InitialBackoff;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            NamedPipeServerStream? server = null;
+            try
+            {
+                server = ServiceSecurity.CreateSecureServer(_pipeName);
+                await server.WaitForConnectionAsync(cancellationToken);
+
+                currentBackoff = InitialBackoff;
+                _lastActivityTime = DateTime.UtcNow;
+
+                var clientServer = server;
+                server = null;
+
+                var connectionTask = Task.Run(async () =>
+                {
+                    await connectionLimit.WaitAsync(CancellationToken.None);
+                    try
+                    {
+                        var rpcTarget = new DaemonRpcTarget(this);
+                        using var rpc = JsonRpc.Attach(clientServer, rpcTarget);
+                        await rpc.Completion;
+                    }
+                    catch (Exception)
+                    {
+                        // Connection-level failures are expected on client disconnect; nothing to
+                        // recover here — the accept loop simply serves the next connection.
+                    }
+                    finally
+                    {
+                        connectionLimit.Release();
+                        try { if (clientServer.IsConnected) clientServer.Disconnect(); } catch (Exception) { }
+                        try { await clientServer.DisposeAsync(); } catch (Exception) { }
+                    }
+                }, CancellationToken.None);
+                _activeConnectionTasks.TryAdd(connectionTask, 0);
+                _ = connectionTask.ContinueWith(
+                    completed => _activeConnectionTasks.TryRemove(completed, out _),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception)
+            {
+                try { await Task.Delay(currentBackoff, cancellationToken); } catch (OperationCanceledException) { break; }
+                currentBackoff = TimeSpan.FromMilliseconds(Math.Min(currentBackoff.TotalMilliseconds * 2, MaxBackoff.TotalMilliseconds));
+            }
+            finally
+            {
+                if (server != null)
+                {
+                    try { if (server.IsConnected) server.Disconnect(); } catch (Exception) { }
+                    await server.DisposeAsync();
+                }
+            }
+        }
+
+        if (!_activeConnectionTasks.IsEmpty)
+        {
+            await Task.WhenAll(_activeConnectionTasks.Keys.Select(ObserveConnectionTaskAsync));
+        }
+    }
+
+    private static async Task ObserveConnectionTaskAsync(Task connectionTask)
+    {
+        try { await connectionTask; } catch (Exception) { }
+    }
+
+    private async Task MonitorIdleTimeoutAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+
+            if (_sessions.List().Count > 0)
+            {
+                _lastActivityTime = DateTime.UtcNow;
+                continue;
+            }
+
+            var idleTime = DateTime.UtcNow - _lastActivityTime;
+            if (idleTime >= _idleTimeout!.Value)
+            {
+                RequestShutdown();
+                break;
+            }
+        }
+    }
+
+    /// <summary>Processes a single request. Used by the pipe RPC target.</summary>
+    public Task<ServiceResponse> ProcessAsync(ServiceRequest request)
+    {
+        try
+        {
+            var parts = request.Command.Split('.', 2);
+            var category = parts[0];
+            var action = parts.Length > 1 ? parts[1] : "";
+
+            ServiceResponse response = category switch
+            {
+                "service" => HandleServiceCommand(action),
+                "session" => HandleSessionCommand(action, request),
+                "presentation" => DispatchSimple<PresentationAction>(action, request,
+                    ServiceRegistry.Presentation.TryParseAction,
+                    (a, batch) => ServiceRegistry.Presentation.DispatchToCore(_presentationCommands, a, batch, request.Args)),
+                "slide" => DispatchSimple<SlideAction>(action, request,
+                    ServiceRegistry.Slide.TryParseAction,
+                    (a, batch) => ServiceRegistry.Slide.DispatchToCore(_slideCommands, a, batch, request.Args)),
+                "shape" => DispatchSimple<ShapeAction>(action, request,
+                    ServiceRegistry.Shape.TryParseAction,
+                    (a, batch) => ServiceRegistry.Shape.DispatchToCore(_shapeCommands, a, batch, request.Args)),
+                "textframe" => DispatchSimple<TextFrameAction>(action, request,
+                    ServiceRegistry.TextFrame.TryParseAction,
+                    (a, batch) => ServiceRegistry.TextFrame.DispatchToCore(_textFrameCommands, a, batch, request.Args)),
+                "table" => DispatchSimple<TableAction>(action, request,
+                    ServiceRegistry.Table.TryParseAction,
+                    (a, batch) => ServiceRegistry.Table.DispatchToCore(_tableCommands, a, batch, request.Args)),
+                "chart" => DispatchSimple<ChartAction>(action, request,
+                    ServiceRegistry.Chart.TryParseAction,
+                    (a, batch) => ServiceRegistry.Chart.DispatchToCore(_chartCommands, a, batch, request.Args)),
+                "image" => DispatchSimple<ImageAction>(action, request,
+                    ServiceRegistry.Image.TryParseAction,
+                    (a, batch) => ServiceRegistry.Image.DispatchToCore(_imageCommands, a, batch, request.Args)),
+                "notes" => DispatchSimple<NotesAction>(action, request,
+                    ServiceRegistry.Notes.TryParseAction,
+                    (a, batch) => ServiceRegistry.Notes.DispatchToCore(_notesCommands, a, batch, request.Args)),
+                "layout" => DispatchSimple<LayoutAction>(action, request,
+                    ServiceRegistry.Layout.TryParseAction,
+                    (a, batch) => ServiceRegistry.Layout.DispatchToCore(_layoutCommands, a, batch, request.Args)),
+                _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown command category: {category}" }
+            };
+
+            return Task.FromResult(AttachRequestContext(request, response));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(CreateErrorResponse(ex, request.Command, request.SessionId));
+        }
+    }
+
+    // === SERVICE COMMANDS ===
+
+    private ServiceResponse HandleServiceCommand(string action)
+    {
+        return action switch
+        {
+            "ping" => new ServiceResponse { Success = true },
+            "shutdown" => HandleShutdown(),
+            "status" => HandleStatus(),
+            _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown service action: {action}" }
+        };
+    }
+
+    private ServiceResponse HandleShutdown()
+    {
+        RequestShutdownAfterResponse();
+        return new ServiceResponse { Success = true };
+    }
+
+    private ServiceResponse HandleStatus()
+    {
+        var status = new ServiceStatus
+        {
+            Running = true,
+            ProcessId = Environment.ProcessId,
+            SessionCount = SessionCount,
+            StartTime = _startTime
+        };
+        return new ServiceResponse { Success = true, Result = JsonSerializer.Serialize(status, ServiceProtocol.JsonOptions) };
+    }
+
+    // === SESSION COMMANDS ===
+
+    private ServiceResponse HandleSessionCommand(string action, ServiceRequest request)
+    {
+        return action switch
+        {
+            "create" => HandleSessionCreate(request),
+            "open" => HandleSessionOpen(request),
+            "close" => HandleSessionClose(request),
+            "save" => HandleSessionSave(request),
+            "list" => HandleSessionList(),
+            _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown session action: {action}" }
+        };
+    }
+
+    private ServiceResponse HandleSessionCreate(ServiceRequest request)
+    {
+        var args = ServiceRegistry.DeserializeArgs<SessionOpenArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.FilePath))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "filePath is required" };
+        }
+
+        var fullPath = Path.GetFullPath(args.FilePath);
+        if (File.Exists(fullPath))
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorMessage = $"File already exists: {fullPath}. Use 'session open' to open an existing presentation."
+            };
+        }
+
+        var extension = Path.GetExtension(fullPath);
+        if (!string.Equals(extension, ".pptx", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(extension, ".pptm", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorMessage = $"Invalid file extension '{extension}'. session create supports .pptx and .pptm only."
+            };
+        }
+
+        try
+        {
+            var sessionId = _sessions.Create(fullPath);
+            return new ServiceResponse
+            {
+                Success = true,
+                Result = JsonSerializer.Serialize(new { success = true, sessionId, filePath = fullPath }, ServiceProtocol.JsonOptions)
+            };
+        }
+        catch (Exception ex)
+        {
+            return CreateErrorResponse(ex);
+        }
+    }
+
+    private ServiceResponse HandleSessionOpen(ServiceRequest request)
+    {
+        var args = ServiceRegistry.DeserializeArgs<SessionOpenArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.FilePath))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "filePath is required" };
+        }
+
+        try
+        {
+            var sessionId = _sessions.Open(args.FilePath);
+            return new ServiceResponse
+            {
+                Success = true,
+                Result = JsonSerializer.Serialize(new { success = true, sessionId, filePath = args.FilePath }, ServiceProtocol.JsonOptions)
+            };
+        }
+        catch (Exception ex)
+        {
+            return CreateErrorResponse(ex);
+        }
+    }
+
+    private ServiceResponse HandleSessionClose(ServiceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" };
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionCloseArgs>(request.Args);
+
+        if (args.Save && _sessions.TryGet(request.SessionId, out var batchToSave))
+        {
+            try
+            {
+                batchToSave.Save();
+            }
+            catch (Exception ex)
+            {
+                return CreateErrorResponse(ex, request.Command, request.SessionId);
+            }
+        }
+
+        // Close() removes the session immediately and disposes the batch (and PowerPoint) on a
+        // background task — mirrors PresentationSessionRegistry's MCP-server usage, see its
+        // remarks for why this must not block the caller.
+        var closed = _sessions.Close(request.SessionId);
+
+        return new ServiceResponse { Success = true, Result = closed
+            ? null
+            : JsonSerializer.Serialize(new { success = true, sessionId = request.SessionId, message = "Session already closed." }, ServiceProtocol.JsonOptions) };
+    }
+
+    private ServiceResponse HandleSessionSave(ServiceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" };
+        }
+
+        if (!_sessions.TryGet(request.SessionId, out var batch))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = $"Session '{request.SessionId}' not found" };
+        }
+
+        try
+        {
+            batch.Save();
+            return new ServiceResponse { Success = true };
+        }
+        catch (Exception ex)
+        {
+            return CreateErrorResponse(ex, request.Command, request.SessionId);
+        }
+    }
+
+    private ServiceResponse HandleSessionList()
+    {
+        var sessions = _sessions.List()
+            .Select(s => new
+            {
+                sessionId = s.SessionId,
+                filePath = s.PresentationPath,
+                isPowerPointAlive = s.IsPowerPointProcessAlive
+            })
+            .ToList();
+
+        return new ServiceResponse
+        {
+            Success = true,
+            Result = JsonSerializer.Serialize(new { success = true, sessions, count = sessions.Count }, ServiceProtocol.JsonOptions)
+        };
+    }
+
+    // === GENERATED DISPATCH ===
+
+    private delegate bool TryParseDelegate<TAction>(string action, out TAction result);
+
+    private static ServiceResponse WrapResult(string? dispatchResult)
+    {
+        return dispatchResult == null
+            ? new ServiceResponse { Success = true }
+            : new ServiceResponse { Success = true, Result = dispatchResult };
+    }
+
+    /// <summary>
+    /// Resolves the session for <paramref name="request"/>, then dispatches
+    /// <paramref name="actionString"/> to Core via the generated
+    /// <c>ServiceRegistry.{Category}.DispatchToCore</c> method.
+    /// </summary>
+    private ServiceResponse DispatchSimple<TAction>(
+        string actionString, ServiceRequest request,
+        TryParseDelegate<TAction> tryParse,
+        Func<TAction, IPresentationBatch, string?> dispatch) where TAction : struct
+    {
+        if (!tryParse(actionString, out var action))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = $"Unknown action: {actionString}" };
+        }
+
+        if (string.IsNullOrWhiteSpace(request.SessionId))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "sessionId is required" };
+        }
+
+        if (!_sessions.TryGet(request.SessionId, out var batch))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = $"Session '{request.SessionId}' not found" };
+        }
+
+        try
+        {
+            return WrapResult(dispatch(action, batch));
+        }
+        catch (Exception ex)
+        {
+            return CreateErrorResponse(ex, request.Command, request.SessionId);
+        }
+    }
+
+    private static ServiceResponse AttachRequestContext(ServiceRequest request, ServiceResponse response)
+    {
+        if (response.Command != null && response.SessionId != null)
+        {
+            return response;
+        }
+
+        return new ServiceResponse
+        {
+            Success = response.Success,
+            Command = response.Command ?? request.Command,
+            SessionId = response.SessionId ?? request.SessionId,
+            ErrorMessage = response.ErrorMessage,
+            ErrorCategory = response.ErrorCategory,
+            ExceptionType = response.ExceptionType,
+            HResult = response.HResult,
+            InnerError = response.InnerError,
+            Result = response.Result
+        };
+    }
+
+    private static ServiceResponse CreateErrorResponse(Exception ex, string? command = null, string? sessionId = null)
+    {
+        var exceptionType = ex.GetType().Name;
+        string? hresult = ex is COMException comEx ? $"0x{comEx.HResult:X8}" : null;
+        string? innerError = null;
+        var errorCategory = ex switch
+        {
+            TimeoutException => "Timeout",
+            ArgumentException => "InvalidInput",
+            COMException => "ComInterop",
+            _ => null
+        };
+
+        if (ex.InnerException != null)
+        {
+            innerError = ex.InnerException.Message;
+            if (ex.InnerException is COMException innerComEx)
+            {
+                innerError += $" [COM: 0x{innerComEx.HResult:X8}]";
+            }
+        }
+
+        return new ServiceResponse
+        {
+            Success = false,
+            Command = command,
+            SessionId = sessionId,
+            ErrorCategory = errorCategory,
+            ErrorMessage = ex.Message,
+            ExceptionType = exceptionType,
+            HResult = hresult,
+            InnerError = innerError
+        };
+    }
+
+    /// <summary>Disposes every open presentation session, closing PowerPoint for each.</summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _shutdownCts.Dispose();
+        _sessions.DisposeAll();
+    }
+}
+
+/// <summary>Args for "session.create"/"session.open".</summary>
+public sealed class SessionOpenArgs
+{
+    /// <summary>Full path to the presentation file to create or open.</summary>
+    public string? FilePath { get; set; }
+}
+
+/// <summary>Args for "session.close".</summary>
+public sealed class SessionCloseArgs
+{
+    /// <summary>Whether to save the presentation before closing it.</summary>
+    public bool Save { get; set; }
+}

--- a/src/PowerPointMcp.Service/Rpc/DaemonRpcTarget.cs
+++ b/src/PowerPointMcp.Service/Rpc/DaemonRpcTarget.cs
@@ -1,0 +1,23 @@
+namespace Sbroenne.PowerPointMcp.Service.Rpc;
+
+/// <summary>
+/// Server-side RPC target that delegates incoming JSON-RPC calls to
+/// <see cref="PowerPointMcpService.ProcessAsync"/>. One instance is attached per pipe connection
+/// via <c>JsonRpc.Attach(stream, target)</c>. Ported from mcp-server-excel's DaemonRpcTarget.
+/// </summary>
+internal sealed class DaemonRpcTarget : IPowerPointDaemonRpc
+{
+    private readonly PowerPointMcpService _service;
+
+    public DaemonRpcTarget(PowerPointMcpService service)
+    {
+        _service = service;
+    }
+
+    /// <inheritdoc />
+    public async Task<ServiceResponse> ProcessCommandAsync(ServiceRequest request)
+    {
+        _service.RecordActivity();
+        return await _service.ProcessAsync(request);
+    }
+}

--- a/src/PowerPointMcp.Service/Rpc/IPowerPointDaemonRpc.cs
+++ b/src/PowerPointMcp.Service/Rpc/IPowerPointDaemonRpc.cs
@@ -1,0 +1,23 @@
+namespace Sbroenne.PowerPointMcp.Service.Rpc;
+
+/// <summary>
+/// Typed RPC interface for CLI &lt;-&gt; daemon communication over named pipes, using StreamJsonRpc
+/// (JSON-RPC 2.0) instead of a hand-rolled newline-delimited protocol.
+/// </summary>
+/// <remarks>
+/// Ported from mcp-server-excel's <c>IExcelDaemonRpc</c>. Deliberately omits Excel's
+/// <c>[JsonRpcContract]</c>/<c>[GenerateShape]</c> (PolyType) attributes — those opt into
+/// NativeAOT-safe source-generated proxies, which this project does not need (it is not
+/// published as NativeAOT). <c>StreamJsonRpc.JsonRpc.Attach&lt;T&gt;</c> builds a classic
+/// reflection-based dynamic proxy for a plain interface with no extra package dependency.
+/// </remarks>
+public interface IPowerPointDaemonRpc
+{
+    /// <summary>
+    /// Sends a command to the daemon for execution. Wraps
+    /// <see cref="PowerPointMcpService.ProcessAsync"/> over the pipe transport.
+    /// </summary>
+    /// <param name="request">The service request with command, sessionId, and args.</param>
+    /// <returns>The service response indicating success/failure with optional result data.</returns>
+    Task<ServiceResponse> ProcessCommandAsync(ServiceRequest request);
+}

--- a/src/PowerPointMcp.Service/ServiceClient.cs
+++ b/src/PowerPointMcp.Service/ServiceClient.cs
@@ -1,0 +1,188 @@
+using System.IO.Pipes;
+using Sbroenne.PowerPointMcp.Service.Rpc;
+using StreamJsonRpc;
+
+namespace Sbroenne.PowerPointMcp.Service;
+
+/// <summary>
+/// Client for communicating with the PowerPointMCP CLI daemon via named pipe + StreamJsonRpc.
+/// Each call creates a new pipe connection, makes one RPC call, and disconnects. Ported from
+/// mcp-server-excel's ExcelMcp.Service.ServiceClient.
+/// </summary>
+public sealed class ServiceClient : IDisposable
+{
+    private readonly string _pipeName;
+    private readonly TimeSpan _connectTimeout;
+    private readonly TimeSpan _requestTimeout;
+    private bool _disposed;
+
+    /// <summary>Default timeout for establishing the named pipe connection.</summary>
+    public static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Default timeout for the whole RPC round-trip (long enough that any caller-supplied timeout wins first).</summary>
+    public static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromHours(2);
+
+    /// <summary>Creates a client bound to a specific daemon pipe name.</summary>
+    /// <param name="pipeName">The named pipe to connect to.</param>
+    /// <param name="connectTimeout">Optional override for the pipe connect timeout.</param>
+    /// <param name="requestTimeout">Optional override for the overall request timeout.</param>
+    public ServiceClient(string pipeName, TimeSpan? connectTimeout = null, TimeSpan? requestTimeout = null)
+    {
+        _pipeName = pipeName;
+        _connectTimeout = connectTimeout ?? DefaultConnectTimeout;
+        _requestTimeout = requestTimeout ?? DefaultRequestTimeout;
+    }
+
+    /// <summary>Sends a request to the daemon and waits for its response via StreamJsonRpc.</summary>
+    public async Task<ServiceResponse> SendAsync(ServiceRequest request, CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        using var pipe = ServiceSecurity.CreateClient(_pipeName);
+        using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        connectCts.CancelAfter(_connectTimeout);
+
+        try
+        {
+            await pipe.ConnectAsync((int)_connectTimeout.TotalMilliseconds, connectCts.Token);
+
+            var proxy = JsonRpc.Attach<IPowerPointDaemonRpc>(pipe);
+            try
+            {
+                using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                using var disconnectMonitorCts = CancellationTokenSource.CreateLinkedTokenSource(requestCts.Token);
+                requestCts.CancelAfter(_requestTimeout);
+
+                var callTask = proxy.ProcessCommandAsync(request);
+                var disconnectTask = WaitForPipeDisconnectAsync(pipe, disconnectMonitorCts.Token);
+                var completed = await Task.WhenAny(callTask, disconnectTask);
+                if (completed == disconnectTask
+                    && disconnectTask.IsCompletedSuccessfully
+                    && disconnectTask.Result
+                    && !callTask.IsCompleted)
+                {
+                    return CreateConnectionLostResponse(request);
+                }
+
+                await disconnectMonitorCts.CancelAsync();
+                return await callTask.WaitAsync(requestCts.Token);
+            }
+            finally
+            {
+                ((IDisposable)proxy).Dispose();
+            }
+        }
+        catch (TimeoutException)
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                Command = request.Command,
+                SessionId = request.SessionId,
+                ErrorCategory = "Timeout",
+                ErrorMessage = "Daemon connection timed out",
+                ExceptionType = nameof(TimeoutException)
+            };
+        }
+        catch (OperationCanceledException) when (connectCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                Command = request.Command,
+                SessionId = request.SessionId,
+                ErrorCategory = "Timeout",
+                ErrorMessage = "Daemon connection timed out",
+                ExceptionType = nameof(OperationCanceledException)
+            };
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                Command = request.Command,
+                SessionId = request.SessionId,
+                ErrorCategory = "Timeout",
+                ErrorMessage = "Daemon request timed out",
+                ExceptionType = nameof(OperationCanceledException)
+            };
+        }
+        catch (ConnectionLostException)
+        {
+            return CreateConnectionLostResponse(request);
+        }
+        catch (IOException ex) when (ex.Message.Contains("pipe"))
+        {
+            return new ServiceResponse
+            {
+                Success = false,
+                Command = request.Command,
+                SessionId = request.SessionId,
+                ErrorCategory = "ServiceUnavailable",
+                ErrorMessage = "Cannot connect to daemon. Is it running?",
+                ExceptionType = nameof(IOException)
+            };
+        }
+    }
+
+    private static async Task<bool> WaitForPipeDisconnectAsync(Stream pipe, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (pipe is PipeStream pipeStream && !pipeStream.IsConnected)
+                {
+                    return true;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller completed or request timed out; this is not a disconnect signal.
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static ServiceResponse CreateConnectionLostResponse(ServiceRequest request)
+    {
+        return new ServiceResponse
+        {
+            Success = false,
+            Command = request.Command,
+            SessionId = request.SessionId,
+            ErrorCategory = "ServiceUnavailable",
+            ErrorMessage = "Connection to the daemon was lost while waiting for a response. The daemon may have " +
+                "exited or restarted; run 'pptcli service status' or 'pptcli service stop' and retry.",
+            ExceptionType = nameof(ConnectionLostException)
+        };
+    }
+
+    /// <summary>Pings the daemon to check if it's alive.</summary>
+    public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await SendAsync(new ServiceRequest { Command = "service.ping" }, cancellationToken);
+            return response.Success;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Marks this client as disposed; safe to call even though there is no unmanaged state.</summary>
+    public void Dispose()
+    {
+        _disposed = true;
+    }
+}

--- a/src/PowerPointMcp.Service/ServiceProtocol.cs
+++ b/src/PowerPointMcp.Service/ServiceProtocol.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.PowerPointMcp.Service;
+
+/// <summary>
+/// Protocol messages for CLI-to-daemon communication over named pipes (StreamJsonRpc transport,
+/// JSON-RPC 2.0). Ported from mcp-server-excel's ExcelMcp.Service.ServiceProtocol.
+/// </summary>
+public static class ServiceProtocol
+{
+    /// <summary>Shared JSON options for request/response/result payloads (camelCase, omit nulls, string enums).</summary>
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+}
+
+/// <summary>Request sent from the CLI to the daemon.</summary>
+public sealed class ServiceRequest
+{
+    /// <summary>Command to execute (e.g. "session.open", "notes.set-notes-text").</summary>
+    public required string Command { get; init; }
+
+    /// <summary>Session ID for commands that operate on an open presentation.</summary>
+    public string? SessionId { get; init; }
+
+    /// <summary>JSON-serialized command arguments.</summary>
+    public string? Args { get; init; }
+
+    /// <summary>Source of the request (e.g. "cli").</summary>
+    public string? Source { get; init; }
+}
+
+/// <summary>Response sent from the daemon back to the CLI.</summary>
+public sealed class ServiceResponse
+{
+    /// <summary>Whether the command succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>The command that produced this response, when available.</summary>
+    public string? Command { get; init; }
+
+    /// <summary>The session ID associated with this response, when available.</summary>
+    public string? SessionId { get; init; }
+
+    /// <summary>Error message if Success is false.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Structured error category if Success is false.</summary>
+    public string? ErrorCategory { get; init; }
+
+    /// <summary>Exception type that produced the failure, when available.</summary>
+    public string? ExceptionType { get; init; }
+
+    /// <summary>HRESULT from a COM failure, when available.</summary>
+    [JsonPropertyName("hresult")]
+    public string? HResult { get; init; }
+
+    /// <summary>Inner exception details, when available.</summary>
+    public string? InnerError { get; init; }
+
+    /// <summary>JSON-serialized result data.</summary>
+    public string? Result { get; init; }
+}
+
+/// <summary>Daemon status information, returned by "service.status".</summary>
+public sealed class ServiceStatus
+{
+    /// <summary>Whether the daemon is currently running (always true for a live response).</summary>
+    public bool Running { get; init; }
+
+    /// <summary>The daemon process's OS process id.</summary>
+    public int ProcessId { get; init; }
+
+    /// <summary>Number of currently open presentation sessions.</summary>
+    public int SessionCount { get; init; }
+
+    /// <summary>UTC time the daemon started.</summary>
+    public DateTime StartTime { get; init; }
+
+    /// <summary>How long the daemon has been running.</summary>
+    public TimeSpan Uptime => Running ? DateTime.UtcNow - StartTime : TimeSpan.Zero;
+}

--- a/src/PowerPointMcp.Service/ServiceSecurity.cs
+++ b/src/PowerPointMcp.Service/ServiceSecurity.cs
@@ -1,0 +1,76 @@
+using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Sbroenne.PowerPointMcp.Service;
+
+/// <summary>
+/// Security utilities for PowerPointMCP Service named pipe communication.
+/// Ensures per-user isolation via SID-based pipe names and ACLs.
+/// Ported from mcp-server-excel's ExcelMcp.Service.ServiceSecurity.
+/// </summary>
+/// <remarks>
+/// <para><b>Pipe Name Strategy:</b></para>
+/// <list type="bullet">
+///   <item>MCP Server: powerpointmcp-mcp-{SID}-{PID} (per-process isolation, each instance independent)</item>
+///   <item>CLI daemon: powerpointmcp-cli-{SID} (per-user, shared across CLI invocations)</item>
+/// </list>
+/// <para><b>Security Model:</b></para>
+/// <list type="bullet">
+///   <item>User Isolation: Pipe name includes user SID - users cannot access each other's daemon instances</item>
+///   <item>Windows ACLs: Named pipe restricts access to current user's SID via PipeSecurity</item>
+///   <item>Local Only: Named pipes are local IPC - no network access possible</item>
+/// </list>
+/// </remarks>
+public static class ServiceSecurity
+{
+    private static readonly Lazy<string> LazyUserSid = new(() =>
+    {
+        var sid = WindowsIdentity.GetCurrent().User?.Value;
+        if (string.IsNullOrEmpty(sid))
+        {
+            throw new InvalidOperationException(
+                "Cannot determine current user SID. Named pipe security requires a valid SID for user isolation.");
+        }
+        return sid;
+    });
+
+    private static string UserSid => LazyUserSid.Value;
+
+    /// <summary>Gets the pipe name for the MCP Server (per-process isolation).</summary>
+    public static string GetMcpPipeName() => $"powerpointmcp-mcp-{UserSid}-{Environment.ProcessId}";
+
+    /// <summary>Gets the pipe name for the CLI daemon (shared across CLI invocations for the same user).</summary>
+    public static string GetCliPipeName() => $"powerpointmcp-cli-{UserSid}";
+
+    /// <summary>Creates a secure named pipe server with ACLs restricting access to current user only.</summary>
+    public static NamedPipeServerStream CreateSecureServer(string pipeName)
+    {
+        var pipeSecurity = new PipeSecurity();
+
+        pipeSecurity.AddAccessRule(new PipeAccessRule(
+            WindowsIdentity.GetCurrent().User!,
+            PipeAccessRights.FullControl,
+            AccessControlType.Allow));
+
+        return NamedPipeServerStreamAcl.Create(
+            pipeName,
+            PipeDirection.InOut,
+            maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous,
+            inBufferSize: 4096,
+            outBufferSize: 4096,
+            pipeSecurity);
+    }
+
+    /// <summary>Creates a client connection to a daemon pipe.</summary>
+    public static NamedPipeClientStream CreateClient(string pipeName)
+    {
+        return new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+    }
+}


### PR DESCRIPTION
## Summary

Reverses the 2026-07-06 decision to drop the out-of-process Service/daemon pattern. Per updated
direction from @sbroenne: the daemon's real value is avoiding relaunching/tearing down PowerPoint
(~90-150s) on every CLI invocation — a serious cost for multi-step CLI scripts.

Ports mcp-server-excel's Service/daemon architecture (named pipe + StreamJsonRpc, mutex-based
auto-start detection, idle-timeout shutdown) into a new **`PowerPointMcp.Service`** project. The
daemon holds one long-lived `IPresentationBatch`/PowerPoint process per session id, reused across
*separate* `pptcli` process invocations via `-s|--session <id>`.

## What changed

- New `src/PowerPointMcp.Service` project: named-pipe daemon core, StreamJsonRpc RPC contract,
  pipe security (per-user SID-scoped pipe names), client-side connection helper.
- Moved `PresentationSessionRegistry` from `PowerPointMcp.McpServer` into
  `PowerPointMcp.ComInterop` so both the MCP server and the new daemon share it.
- Rewrote `ServiceCommandBase<TSettings>.ExecuteAsync` (previously a stub — "no execution
  backend yet") to dispatch through `DaemonAutoStart` + `ServiceClient`. **No generator
  changes were needed** — the existing source-generated CLI commands already assumed a
  session-based dispatch model.
- Added `session {create,open,save,close,list}` and `service {start,stop,status}` CLI commands.
- Replaced the legacy hand-written `create`/`slide add-blank|count|delete` placeholder
  commands with their generated, session-based equivalents (avoids overlapping/duplicate action
  names between the two models); updated the CLI README accordingly.

## Deliberate simplifications vs. Excel's "mirror 1:1" instruction (flagged, not silent)

1. Reused PowerPoint's existing, simpler `PresentationSessionRegistry` instead of porting
   Excel's ~860-line Polly-based `SessionManager`.
2. `IPowerPointDaemonRpc` is a plain interface (no PolyType `[JsonRpcContract]`/`[GenerateShape]`
   attributes) — avoids a new package dependency; uses StreamJsonRpc's reflection-based proxy.
3. No WinForms tray icon (daemon runs headless).
4. No NuGet auto-update checker.
5. `DaemonProcessTracker` is a flat PID-file-in-temp-dir approach (force-stop fallback only).

Full rationale recorded via squad decision (`.squad/decisions/inbox/brett-cli-service-daemon.md`).

## Verification

- Full solution build: **0 warnings, 0 errors**.
- Manual smoke test (real PowerPoint):
  - `session create` auto-started the daemon + PowerPoint.
  - `slide add-blank` then `slide get-count` from two **separate** CLI process invocations
    both operated on the same live PowerPoint process (confirmed same OS PID via
    `Get-Process POWERPNT`).
  - `service status` correctly reported session count/uptime.
  - `session close --save` + `service stop` cleanly shut down both the daemon and PowerPoint
    (verified via `Get-Process` — neither remained running).

Closes the reopened architecture discussion from 2026-07-06/07.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>