### PR TITLE
docs(readme): add sister-project tip under hero section

### DIFF
--- a/.changeset/add-readme-hero-tip.md
+++ b/.changeset/add-readme-hero-tip.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": patch
+---
+
+Add a short "Also automating spreadsheets?" tip right after the README's hero section, linking to Excel MCP Server, mirroring the same repositioning done on the docs homepage.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ layout regressions that text-only automation simply cannot detect.
 - ⚠️ **PowerPoint Required** — Microsoft PowerPoint 2016 or later must be installed
 - ⚠️ **Desktop Environment** — controls a real PowerPoint process (not for server-side processing)
 
+> [!TIP]
+> **Also automating spreadsheets?** Check out [Excel MCP Server](https://excelmcpserver.dev/) —
+> the sister project, built the same way.
+
 ## 🎯 What You Can Do
 
 **18 MCP tools with ~98 operations across 12 domains:**


### PR DESCRIPTION
Adds a GitHub-alert style tip right after the README hero/technical-requirements block linking to Excel MCP Server, mirroring the tip repositioning already done on the docs homepage. Related Projects section is unchanged.