### PR TITLE
Add hyperlink management to Shape domain

### DIFF
--- a/.changeset/add-hyperlink-support.md
+++ b/.changeset/add-hyperlink-support.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": minor
+---
+
+Add hyperlink management to the Shape domain: `set-hyperlink`, `get-hyperlink`, and `remove-hyperlink` actions let callers attach, inspect, and clear mouse-click hyperlinks (with optional screen tip text) on any shape.

--- a/skills/powerpoint-mcp/SKILL.md
+++ b/skills/powerpoint-mcp/SKILL.md
@@ -97,7 +97,7 @@ saved.
 | Add/count/delete/duplicate/reorder slides | `slide(action: "add-blank"/"get-count"/"delete"/"duplicate"/"move-to")` |
 | Per-slide background color, sections | `slide(action: "set-background-color"/"get-background-color"/"add-section"/"rename-section"/"delete-section"/"get-section-count"/"get-section-name")` |
 | Add/count/delete/move/resize shapes | `shape(action: "add-rectangle"/"add-text-box"/"add-auto-shape"/"add-line"/"add-connector"/"get-count"/"delete"/"set-position"/"set-size")` |
-| Format shapes (fill/line/rotation/flip/z-order/shadow/group/name/alt-text) | `shape(action: "set-fill"/"get-fill"/"set-line"/"get-line"/"set-rotation"/"get-rotation"/"flip"/"set-z-order"/"set-shadow"/"get-shadow"/"group"/"ungroup"/"set-name"/"get-name"/"set-alt-text"/"get-alt-text")` |
+| Format shapes (fill/line/rotation/flip/z-order/shadow/group/name/alt-text/hyperlink) | `shape(action: "set-fill"/"get-fill"/"set-line"/"get-line"/"set-rotation"/"get-rotation"/"flip"/"set-z-order"/"set-shadow"/"get-shadow"/"group"/"ungroup"/"set-name"/"get-name"/"set-alt-text"/"get-alt-text"/"set-hyperlink"/"get-hyperlink"/"remove-hyperlink")` |
 | Set/read text and font formatting | `textframe(action: "set-text"/"get-text"/"set-font-size"/"set-bold"/"set-font-color"/"set-italic"/"set-underline"/"set-font-name"/"set-alignment"/"set-bullet")` |
 | Tables | `table(action: "add-table"/"set-cell-text"/"get-cell-text"/"insert-row"/"delete-row"/"insert-column"/"delete-column"/"set-cell-fill"/"get-cell-fill"/"set-cell-border"/"get-cell-border"/"merge-cells")` |
 | Native charts | `chart(action: "add-chart"/"get-chart-data"/"add-series"/"set-chart-title"/"get-chart-title"/"set-axis-title"/"get-axis-title"/"set-legend-visibility"/"get-legend-visibility")` |

--- a/skills/powerpoint-mcp/references/slides-and-shapes.md
+++ b/skills/powerpoint-mcp/references/slides-and-shapes.md
@@ -4,7 +4,7 @@ Reference for the `slide` tool (`add-blank`, `get-count`, `delete`, `duplicate`,
 `set-background-color`, `get-background-color`, section management) and the `shape` tool
 (`add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`,
 `delete`, `set-position`, `set-size`, plus the fill/line/rotation/flip/z-order/shadow/group/
-name/alt-text formatting actions below).
+name/alt-text/hyperlink formatting actions below).
 
 ## Slide Actions
 
@@ -79,6 +79,9 @@ All position/size values are **points** (see `deck-builder.md` for the 960×540p
 | `shape` | `get-name` | `session_id`, `slide_index`, `shape_index` | Returns the shape's current name. |
 | `shape` | `set-alt-text` | `session_id`, `slide_index`, `shape_index`, `alt_text` | Sets the shape's alternative text (accessibility description). Returns `altText`. |
 | `shape` | `get-alt-text` | `session_id`, `slide_index`, `shape_index` | Returns the shape's current alternative text. |
+| `shape` | `set-hyperlink` | `session_id`, `slide_index`, `shape_index`, `address`, `screen_tip` (optional) | Sets the shape's mouse-click hyperlink to `address` (URL or file path). `screen_tip` sets hover tooltip text. Returns `hasHyperlink`, `hyperlinkAddress`, `hyperlinkScreenTip`. |
+| `shape` | `get-hyperlink` | `session_id`, `slide_index`, `shape_index` | Returns `hasHyperlink` and, if present, `hyperlinkAddress`/`hyperlinkScreenTip`. |
+| `shape` | `remove-hyperlink` | `session_id`, `slide_index`, `shape_index` | Removes the shape's mouse-click hyperlink, if any (no-op if none is set). Returns `hasHyperlink: false`. |
 
 **Finding a just-grouped shape's index**: `group` does not return the new group shape's own
 `shapeIndex` — reading `.Index` off a freshly-created COM group object is unreliable in this
@@ -87,6 +90,28 @@ the slide (highest indices, nothing added after them), the resulting group occup
 smaller `shapeCount` as its index (since grouping N shapes always removes N-1 from the slide's
 shape list). Otherwise, call `shape(action: "get-count", ...)` before and after grouping and
 inspect via a follow-up read if you need to confirm which index now holds the group.
+
+### Hyperlinks
+
+`set-hyperlink`/`get-hyperlink`/`remove-hyperlink` manage a shape's **mouse-click** action —
+clicking the shape at presentation time navigates to `address` (an absolute URL like
+`"https://example.com"`, or a local file path). There is no separate mouse-hover hyperlink action,
+and no text-run-level hyperlink (a whole-shape hyperlink is the only granularity this tool
+surface exposes) — to make specific words within a text box clickable, put that text in its own
+shape.
+
+`address` is normalized by PowerPoint itself (e.g. `"https://example.com"` round-trips as
+`"https://example.com/"` with a trailing slash) — compare against the returned `hyperlinkAddress`
+rather than assuming an exact byte-for-byte match of what you passed in.
+
+```
+shape(action: "set-hyperlink", session_id: ..., slide_index: ..., shape_index: ...,
+  address: "https://example.com", screen_tip: "Visit our site")
+shape(action: "get-hyperlink", session_id: ..., slide_index: ..., shape_index: ...)
+  → hasHyperlink: true, hyperlinkAddress: "https://example.com/", hyperlinkScreenTip: "Visit our site"
+shape(action: "remove-hyperlink", session_id: ..., slide_index: ..., shape_index: ...)
+  → hasHyperlink: false
+```
 
 ### Dash Styles (`dash_style` for `set-line`)
 

--- a/skills/shared/slides-and-shapes.md
+++ b/skills/shared/slides-and-shapes.md
@@ -4,7 +4,7 @@ Reference for the `slide` tool (`add-blank`, `get-count`, `delete`, `duplicate`,
 `set-background-color`, `get-background-color`, section management) and the `shape` tool
 (`add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`,
 `delete`, `set-position`, `set-size`, plus the fill/line/rotation/flip/z-order/shadow/group/
-name/alt-text formatting actions below).
+name/alt-text/hyperlink formatting actions below).
 
 ## Slide Actions
 
@@ -79,6 +79,9 @@ All position/size values are **points** (see `deck-builder.md` for the 960×540p
 | `shape` | `get-name` | `session_id`, `slide_index`, `shape_index` | Returns the shape's current name. |
 | `shape` | `set-alt-text` | `session_id`, `slide_index`, `shape_index`, `alt_text` | Sets the shape's alternative text (accessibility description). Returns `altText`. |
 | `shape` | `get-alt-text` | `session_id`, `slide_index`, `shape_index` | Returns the shape's current alternative text. |
+| `shape` | `set-hyperlink` | `session_id`, `slide_index`, `shape_index`, `address`, `screen_tip` (optional) | Sets the shape's mouse-click hyperlink to `address` (URL or file path). `screen_tip` sets hover tooltip text. Returns `hasHyperlink`, `hyperlinkAddress`, `hyperlinkScreenTip`. |
+| `shape` | `get-hyperlink` | `session_id`, `slide_index`, `shape_index` | Returns `hasHyperlink` and, if present, `hyperlinkAddress`/`hyperlinkScreenTip`. |
+| `shape` | `remove-hyperlink` | `session_id`, `slide_index`, `shape_index` | Removes the shape's mouse-click hyperlink, if any (no-op if none is set). Returns `hasHyperlink: false`. |
 
 **Finding a just-grouped shape's index**: `group` does not return the new group shape's own
 `shapeIndex` — reading `.Index` off a freshly-created COM group object is unreliable in this
@@ -87,6 +90,28 @@ the slide (highest indices, nothing added after them), the resulting group occup
 smaller `shapeCount` as its index (since grouping N shapes always removes N-1 from the slide's
 shape list). Otherwise, call `shape(action: "get-count", ...)` before and after grouping and
 inspect via a follow-up read if you need to confirm which index now holds the group.
+
+### Hyperlinks
+
+`set-hyperlink`/`get-hyperlink`/`remove-hyperlink` manage a shape's **mouse-click** action —
+clicking the shape at presentation time navigates to `address` (an absolute URL like
+`"https://example.com"`, or a local file path). There is no separate mouse-hover hyperlink action,
+and no text-run-level hyperlink (a whole-shape hyperlink is the only granularity this tool
+surface exposes) — to make specific words within a text box clickable, put that text in its own
+shape.
+
+`address` is normalized by PowerPoint itself (e.g. `"https://example.com"` round-trips as
+`"https://example.com/"` with a trailing slash) — compare against the returned `hyperlinkAddress`
+rather than assuming an exact byte-for-byte match of what you passed in.
+
+```
+shape(action: "set-hyperlink", session_id: ..., slide_index: ..., shape_index: ...,
+  address: "https://example.com", screen_tip: "Visit our site")
+shape(action: "get-hyperlink", session_id: ..., slide_index: ..., shape_index: ...)
+  → hasHyperlink: true, hyperlinkAddress: "https://example.com/", hyperlinkScreenTip: "Visit our site"
+shape(action: "remove-hyperlink", session_id: ..., slide_index: ..., shape_index: ...)
+  → hasHyperlink: false
+```
 
 ### Dash Styles (`dash_style` for `set-line`)
 

--- a/src/PowerPointMcp.Core/Shape/IShapeCommands.cs
+++ b/src/PowerPointMcp.Core/Shape/IShapeCommands.cs
@@ -122,4 +122,22 @@ public interface IShapeCommands
 
     /// <summary>Gets a shape's alternative text (accessibility description).</summary>
     ShapeOperationResult GetAltText(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex);
+
+    /// <summary>
+    /// Sets a shape's mouse-click hyperlink to <paramref name="address"/> (a URL, e.g.
+    /// <c>"https://example.com"</c>, or a local file path). Optionally sets the hyperlink's
+    /// screen tip text shown on hover. Clicking the shape at presentation time navigates to
+    /// <paramref name="address"/>.
+    /// </summary>
+    ShapeOperationResult SetHyperlink(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex, string address, string? screenTip = null);
+
+    /// <summary>
+    /// Gets a shape's mouse-click hyperlink, if any. Returns <c>HasHyperlink = false</c> (with
+    /// null <c>HyperlinkAddress</c>/<c>HyperlinkScreenTip</c>) when the shape has no hyperlink
+    /// action assigned.
+    /// </summary>
+    ShapeOperationResult GetHyperlink(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex);
+
+    /// <summary>Removes a shape's mouse-click hyperlink, if any (idempotent — no-op if none is set).</summary>
+    ShapeOperationResult RemoveHyperlink(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex);
 }

--- a/src/PowerPointMcp.Core/Shape/ShapeCommands.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeCommands.cs
@@ -15,6 +15,13 @@ public sealed class ShapeCommands : IShapeCommands
     private const int MsoTrue = -1;
     private const int MsoFalse = 0;
 
+    // PowerPoint.PpActionSetting.ppMouseClick / Office.MsoPresentationTarget-related action
+    // constants — office.dll types, so used as raw ints per the project's dynamic-COM
+    // convention (see MsoShapeRectangle above). Verified live via ActionSettings(ppMouseClick).
+    private const int MsoMouseClick = 1; // PpActionSetting.ppMouseClick
+    private const int PpActionNone = 0; // PpActionType.ppActionNone
+    private const int PpActionHyperlink = 7; // PpActionType.ppActionHyperlink
+
     // MsoAutoShapeType member name -> value, for AddAutoShape. A curated subset of the full
     // enum covering the shapes authors most commonly need beyond a plain rectangle (arrows,
     // ovals, basic flowchart/callout shapes) — verified against the published MsoAutoShapeType
@@ -772,6 +779,100 @@ public sealed class ShapeCommands : IShapeCommands
             dynamic shape = slide.Shapes[shapeIndex];
 
             return new ShapeOperationResult { Success = true, ShapeIndex = shapeIndex, AltText = (string)shape.AlternativeText };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ShapeOperationResult SetHyperlink(IPresentationBatch batch, int slideIndex, int shapeIndex, string address, string? screenTip = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(address);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            // ActionSettings(ppMouseClick).Hyperlink.Address — verified live: setting Address
+            // automatically flips the action setting's Action to ppActionHyperlink; no separate
+            // "enable hyperlink" step is needed.
+            dynamic actionSetting = shape.ActionSettings[MsoMouseClick];
+            actionSetting.Hyperlink.Address = address;
+            if (screenTip is not null)
+            {
+                actionSetting.Hyperlink.ScreenTip = screenTip;
+            }
+
+            return new ShapeOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                HasHyperlink = true,
+                HyperlinkAddress = (string)actionSetting.Hyperlink.Address,
+                HyperlinkScreenTip = (string)actionSetting.Hyperlink.ScreenTip
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ShapeOperationResult GetHyperlink(IPresentationBatch batch, int slideIndex, int shapeIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            dynamic actionSetting = shape.ActionSettings[MsoMouseClick];
+            int action = (int)actionSetting.Action;
+            bool hasHyperlink = action == PpActionHyperlink;
+
+            return new ShapeOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                HasHyperlink = hasHyperlink,
+                HyperlinkAddress = hasHyperlink ? (string)actionSetting.Hyperlink.Address : null,
+                HyperlinkScreenTip = hasHyperlink ? (string)actionSetting.Hyperlink.ScreenTip : null
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ShapeOperationResult RemoveHyperlink(IPresentationBatch batch, int slideIndex, int shapeIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            dynamic actionSetting = shape.ActionSettings[MsoMouseClick];
+            actionSetting.Action = PpActionNone;
+
+            return new ShapeOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                HasHyperlink = false
+            };
         });
     }
 

--- a/src/PowerPointMcp.Core/Shape/ShapeOperationResult.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeOperationResult.cs
@@ -80,4 +80,13 @@ public sealed class ShapeOperationResult
 
     /// <summary>Shape alternative text (accessibility description), if applicable.</summary>
     public string? AltText { get; init; }
+
+    /// <summary>Whether the shape has a mouse-click hyperlink assigned, if applicable.</summary>
+    public bool? HasHyperlink { get; init; }
+
+    /// <summary>The shape's hyperlink target address (URL or file path), if applicable.</summary>
+    public string? HyperlinkAddress { get; init; }
+
+    /// <summary>The shape's hyperlink hover screen tip text, if applicable.</summary>
+    public string? HyperlinkScreenTip { get; init; }
 }

--- a/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
@@ -532,4 +532,82 @@ public class ShapeCommandsTests : IClassFixture<SharedPresentationFixture>
         Assert.False(result.Success);
         Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
+
+    [Fact]
+    public void SetHyperlink_AndGetHyperlink_RoundTripsAddress()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
+
+        var setResult = _commands.SetHyperlink(batch, 1, 1, "https://example.com");
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        Assert.True(setResult.HasHyperlink);
+        Assert.Equal("https://example.com/", setResult.HyperlinkAddress);
+
+        var getResult = _commands.GetHyperlink(batch, 1, 1);
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.True(getResult.HasHyperlink);
+        Assert.Equal("https://example.com/", getResult.HyperlinkAddress);
+    }
+
+    [Fact]
+    public void SetHyperlink_WithScreenTip_RoundTripsScreenTip()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
+
+        var setResult = _commands.SetHyperlink(batch, 1, 1, "https://example.com", screenTip: "Visit Example");
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        Assert.Equal("Visit Example", setResult.HyperlinkScreenTip);
+
+        var getResult = _commands.GetHyperlink(batch, 1, 1);
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.Equal("Visit Example", getResult.HyperlinkScreenTip);
+    }
+
+    [Fact]
+    public void GetHyperlink_OnShapeWithoutHyperlink_ReturnsHasHyperlinkFalse()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
+
+        var result = _commands.GetHyperlink(batch, 1, 1);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.False(result.HasHyperlink);
+        Assert.Null(result.HyperlinkAddress);
+    }
+
+    [Fact]
+    public void RemoveHyperlink_ClearsPreviouslySetHyperlink()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        _commands.AddRectangle(batch, 1, 0f, 0f, 50f, 50f);
+        _commands.SetHyperlink(batch, 1, 1, "https://example.com");
+
+        var removeResult = _commands.RemoveHyperlink(batch, 1, 1);
+        Assert.True(removeResult.Success, removeResult.ErrorMessage);
+        Assert.False(removeResult.HasHyperlink);
+
+        var getResult = _commands.GetHyperlink(batch, 1, 1);
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.False(getResult.HasHyperlink);
+        Assert.Null(getResult.HyperlinkAddress);
+    }
+
+    [Fact]
+    public void SetHyperlink_WithInvalidShapeIndex_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        var result = _commands.SetHyperlink(batch, 1, 99, "https://example.com");
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
 }


### PR DESCRIPTION
## Summary
Adds whole-shape hyperlink management to the Shape domain: three new actions on the existing `shape` MCP tool.

- `set-hyperlink` — set a shape's mouse-click hyperlink address, with optional screen tip text.
- `get-hyperlink` — read back whether a shape has a hyperlink, its address, and screen tip.
- `remove-hyperlink` — clear a shape's hyperlink.

Backed by PowerPoint's `Shape.ActionSettings[ppMouseClick].Hyperlink` COM API (verified live). Setting `.Address` auto-flips `.Action` to `ppActionHyperlink`; clearing sets `.Action = ppActionNone`, which also clears the address. Scope intentionally limited to whole-shape hyperlinks (not text-range/TextRange-level hyperlinks) per the backlog item.

Part of the ongoing feature-parity push (see SmartArt PR #15).

## Testing
- 6 new real-COM tests in `ShapeCommandsTests.cs` (round-trip address/screen-tip, no-hyperlink case, remove-after-set, invalid shape index).
- `dotnet test tests\PowerPointMcp.Core.Tests --filter "Feature=Shape"`: **40/40 passed**.
- Full solution build: 0 warnings, 0 errors.
- `McpServer.Tests`: 8/9 passed; the 1 failure (`chart.add-chart` COMException) is the known pre-existing chart flake under sustained COM load, unrelated to this change — confirmed passing in isolation previously.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
