### PR TITLE
docs: restructure gh-pages site to match sister project structure

### DIFF
--- a/.changeset/align-docs-site-structure.md
+++ b/.changeset/align-docs-site-structure.md
@@ -1,0 +1,12 @@
+---
+"powerpointmcp": patch
+---
+
+Restructured the documentation site homepage to match the sister
+`mcp-server-excel` project's structure: removed the redundant "Quick install"
+card grid from the homepage (installation already has its own dedicated
+page), split "How it works" out into a new `architecture.md` page, and split
+"Related projects" out into a new `related-projects.md` page. Also fixed the
+last remaining stale "31 tools across 10 domains" references in
+`installation.md`, `mcp-server.md`, and `mcpb/README.md` to the current
+18-tool / ~98-operation / 12-domain count.

--- a/gh-pages/docs/architecture.md
+++ b/gh-pages/docs/architecture.md
@@ -1,0 +1,57 @@
+---
+title: Architecture
+description: >-
+  How PowerPoint MCP Server works — Windows COM automation driving the real
+  PowerPoint application through two equal entry points (MCP Server and CLI)
+  that share one core.
+keywords: "PowerPoint MCP architecture, PowerPoint COM automation, MCP server design, pptcli daemon, PowerPoint.Application, named pipe"
+---
+
+# Architecture
+
+**PowerPoint MCP Server uses Windows COM automation to control the actual
+PowerPoint application — not just `.pptx` files.** Because it drives
+PowerPoint's official COM API (`PowerPoint.Application`), every edit is
+rendered and saved by PowerPoint itself, so there's zero risk of producing a
+file PowerPoint can't open — and any visual change can be exported to an
+image and verified by a vision-capable AI assistant.
+
+## Two equal entry points
+
+The project ships **both** an MCP Server and a CLI. They are first-class,
+interchangeable entry points that share the same core, so every operation
+behaves identically no matter which you use:
+
+- **MCP Server** hosts the service **in-process** — direct method calls, no
+  pipe — which suits conversational, interactive AI clients.
+- **CLI** (`pptcli`) talks to a **background daemon** over a named pipe, so
+  sessions persist across invocations — ideal for scripted, high-throughput
+  automation by coding agents.
+
+```mermaid
+flowchart TD
+    A["AI assistants<br/>(Claude, Copilot, ChatGPT)"] -->|MCP protocol| B["MCP Server<br/>in-process service"]
+    C["Coding agents<br/>(Copilot, Cursor, Windsurf)"] -->|pptcli| D["CLI<br/>named pipe → background daemon"]
+    B --> E["Core Commands<br/>(shared codebase)"]
+    D --> E
+    E --> F["PowerPoint COM API<br/>(PowerPoint.Application)"]
+```
+
+## Shared core, separate processes
+
+Both entry points build on the same **Core Commands** codebase, so a feature
+added to one is automatically available to the other with the same
+parameters, defaults and validation. They run as **separate processes**, each
+managing its own PowerPoint instance, and do **not** share live sessions with
+each other.
+
+## Sessions
+
+Every open presentation is a session identified by a `session_id`, obtained
+from `open_presentation`/`create_presentation` (MCP Server) or
+`session create`/`session open` (CLI). Tools and commands operate on a
+session until it is explicitly closed, and nothing is written to disk until
+`save_presentation`/`session save` is called.
+
+Ready to install? See the [installation guide](installation.md), or dive into
+the [MCP Server](mcp-server.md) and [CLI](cli.md) references.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -28,36 +28,6 @@ hide:
       *see* the result — catching overlapping shapes, text overflow, and
       layout regressions that text-only automation simply cannot detect.
 
-## Quick install
-
-<div class="grid cards" markdown>
-
--   :material-microsoft-visual-studio-code:{ .lg .middle } __VS Code / GitHub Copilot__
-
-    ---
-
-    [Install Extension](https://marketplace.visualstudio.com/items?itemName=sbroenne.powerpoint-mcp){ .md-button .md-button--primary }
-
--   :material-robot:{ .lg .middle } __Claude Desktop__
-
-    ---
-
-    [One-click install (MCPB)](https://github.com/sbroenne/mcp-server-powerpoint/releases/latest){ .md-button }
-
--   :material-nuget:{ .lg .middle } __NuGet .NET tool__
-
-    ---
-
-    [dotnet tool install guide](installation.md){ .md-button }
-
--   :material-console:{ .lg .middle } __Cursor, Windsurf, etc.__
-
-    ---
-
-    [Installation guide](installation.md){ .md-button }
-
-</div>
-
 ## Key features
 
 <div class="grid cards" markdown>
@@ -96,6 +66,27 @@ hide:
 
     Insert pictures from local files directly onto any slide.
 
+-   :material-palette-swatch:{ .lg .middle } __Templates &amp; themes__
+
+    ---
+
+    Apply a `.potx`/`.pptx` template's masters, theme and layouts while
+    preserving existing slide content, and read back the current theme name.
+
+-   :material-format-font:{ .lg .middle } __Slide masters__
+
+    ---
+
+    Set title/body placeholder fonts and background color on the slide
+    master — one edit, applied to every slide that inherits it.
+
+-   :material-motion-play:{ .lg .middle } __Animations &amp; transitions__
+
+    ---
+
+    Add entrance/emphasis/exit effects to shapes and set slide transitions,
+    then read them back to verify.
+
 -   :material-image-check:{ .lg .middle } __Export-to-verify__
 
     ---
@@ -106,7 +97,7 @@ hide:
 
 </div>
 
-[See all 31 tools across 10 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 18 tools (~98 operations) across 12 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 
@@ -159,38 +150,7 @@ based on your use case:
 
 [MCP Server docs](mcp-server.md){ .md-button } [CLI docs](cli.md){ .md-button }
 
-## How it works — live COM automation
-
-**PowerPoint MCP Server uses Windows COM automation to control the actual
-PowerPoint application (not just `.pptx` files).**
-
-```mermaid
-flowchart TB
-    A[MCP Server<br/>AI assistants] --> C[Session Registry<br/>in-process, per-server]
-    B[CLI - pptcli<br/>coding agents] --> C
-    C --> D[PowerPoint COM API<br/>PowerPoint.Application]
-```
-
-- ✅ **True fidelity** — every render, export, and edit happens inside real
-  PowerPoint, so what you get is exactly what PowerPoint would produce.
-- ✅ **Session-based workflow** — `open_presentation`/`create_presentation`
-  start a session; every subsequent tool call operates on that session by
-  `session_id`.
-- ✅ **Export-to-verify** — close the loop on every visual change with a real
-  rendered image.
-
-## Related projects
-
-Other projects by the author:
-
-- [Excel MCP Server](https://excelmcpserver.dev/) — the sibling project this
-  port is based on: AI-powered Excel automation via Power Query, DAX, VBA and
-  PivotTables
-- [Windows MCP Server](https://windowsmcpserver.dev/) — AI-powered Windows
-  automation via GitHub Copilot, Claude and other MCP clients
-- [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering) —
-  LLM-powered testing framework for AI agents
-- [OBS Studio MCP Server](https://github.com/sbroenne/mcp-server-obs) —
-  AI-powered OBS Studio automation
-- [HeyGen MCP Server](https://github.com/sbroenne/heygen-mcp) — MCP server
-  for HeyGen AI video generation
+!!! tip "Also automating spreadsheets?"
+    Check out [Excel MCP Server](https://excelmcpserver.dev/) — the sister
+    project to PowerPoint MCP Server, bringing the same real-application
+    automation approach to Excel.

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -122,7 +122,7 @@ slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 31 tools across 10 domains
+- [Complete Feature Reference](features.md) — all 18 tools (~98 operations) across 12 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 31 tools across 10 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 18 tools with ~98 operations across 12 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/gh-pages/docs/related-projects.md
+++ b/gh-pages/docs/related-projects.md
@@ -1,0 +1,74 @@
+---
+title: Related projects
+description: >-
+  More open-source projects by Stefan Broenner — AI automation, testing and
+  cloud tooling that complement PowerPoint MCP Server.
+keywords: "Stefan Broenner projects, Excel MCP Server, Windows MCP Server, OBS MCP Server, pytest-skill-engineering, RVToolsMerge"
+---
+
+# Related projects
+
+Other open-source projects by the author that pair well with PowerPoint MCP
+Server:
+
+<div class="grid cards" markdown>
+
+-   :material-microsoft-excel:{ .lg .middle } __Excel MCP Server__
+
+    ---
+
+    AI-powered Excel automation via MCP — the sister project to PowerPoint
+    MCP Server, built the same way.
+
+    [:octicons-arrow-right-24: excelmcpserver.dev](https://excelmcpserver.dev/)
+
+-   :material-test-tube:{ .lg .middle } __pytest-skill-engineering__
+
+    ---
+
+    LLM-powered testing framework for AI agents — the same framework used to
+    validate this project's tools.
+
+    [:octicons-arrow-right-24: View on GitHub](https://github.com/sbroenne/pytest-skill-engineering)
+
+-   :material-microsoft-windows:{ .lg .middle } __Windows MCP Server__
+
+    ---
+
+    AI-powered Windows automation: mouse, keyboard, windows and screenshots.
+
+    [:octicons-arrow-right-24: windowsmcpserver.dev](https://windowsmcpserver.dev/)
+
+-   :material-video:{ .lg .middle } __OBS Studio MCP Server__
+
+    ---
+
+    AI-powered OBS Studio automation for recording and streaming.
+
+    [:octicons-arrow-right-24: View on GitHub](https://github.com/sbroenne/mcp-server-obs)
+
+-   :material-server:{ .lg .middle } __RVToolsMerge__
+
+    ---
+
+    Merge and anonymize VMware RVTools exports.
+
+    [:octicons-arrow-right-24: View on GitHub](https://github.com/sbroenne/RvToolsMerge)
+
+-   :material-currency-usd:{ .lg .middle } __Azure Retail Prices Exporter__
+
+    ---
+
+    Daily automated Azure pricing exports with FX rates.
+
+    [:octicons-arrow-right-24: View on GitHub](https://github.com/sbroenne/azureretailprices-exporter)
+
+-   :material-shield-account:{ .lg .middle } __AWS CUR Anonymize__
+
+    ---
+
+    Anonymize AWS Cost &amp; Usage Reports for secure sharing.
+
+    [:octicons-arrow-right-24: View on GitHub](https://github.com/sbroenne/aws-cur-anonymize)
+
+</div>

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -86,10 +86,12 @@ nav:
   - CLI: cli.md
   - More:
       - Agent Skills: skills.md
+      - Architecture: architecture.md
       - Changelog: changelog.md
       - Contributing: contributing.md
       - Security: security.md
       - Privacy: privacy.md
+      - Related projects: related-projects.md
 
 markdown_extensions:
   - abbr

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -17,9 +17,9 @@ Claude can now create and edit PowerPoint decks directly.
 ## What's inside
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
-required) plus the manifest, license, and changelog. The server exposes 31 tools
-across 10 domains — see the [documentation](https://powerpointmcpserver.dev) for
-the full list.
+required) plus the manifest, license, and changelog. The server exposes 18
+tools (~98 operations across 12 domains) — see the
+[documentation](https://powerpointmcpserver.dev) for the full list.
 
 ## Building locally
 


### PR DESCRIPTION
## Summary
Aligns the documentation site's structure with mcp-server-excel's, per feedback that the homepage should follow the same pattern rather than inventing our own.

- Removed the redundant "Quick install" card grid from the homepage — installation already has its own dedicated page, and the sister site's homepage doesn't duplicate it.
- Split "How it works" out into a new dedicated \rchitecture.md\ page (added to the "More" nav dropdown), matching the sister project's \rchitecture.md\.
- Split "Related projects" out into a new dedicated \elated-projects.md\ page (added to the "More" nav dropdown), matching the sister project's \elated-projects.md\. The homepage now ends with a short 'sister project' tip callout instead, exactly like the Excel site does for PowerPoint.
- Fixed the last remaining stale "31 tools across 10 domains" references in \installation.md\, \mcp-server.md\, and \mcpb/README.md\ to the current 18-tool / ~98-operation / 12-domain count.

Verified with \mkdocs build --strict --clean\ (0 warnings/errors). Docs-only change; includes a changeset.