### PR TITLE
docs: correct feature reference to match 18-tool/12-domain architecture

### DIFF
--- a/.changeset/fix-feature-docs-accuracy.md
+++ b/.changeset/fix-feature-docs-accuracy.md
@@ -1,0 +1,10 @@
+---
+"powerpointmcp": patch
+---
+
+Fixed the "What You Can Do" section of the root README and rewrote
+`gh-pages/docs/features.md` and `src/PowerPointMcp.McpServer/README.md`, which
+all still described the old 31-tool/10-domain architecture. They now
+correctly document the current 18-tool, ~98-operation, 12-domain surface,
+including the previously undocumented Template, Master, and Animation
+domains.

--- a/README.md
+++ b/README.md
@@ -40,21 +40,29 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**31 tools across 10 domains:**
+**18 MCP tools with ~98 operations across 12 domains:**
 
-- 🗂️ **Presentation** (5 tools) — create, open, save, close, list sessions
-- 📑 **Slide** (3 tools) — add, count, delete
-- ▭ **Shape** (6 tools) — rectangle, text box, count, delete, position, size
-- ✏️ **TextFrame** (5 tools) — set/get text, font size, bold, font color
-- 📊 **Table** (3 tools) — add, set/get cell text
-- 🗣️ **Notes** (2 tools) — set/get speaker notes
-- 🖼️ **Layout** (2 tools) — set/get slide layout
-- 🖼️ **Image** (1 tool) — insert pictures
-- 📈 **Chart** (2 tools) — add chart, get chart data
-- 🖼️ **Export** (2 tools) — export a slide, or all slides, to images for visual verification
+- 🗂️ **Presentation** (5 ops) — create, open, save, close, list sessions
+- 🎨 **Template** (2 ops) — apply a `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name
+- 📑 **Slide** (12 ops) — add, count, delete, duplicate, reorder, per-slide background color, sections
+- ▭ **Shape** (25 ops) — rectangles, text boxes, auto shapes, lines, connectors, fill/line/shadow,
+  rotation, flip, z-order, grouping, naming, alt text
+- ✏️ **TextFrame** (15 ops) — text, font size/name/color, bold, italic, underline, alignment, bullets
+- 📊 **Table** (12 ops) — add, cell text, insert/delete rows &amp; columns, cell fill/border, merge cells
+- 🗣️ **Notes** (2 ops) — set/get speaker notes
+- 🖼️ **Layout** (2 ops) — set/get slide layout
+- 🎭 **Master** (6 ops) — slide master title/body placeholder fonts, background color
+- 🎬 **Animation** (5 ops) — shape entrance/emphasis/exit effects, slide transitions
+- 🖼️ **Image** (1 op) — insert pictures
+- 📈 **Chart** (9 ops) — add chart, multi-series data, titles, axis titles, legend
+- 🖼️ **Export** (2 ops) — export a slide, or all slides, to images for visual verification
+
+Each domain other than Presentation/Template is exposed as a single **action-dispatch tool**
+(e.g. `shape`, `table`, `chart`) with an `operation` parameter selecting the specific action —
+keeping the tool list small for AI assistants while still exposing every operation.
 
 📚 **[Complete Feature Reference →](https://powerpointmcpserver.dev/features/)** — detailed
-documentation of all 31 tools
+documentation of every tool and operation
 
 ## 💬 Example Prompts
 
@@ -70,6 +78,9 @@ documentation of all 31 tools
 
 **Speaker notes:**
 - *"Write speaker notes for each slide summarizing the key talking point."*
+
+**Templates &amp; themes:**
+- *"Apply our corporate template to this deck without losing any of the slide content."*
 
 **Visual verification:**
 - *"Export slide 3 as an image and tell me if the chart overlaps the text box."*

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,7 +1,7 @@
 ---
 title: Complete Feature Reference
-description: 31 MCP tools across 10 domains for live PowerPoint automation. Slides, shapes, text, tables, charts, notes, layouts, images and export-to-verify.
-keywords: "PowerPoint MCP features, PowerPoint automation, slide tools, shape tools, chart tools, table tools, MCP operations"
+description: 18 MCP tools with ~98 operations across 12 domains for live PowerPoint automation. Slides, shapes, text, tables, charts, notes, layouts, masters, animations, templates, images and export-to-verify.
+keywords: "PowerPoint MCP features, PowerPoint automation, slide tools, shape tools, chart tools, table tools, template tools, MCP operations"
 ---
 
 # Complete Feature Reference
@@ -9,6 +9,12 @@ keywords: "PowerPoint MCP features, PowerPoint automation, slide tools, shape to
 Every tool operates on a **session** (`session_id`) obtained from
 `open_presentation` or `create_presentation`, and drives a real, live
 PowerPoint desktop process via COM — not an offline `.pptx` parser.
+
+Most domains are exposed as a single **action-dispatch tool** (e.g. `shape`,
+`table`, `chart`) with an `operation` parameter selecting the specific
+action — this keeps the tool list small for AI assistants while still
+exposing every operation below. `Presentation` and `Template` are the
+exception: they're small enough to stay as individual, hand-written tools.
 
 ## Tool matrix
 
@@ -22,76 +28,137 @@ PowerPoint desktop process via COM — not an offline `.pptx` parser.
 | `close_presentation` | Closes a session (optionally saving first); closing is async |
 | `list_sessions` | Lists all currently open sessions, for state discovery without asking the user |
 
-### Slide
+### Template — themes &amp; masters
 
 | Tool | What it does |
 |------|---------------|
-| `add_slide` | Adds a new slide, optionally with a specific layout |
-| `get_slide_count` | Returns the number of slides in the presentation |
-| `delete_slide` | Deletes a slide by 1-based index |
+| `apply_template` | Applies a `.potx`/`.potm`/`.pot` (or `.pptx`/`.pptm`) template's masters/theme/layouts, preserving existing slide content |
+| `get_theme_name` | Reads the name of the design/theme currently applied to the presentation |
 
-### Shape
+### Slide (`slide` tool — 12 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `add_rectangle` | Adds a rectangle shape at a given position and size |
-| `add_text_box` | Adds a text box shape |
-| `get_shape_count` | Returns the number of shapes on a slide |
-| `delete_shape` | Deletes a shape by 1-based index |
-| `set_shape_position` | Moves a shape to a new X/Y position |
-| `set_shape_size` | Resizes a shape's width/height |
+| Operation | What it does |
+|-----------|---------------|
+| `add-blank` | Adds a new blank slide at the end of the presentation |
+| `get-count` | Returns the number of slides in the presentation |
+| `delete` | Deletes a slide by 1-based index |
+| `duplicate` | Duplicates a slide, inserting the copy immediately after the source |
+| `move-to` | Moves a slide to a new 1-based position, renumbering the rest |
+| `set-background-color` | Sets a solid background color for a single slide, overriding the master |
+| `get-background-color` | Reads a slide's background color and whether it follows the master |
+| `add-section` | Adds a new section at a given position |
+| `rename-section` | Renames a section |
+| `delete-section` | Deletes a section (optionally deleting its slides too) |
+| `get-section-count` | Returns the number of sections |
+| `get-section-name` | Reads a section's name |
 
-### TextFrame — text content &amp; formatting
+### Shape (`shape` tool — 25 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `set_text` | Sets the text content of a shape's text frame |
-| `get_text` | Reads the text content of a shape's text frame |
-| `set_font_size` | Sets font size for a text range |
-| `set_bold` | Toggles bold for a text range |
-| `set_font_color` | Sets font color for a text range |
+| Operation | What it does |
+|-----------|---------------|
+| `add-rectangle` | Adds a rectangle shape at a given position and size |
+| `add-text-box` | Adds a text box shape |
+| `add-auto-shape` | Adds a non-rectangle auto shape (oval, arrow, star, etc.) by `MsoAutoShapeType` name |
+| `add-line` | Adds a straight line between two points |
+| `add-connector` | Adds a connector shape (straight, elbow, or curved) between two points |
+| `get-count` | Returns the number of shapes on a slide |
+| `delete` | Deletes a shape by 1-based index |
+| `set-position` | Moves a shape to a new X/Y position |
+| `set-size` | Resizes a shape's width/height |
+| `set-fill` / `get-fill` | Sets / reads a shape's solid fill color |
+| `set-line` / `get-line` | Sets / reads a shape's line/border color, weight, dash style, visibility |
+| `set-rotation` / `get-rotation` | Sets / reads a shape's rotation in degrees |
+| `flip` | Flips a shape horizontally or vertically |
+| `set-z-order` | Moves a shape in the slide's draw order (front/back/forward/backward) |
+| `set-shadow` / `get-shadow` | Toggles / reads a shape's default drop shadow |
+| `group` / `ungroup` | Groups multiple shapes into one, or splits a group back apart |
+| `set-name` / `get-name` | Sets / reads a shape's name (Selection Pane) |
+| `set-alt-text` / `get-alt-text` | Sets / reads a shape's accessibility alt text |
 
-### Table
+### TextFrame (`textframe` tool — 15 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `add_table` | Adds a table shape with a given row/column count |
-| `set_cell_text` | Sets the text of a table cell by 1-based row/column |
-| `get_cell_text` | Reads the text of a table cell by 1-based row/column |
+| Operation | What it does |
+|-----------|---------------|
+| `set-text` / `get-text` | Sets / reads a shape's text content |
+| `set-font-size` | Sets font size for a shape's text range |
+| `set-bold` | Toggles bold |
+| `set-font-color` | Sets font color |
+| `set-italic` / `get-italic` | Sets / reads italic |
+| `set-underline` / `get-underline` | Sets / reads underline |
+| `set-font-name` / `get-font-name` | Sets / reads the font typeface |
+| `set-alignment` / `get-alignment` | Sets / reads paragraph alignment |
+| `set-bullet` / `get-bullet` | Sets / reads bullet formatting |
 
-### Notes — speaker notes
+### Table (`table` tool — 12 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `set_notes_text` | Sets the speaker notes text for a slide |
-| `get_notes_text` | Reads the speaker notes text for a slide |
+| Operation | What it does |
+|-----------|---------------|
+| `add-table` | Adds a table shape with a given row/column count |
+| `set-cell-text` / `get-cell-text` | Sets / reads a cell's text by 1-based row/column |
+| `insert-row` / `delete-row` | Inserts / deletes a table row |
+| `insert-column` / `delete-column` | Inserts / deletes a table column |
+| `set-cell-fill` / `get-cell-fill` | Sets / reads a cell's solid fill color |
+| `set-cell-border` / `get-cell-border` | Sets / reads a single cell border's color, weight, dash style, visibility |
+| `merge-cells` | Merges two adjacent cells into one |
 
-### Layout
+### Notes (`notes` tool — 2 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `set_layout` | Applies a slide layout to a slide |
-| `get_layout` | Reads the current layout of a slide |
+| Operation | What it does |
+|-----------|---------------|
+| `set-notes-text` | Sets the speaker notes text for a slide |
+| `get-notes-text` | Reads the speaker notes text for a slide |
 
-### Image
+### Layout (`layout` tool — 2 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `add_picture` | Inserts a picture from a local file path onto a slide |
+| Operation | What it does |
+|-----------|---------------|
+| `set-layout` | Applies a built-in slide layout (e.g. Title Only, Blank) |
+| `get-layout` | Reads a slide's current layout name |
 
-### Chart
+### Master (`master` tool — 6 operations)
 
-| Tool | What it does |
-|------|---------------|
-| `add_chart` | Adds a chart shape with a given chart type and data |
-| `get_chart_data` | Reads back the underlying chart data |
+| Operation | What it does |
+|-----------|---------------|
+| `get-title-font` / `set-title-font` | Reads / sets the slide master's title placeholder font (name, size, bold, color) |
+| `get-body-font` / `set-body-font` | Reads / sets the slide master's body placeholder font |
+| `get-background-color` / `set-background-color` | Reads / sets the slide master's background fill color |
 
-### Export — the visual-verification differentiator
+Changes to the master apply to every slide that inherits from it (i.e. any slide that doesn't
+override the property itself) — the practical "edit once, apply everywhere" workflow PowerPoint's
+COM model supports safely.
 
-| Tool | What it does |
-|------|---------------|
-| `export_slide_to_image` | Exports a single slide to an image file, for multimodal visual verification |
-| `export_all_slides_to_images` | Exports every slide to image files in one call |
+### Animation (`animation` tool — 5 operations)
+
+| Operation | What it does |
+|-----------|---------------|
+| `add-effect` | Adds an entrance/emphasis/exit animation effect to a shape by `MsoAnimEffect` name |
+| `get-effect-count` | Returns the number of animation effects on a slide's timeline |
+| `delete-effect` | Deletes an effect from a slide's timeline by 1-based index |
+| `get-transition` / `set-transition` | Reads / sets a slide's transition (effect, duration, advance behavior) |
+
+### Image (`image` tool — 1 operation)
+
+| Operation | What it does |
+|-----------|---------------|
+| `add-picture` | Embeds a picture from a local file path onto a slide |
+
+### Chart (`chart` tool — 9 operations)
+
+| Operation | What it does |
+|-----------|---------------|
+| `add-chart` | Adds a native chart shape (bar, line, or pie) with categories and a data series |
+| `get-chart-data` | Reads back a chart's category and series counts |
+| `add-series` | Adds another data series to an existing chart |
+| `set-chart-title` / `get-chart-title` | Sets / reads the chart's main title |
+| `set-axis-title` / `get-axis-title` | Sets / reads a category or value axis title |
+| `set-legend-visibility` / `get-legend-visibility` | Shows/hides / reads the chart's legend |
+
+### Export (`export` tool — 2 operations) — the visual-verification differentiator
+
+| Operation | What it does |
+|-----------|---------------|
+| `export-slide-to-image` | Exports a single slide to an image file, for multimodal visual verification |
+| `export-all-slides-to-images` | Exports every slide to image files in one call |
 
 !!! tip "Why export-to-verify matters"
     Because tools drive a real PowerPoint instance, every edit can be

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,27 +32,35 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-31 tools across 10 domains:
+18 tools with ~98 operations across 12 domains:
 
 | Domain | Tools |
 | --- | --- |
 | Presentation | create, open, save, close, list sessions |
-| Slide | add, count, delete |
-| Shape | add rectangle / text box, count, delete, position, size |
-| Text | set/get text, font size, bold, font color |
-| Table | add table, set/get cell text |
+| Template | apply template, get theme name |
+| Slide | add, count, delete, duplicate, move, sections, background color |
+| Shape | add rectangle / text box / auto shape / line / connector, position, size, fill, line, rotation, flip, z-order, shadow, group, name, alt text |
+| TextFrame | set/get text, font size, bold, color, italic, underline, font name, alignment, bullets |
+| Table | add table, set/get cell text, insert/delete rows and columns, cell fill, cell border, merge cells |
 | Notes | set/get speaker notes |
 | Layout | set/get slide layout |
+| Master | title/body placeholder font, background color |
+| Animation | add/delete shape effects, get transition, set transition |
 | Image | add picture |
-| Chart | add chart, get chart data |
+| Chart | add chart, get chart data, add series, chart/axis title, legend visibility |
 | Export | export a slide / all slides to images (visual verification) |
+
+Most domains are exposed as a single **action-dispatch tool** (e.g. `shape`, `table`) taking an
+`operation` parameter, keeping the tool list small for AI assistants while still exposing every
+operation above. `Presentation` and `Template` remain individual, hand-written tools.
 
 ## How it works
 
-`ComInterop` (STA thread + OLE message filter) → `Core` (domain command
-classes) → `McpServer` (stdio host with an in-process session registry). Each
-open presentation is a session identified by a `sessionId`; tools operate on a
-session until it is closed.
+`ComInterop` (STA thread + OLE message filter) → `Core` (domain command classes) →
+`PowerPointMcp.Service` (shared service layer) → `McpServer` (stdio host, calling the service
+in-process) and `CLI` (talks to the same service via a background named-pipe daemon). Each open
+presentation is a session identified by a `sessionId`; tools operate on a session until it is
+closed.
 
 ## Links
 


### PR DESCRIPTION
## Summary
Fixes stale documentation that still described the old 31-tool/10-domain MCP architecture.

- Rewrote README.md's "What You Can Do" section: 18 tools / ~98 operations / 12 domains (was 31 tools / 10 domains). Added the previously-undocumented Template, Master, and Animation domains, plus an explanation of the action-dispatch tool pattern.
- Fully rewrote gh-pages/docs/features.md with an accurate, per-domain operation reference matching the real Core command interfaces.
- Fixed src/PowerPointMcp.McpServer/README.md's capability table and architecture description (added the shared PowerPointMcp.Service layer, corrected tool/domain counts).

All operation counts were verified by reading each Core I{Domain}Commands.cs interface directly, and the tool surface was cross-checked against tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs's ExpectedToolNames set.

Docs-only change; includes a changeset.