### PR TITLE
docs: fix stale agent instructions describing pre-Service architecture

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,27 +84,43 @@ interop, designed for coding agents and automation scripts. It drives a **live P
 instance** through the official `Microsoft.Office.Interop.PowerPoint` PIA (embedded via
 `ForceEmbedPowerPointInteropTypes` — no runtime assembly-resolver needed, unlike Excel).
 
-> **NOTE: Unlike `mcp-server-excel`, the CLI here is currently a hand-written placeholder, not an
-> equal first-class entry point.** The MCP Server is the primary, actively-developed surface.
-> Do not assume CLI/MCP parity exists yet — see `src/PowerPointMcp.CLI/Program.cs`.
+The project ships **two equal, first-class entry points** — an MCP Server and a CLI — that share
+one `Core` codebase and are kept in parity by source generators, mirroring `mcp-server-excel`'s
+Unified Service Architecture.
 
 **Core Layers:**
 1. **ComInterop** (`src/PowerPointMcp.ComInterop`) - STA thread + OLE message filter + channel-based
    work queue (`PresentationBatch`), ported from `mcp-server-excel`'s `ExcelBatch` pattern.
 2. **Core** (`src/PowerPointMcp.Core`) - PowerPoint domain commands, one folder per domain
-   (Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Image, Chart, Export).
-3. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. Hand-written
-   `[McpServerToolType]` classes (one per domain, 31 tools total) — no source generators yet
-   (deferred until the Core shape is proven stable; see architecture decision in
-   `.squad/decisions.md`, 2026-07-01T11-14-34).
-4. **CLI** (`src/PowerPointMcp.CLI`) - Minimal hand-written placeholder proving
-   ComInterop → Core → CLI end to end. NOT the target Generators-based CLI.
+   (Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation, Image, Chart,
+   Export). Domains other than Presentation carry a `[ServiceCategory]` marker attribute that the
+   generators discover.
+3. **Generators** (`src/PowerPointMcp.Generators.Mcp`, `src/PowerPointMcp.Generators.Cli`,
+   `src/PowerPointMcp.Generators.Shared`) - Roslyn source generators that read `[ServiceCategory]`
+   Core interfaces and emit one **action-dispatch tool per domain** for the MCP surface (e.g.
+   `slide`, `shape`, `chart`, each taking an `operation` parameter like `"chart.add-chart"`) and
+   one `pptcli {category} {action}` command per operation for the CLI. `Presentation` (session
+   lifecycle) and its `ApplyTemplate`/`GetThemeName` methods stay hand-written
+   (`PresentationTools.cs`) since they don't fit the per-session action-dispatch shape.
+4. **Service** (`src/PowerPointMcp.Service`) - `PowerPointMcpService`: the shared session registry
+   + dispatch layer both entry points call into. **McpServer** hosts it **in-process** (no pipe,
+   via `ServiceBridge.ForwardToService`); **CLI** (`pptcli`) talks to it via a **separate
+   background daemon process** over a named pipe (`ServiceClient`/`IPowerPointDaemonRpc`,
+   auto-started on first `session open`/`session create`), so sessions persist across CLI
+   invocations without paying PowerPoint's ~90-150s launch cost every command.
+5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 18 tools
+   total: 7 hand-written session-lifecycle/template tools
+   (`create_presentation`/`open_presentation`/`save_presentation`/`close_presentation`/
+   `list_sessions`/`apply_template`/`get_theme_name`) + 11 generated action-dispatch tools (one per
+   remaining Core domain), covering ~98 operations. See
+   `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
+   the ground-truth tool list.
+6. **CLI** (`src/PowerPointMcp.CLI`) - `pptcli`, built on the same generators as the MCP surface
+   (`CliCommandRegistration.RegisterCommands`) plus hand-written `session`/`service` command
+   branches for daemon lifecycle. Full parity with the MCP surface (Export is exposed here too).
 
-**No out-of-process Service** (unlike Excel's `ExcelMcp.Service` + named-pipe `ServiceBridge`).
-The MVP uses an in-process `PresentationSessionRegistry` singleton
-(`ConcurrentDictionary<string sessionId, IPresentationBatch>`) inside the MCP host — the STA
-thread + work queue already live inside `PresentationBatch`, and the MCP stdio host is itself
-long-lived, so no RPC layer is needed for the MVP. Out-of-process hardening is deferred to Phase 2.
+MCP Server and CLI run as **separate processes**, each managing its own PowerPoint instance — they
+do **not** share live sessions with each other, only the same `Core`/`Service` codebase.
 
 ## Session Model (MCP Server)
 
@@ -217,22 +233,25 @@ When using `gh` against `sbroenne/mcp-server-powerpoint` (issues, PRs, comments,
 **Success Flag:** NEVER `Success = true` with `ErrorMessage`. Set `Success` in the success path
 only; catch-free in Core (see Rule 1/1b above).
 
-**Session Registry:** DI-injected `PresentationSessionRegistry registry` parameter on static MCP
-tool methods is correctly EXCLUDED from the MCP JSON schema by SDK 1.3.0 — verified via
-`tools/list`. Don't add manual schema suppression for it.
+**Session Registry / Service DI:** The DI-injected `PresentationSessionRegistry registry` parameter
+(hand-written session-lifecycle tools) and `PowerPointMcpService service` parameter (generated
+action-dispatch tools) are both correctly EXCLUDED from the MCP JSON schema by SDK 1.3.0 —
+verified via `tools/list`. Don't add manual schema suppression for either.
 
 **Two-Layer Shutdown:** `PresentationSessionShutdownService : IHostedService` disposes batches on
 host `StopAsync`, AND `Main`'s `finally` calls `registry.DisposeAll()` as an idempotent backstop.
 Both layers must stay in sync if session lifecycle changes.
 
-**No CLI/MCP Parity Requirement (Yet):** Unlike Excel, do not assume every MCP action needs a
-matching CLI command — the CLI is a placeholder pending a future Generators-based rebuild. Don't
-block MCP feature work on CLI parity.
+**No CLI/MCP Parity Gaps:** Both entry points are built from the same generators against the same
+`[ServiceCategory]` Core interfaces, so a new Core operation is automatically available on both
+surfaces once its domain's generator runs — there is no placeholder/parity-gap state to track
+anymore. Export is exposed identically on both.
 
-**Generators Deferred:** Do not stand up source generators (mirroring
-`ExcelMcp.Generators.Mcp`) until explicitly decided — Core interfaces currently take
-`IPresentationBatch batch` directly (no `[ServiceCategory]`/session-id marker attributes the
-generator would need). See `.squad/decisions.md` for the full rationale.
+**Generators Are Live:** `PowerPointMcp.Generators.Mcp`/`PowerPointMcp.Generators.Cli` (mirroring
+`ExcelMcp.Generators.Mcp`/`.Cli`) read `[ServiceCategory]`-attributed Core interfaces and emit the
+action-dispatch MCP tools and `pptcli` commands. Adding a new domain means adding the
+`[ServiceCategory]` attribute + interface/implementation to Core — the generators pick it up
+automatically; do not hand-write a new tool class for it.
 
 **Export Domain:** `ExportSlideToImage`/`ExportAllSlidesToImages` use PowerPoint's native
 `Presentation.Export`/`Slide.Export` COM calls — prefer the single multi-slide `Export` call over

--- a/.github/instructions/architecture-patterns.instructions.md
+++ b/.github/instructions/architecture-patterns.instructions.md
@@ -21,62 +21,63 @@ applyTo: "src/**/*.cs"
 ```
 ComInterop (STA thread, OLE message filter, PresentationBatch work queue)
     ↓
-Core (domain commands: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Image, Chart, Export)
+Core (domain commands: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master,
+      Animation, Image, Chart, Export — all but Presentation carry a [ServiceCategory] attribute)
     ↓
-McpServer (hand-written [McpServerToolType] classes, PresentationSessionRegistry)
-    ↓ (separately, not yet at parity)
-CLI (placeholder Program.cs)
+Service (PowerPointMcpService: session registry + dispatch, shared codebase)
+    ↓                                              ↓
+McpServer (in-process, ServiceBridge)        CLI / pptcli (named-pipe daemon, ServiceClient)
 ```
 
 - **ComInterop** owns all direct COM object lifetime and STA-thread marshaling. Core never talks
   to `Microsoft.Office.Interop.PowerPoint` types outside of a `batch.Execute(...)` callback.
 - **Core** commands take `IPresentationBatch batch` as an explicit first parameter (no ambient
-  session state, no `[ServiceCategory]` marker attributes — those exist in `mcp-server-excel` for
-  its generator pipeline, which this repo has NOT ported; see
-  `.squad/decisions.md` for the rationale).
-- **McpServer** tools are thin: resolve `sessionId` → `IPresentationBatch` via
-  `PresentationSessionRegistry.TryGet`, call the matching Core command, serialize the
-  `{Domain}OperationResult` to JSON. No domain logic lives in the `Tools/` classes.
+  session state). Domains other than `Presentation` also carry a `[ServiceCategory("name",
+  "PascalName")]` attribute (and an `[McpTool(...)]` attribute describing the generated tool) so
+  `PowerPointMcp.Generators.Mcp`/`.Cli` can discover them — mirroring `mcp-server-excel`'s
+  generator pipeline.
+- **Service** (`PowerPointMcp.Service`) resolves `sessionId` → `IPresentationBatch` via its own
+  `PresentationSessionRegistry`, then calls the matching Core command with the resolved batch.
+  Both entry points call into this same dispatch logic (`ServiceRegistry.{Category}.RouteAction`)
+  — MCP in-process via `ServiceBridge.ForwardToService`, CLI over a named pipe via
+  `ServiceClient`/`IPowerPointDaemonRpc`.
+- **McpServer** tools are thin either way: the 7 hand-written session/template tools
+  (`PresentationTools.cs`) resolve `sessionId` → batch directly via
+  `PresentationSessionRegistry.TryGet`; the 11 generated action-dispatch tools
+  (`slide`/`shape`/`chart`/etc., one per `[ServiceCategory]` domain) forward straight to the
+  shared `PowerPointMcpService`. No domain logic lives in either.
 
 ## Command Pattern
 
 ### Structure (per domain)
 ```
 Core/Shape/
-├── IShapeCommands.cs     # Interface (contract)
+├── IShapeCommands.cs     # Interface (contract) — [ServiceCategory] + [McpTool] attributes
 ├── ShapeCommands.cs      # Implementation
 └── ShapeOperationResult.cs  # Result DTO (Success/ErrorMessage + domain fields)
 ```
 
-### MCP Tool Routing (one static class per domain, not action-dispatch)
+### MCP Tool Routing (generated action-dispatch, one tool per domain)
 
-Unlike `mcp-server-excel`'s single action-dispatch tool per domain (e.g. `slide(action:'add')`),
-PowerPointMcp registers **one `[McpServerTool]` method per verb** (e.g. `add_slide`,
-`get_slide_count`, `delete_slide` as three separate MCP tools). This was a deliberate MVP choice
-(see `.squad/decisions.md`, Q2) to keep the hand-written tool classes simple before generators are
-introduced — do not silently convert existing tools to action-dispatch without an explicit
-architecture decision.
+Matching `mcp-server-excel`'s pattern, each `[ServiceCategory]` Core domain is exposed as a
+**single generated action-dispatch MCP tool** (e.g. `shape`) taking an `operation` parameter (e.g.
+`"shape.add-rectangle"`) rather than one hand-written `[McpServerTool]` method per verb. Do not
+hand-write a new per-verb tool class for a Core domain — add the domain's
+`[ServiceCategory]`/`[McpTool]` attributes and the generators emit the dispatch tool and its
+`pptcli` commands automatically. `Presentation` (session lifecycle) and its
+`ApplyTemplate`/`GetThemeName` methods are the deliberate exception and stay hand-written in
+`PresentationTools.cs`, since session create/open/save/close doesn't fit the per-session
+action-dispatch shape.
 
 ```csharp
-[McpServerToolType]
-public static class ShapeTools
+// Core: attribute-driven, discovered by the generators — no hand-written tool class needed.
+[ServiceCategory("shape", "Shape")]
+[McpTool("shape", Title = "Shape Operations", Destructive = true, Category = "content",
+    Description = "Add, count, delete, reposition, and resize shapes on a slide in an open presentation session.")]
+public interface IShapeCommands
 {
-    private static readonly ShapeCommands Commands = new();
-
-    [McpServerTool(Name = "add_rectangle")]
-    [Description("Add a rectangle shape to the given slide.")]
-    public static string AddRectangle(
-        [Description("The session id returned by open_presentation.")] string sessionId,
-        [Description("1-based index of the slide to add the rectangle to.")] int slideIndex,
-        float left, float top, float width, float height,
-        PresentationSessionRegistry registry)
-        => PowerPointToolsBase.ExecuteToolAction("add_rectangle", () =>
-        {
-            if (!registry.TryGet(sessionId, out var batch))
-                return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
-
-            return SerializeResult(Commands.AddRectangle(batch, slideIndex, left, top, width, height));
-        });
+    ShapeOperationResult AddRectangle(IPresentationBatch batch, int slideIndex, float left, float top, float width, float height);
+    // ...
 }
 ```
 
@@ -94,15 +95,19 @@ objects beyond what the PIA's NoPIA embedding already manages for you.
 returns an error result. See `critical-rules.instructions.md` Rule 1b for the full rationale and
 example.
 
-## Session Ownership (In-Process Registry, No Out-of-Process Service)
+## Session Ownership (Service-Backed Registry, Two Entry Points)
 
-Unlike `mcp-server-excel`'s `ExcelMcp.Service` + named-pipe `ServiceBridge`, PowerPointMcp's MVP
-uses an **in-process singleton** `PresentationSessionRegistry`
-(`ConcurrentDictionary<string sessionId, IPresentationBatch>`) registered as a DI singleton /
-`IHostedService` inside the MCP stdio host itself. There is no separate daemon process, no named
-pipe RPC — the STA thread + work queue already live inside `PresentationBatch`, and the MCP host
-is itself long-lived per client connection.
+`PowerPointMcp.Service`'s `PowerPointMcpService` owns a `PresentationSessionRegistry`
+(`ConcurrentDictionary<string sessionId, IPresentationBatch>`) and is the single dispatch point
+both entry points use — mirroring `mcp-server-excel`'s `ExcelMcp.Service` + `ServiceBridge`:
 
-Do not introduce an out-of-process Service without an explicit architecture decision — it's a
-deliberate Phase-2 item (crash isolation, multi-client sharing, survives MCP restart), not
-required for current functionality.
+- **MCP Server** hosts `PowerPointMcpService` **in-process** (no pipe): DI singleton, called
+  directly via `ServiceBridge.ForwardToService`. The stdio host is itself long-lived per client
+  connection, so no RPC layer is needed on this side.
+- **CLI** (`pptcli`) talks to a **separate background daemon process** hosting the same
+  `PowerPointMcpService`, over a named pipe (`ServiceClient`/`IPowerPointDaemonRpc`,
+  `StreamJsonRpc`), auto-started on first `session open`/`session create` and reused by every
+  subsequent `pptcli` invocation referencing the same session id.
+
+The two entry points run as **separate processes** with **separate PowerPoint instances** and do
+**not** share live sessions with each other — only the same `Core`/`Service` codebase.

--- a/.github/instructions/mcp-server-guide.instructions.md
+++ b/.github/instructions/mcp-server-guide.instructions.md
@@ -22,35 +22,53 @@ applyTo: "src/PowerPointMcp.McpServer/**/*.cs"
 human-read documentation — humans appreciate visual aids; LLM tool schemas do not need them and
 they cost tokens for no benefit.
 
-## Implementation Pattern: One Verb Per Tool
+## Two Kinds of Tools: Hand-Written vs. Generated
+
+Most of the MCP tool surface is **generated**, not hand-written. Before editing anything under
+`Tools/`, know which kind you're touching:
+
+- **Hand-written** (`PresentationTools.cs` only): `create_presentation`, `open_presentation`,
+  `save_presentation`, `close_presentation`, `list_sessions`, `apply_template`, `get_theme_name` —
+  session lifecycle and template application don't fit the per-session action-dispatch shape, so
+  they stay hand-written following the pattern below.
+- **Generated** (everything else — `slide`, `shape`, `textframe`, `table`, `notes`, `layout`,
+  `master`, `animation`, `image`, `chart`, `export`): one action-dispatch tool per
+  `[ServiceCategory]` Core domain, emitted by `PowerPointMcp.Generators.Mcp` from the Core
+  interface's `[ServiceCategory]`/`[McpTool]` attributes and XML doc comments. **Never hand-write a
+  new tool class for one of these domains** — add the operation to the Core interface (with XML
+  docs) and the generator picks it up. See `architecture-patterns.instructions.md`'s Command
+  Pattern section for the Core-side attribute shape.
+
+The rest of this guide (verb-per-tool pattern, manual `SerializeResult`, etc.) applies to the
+hand-written `PresentationTools.cs` tools only.
+
+## Implementation Pattern: One Verb Per Tool (Hand-Written Tools Only)
 
 ```csharp
 [McpServerToolType]
-public static class SlideTools
+public static class PresentationTools
 {
-    private static readonly SlideCommands Commands = new();
+    private static readonly PresentationCommands Commands = new();
 
-    [McpServerTool(Name = "add_slide")]
-    [Description("Add a new blank slide at the end of the presentation.")]
-    public static string AddSlide(
-        [Description("The session id returned by open_presentation.")] string sessionId,
-        PresentationSessionRegistry registry)
-        => PowerPointToolsBase.ExecuteToolAction("add_slide", () =>
+    [McpServerTool(Name = "create_presentation")]
+    [Description("Create a new, blank presentation and save it to disk.")]
+    public static string CreatePresentation(
+        [Description("Path to save the new presentation to.")] string filePath)
+        => PowerPointToolsBase.ExecuteToolAction("create_presentation", () =>
         {
-            if (!registry.TryGet(sessionId, out var batch))
-                return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
-
-            return SerializeResult(Commands.AddBlank(batch));
+            return SerializeResult(Commands.Create(filePath));
         });
 
-    private static string SerializeResult(SlideOperationResult result) => /* ... */;
+    private static string SerializeResult(PresentationOperationResult result) => /* ... */;
 }
 ```
 
-Every tool class follows this shape: a `private static readonly {Domain}Commands Commands = new();`
-field, one `[McpServerTool]` method per verb wrapped in `PowerPointToolsBase.ExecuteToolAction`,
-and a shared `SerializeResult` helper for the domain's `{Domain}OperationResult` shape. Keep new
-domain tool classes consistent with this pattern rather than inventing a new one.
+Every hand-written tool class follows this shape: a
+`private static readonly {Domain}Commands Commands = new();` field, one `[McpServerTool]` method
+per verb wrapped in `PowerPointToolsBase.ExecuteToolAction`, and a shared `SerializeResult` helper
+for the domain's `{Domain}OperationResult` shape. Keep new hand-written tools consistent with this
+pattern rather than inventing a new one — but remember: this only applies to
+`PresentationTools.cs`. A new Shape/Chart/etc. operation goes into Core, not here.
 
 ## Error Handling (MANDATORY)
 
@@ -86,12 +104,14 @@ at that single boundary, logging the HResult to stderr and serializing a structu
 `SerializeToolError`. Do not add a second try-catch inside an individual tool method — let
 `ExecuteToolAction` be the only catch-all.
 
-## Session Injection Pattern
+## Session Injection Pattern (Hand-Written Tools)
 
 `PresentationSessionRegistry registry` is a **plain parameter**, not a tool-facing argument — the
 MCP SDK (1.3.0+) resolves it from the DI container and correctly excludes it from the generated
-JSON schema (verified via `tools/list`). Every tool that needs to look up a session takes it as
-the last parameter, named exactly `registry`.
+JSON schema (verified via `tools/list`). Every hand-written tool that needs to look up a session
+takes it as the last parameter, named exactly `registry`. Generated action-dispatch tools instead
+take a DI-injected `PowerPointMcpService service` parameter, which the generator wires
+automatically — you never write this by hand.
 
 ## Result Serialization Pattern
 
@@ -116,12 +136,24 @@ configuration per tool class.
 
 ## Adding a New Tool
 
+**For a generated domain (Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation,
+Image, Chart, Export) — the common case:**
 1. Add the Core command + `{Domain}OperationResult` fields first (Core-first, tested with real
-   COM per `testing-strategy.instructions.md`).
-2. Add the `[McpServerTool(Name = "snake_case_name")]` method to the matching `Tools/*.cs` class,
-   following the pattern above.
-3. Verify the new tool appears correctly in `tools/list` (protocol test in
-   `tests/PowerPointMcp.McpServer.Tests`) with the expected parameter schema and no leaked
-   `registry` parameter.
+   COM per `testing-strategy.instructions.md`), with an XML doc `<summary>` — the generator uses
+   it as the operation's description.
+2. Nothing else to write by hand — `PowerPointMcp.Generators.Mcp` picks up the new interface
+   method automatically and adds it as a new `operation` value on that domain's action-dispatch
+   tool (e.g. `shape.add-oval`) the next time the project builds.
+3. Verify the new operation appears correctly in `tools/list`'s schema (protocol test in
+   `tests/PowerPointMcp.McpServer.Tests`) and that `PowerPointMcp.Generators.Cli` emitted the
+   matching `pptcli {category} {action}` command.
 4. Update `skills/shared/*.md` (and its copy under `skills/powerpoint-mcp/references/`) if the new
-   tool changes recommended workflows.
+   operation changes recommended workflows.
+
+**For a hand-written tool (`PresentationTools.cs` only) — rare, session-lifecycle/template work:**
+1. Add the Core command first, same as above.
+2. Add the `[McpServerTool(Name = "snake_case_name")]` method to `PresentationTools.cs`, following
+   the pattern above.
+3. Verify the new tool appears correctly in `tools/list` with the expected parameter schema and no
+   leaked `registry` parameter.
+4. Update `skills/shared/*.md` as above.

--- a/.github/instructions/testing-strategy.instructions.md
+++ b/.github/instructions/testing-strategy.instructions.md
@@ -59,7 +59,7 @@ public class ShapeCommandsTests
 ```
 
 `Feature` values match the Core domain folder name (`Presentation`, `Slide`, `Shape`, `TextFrame`,
-`Table`, `Notes`, `Layout`, `Image`, `Chart`, `Export`). This enables:
+`Table`, `Notes`, `Layout`, `Master`, `Animation`, `Image`, `Chart`, `Export`). This enables:
 
 ```powershell
 # Fast, targeted feedback for the domain you're changing


### PR DESCRIPTION
## Summary
.github/copilot-instructions.md and the three .github/instructions/*.md files still described the pre-migration architecture (before the Service + Generators work landed): CLI as a hand-written placeholder, no out-of-process Service, no source generators, 31 hand-written one-verb-per-tool MCP tools, and a Feature-trait list missing Master/Animation.

Verified the real current architecture directly against source (`src/PowerPointMcp.Service`, `src/PowerPointMcp.Generators.Mcp`/`.Cli`, Core `[ServiceCategory]`/`[McpTool]` attributes, `ServiceBridge.cs`, `ServiceClient`) rather than trusting the existing docs, and rewrote all four files to match:

- CLI and MCP Server are both first-class entry points sharing one `PowerPointMcp.Service` (in-process for MCP, named-pipe daemon for CLI) - not a placeholder.
- 11 of the 18 total MCP tools are generated per-domain action-dispatch tools (`shape`, `chart`, etc. with an `operation` param); only 7 session-lifecycle/template tools stay hand-written in `PresentationTools.cs`.
- `testing-strategy.instructions.md`'s Feature-trait list was missing `Master`/`Animation`.
- `mcp-server-guide.instructions.md` now clearly separates hand-written-tool guidance from generated-tool guidance so future work doesn't hand-write a tool class for a generator-owned domain.

Internal agent-instructions only, no user-facing/shipped-product change - labeled skip-changelog rather than adding a changeset.