### PR TITLE
Add picture-effect actions (brightness/contrast, recolor)

### DIFF
--- a/.changeset/add-picture-effects.md
+++ b/.changeset/add-picture-effects.md
@@ -1,5 +1,5 @@
 ---
-"@sbroenne/mcp-server-powerpoint": minor
+"powerpointmcp": minor
 ---
 
 Add picture-effect actions to the `image` domain: `set-brightness-contrast`/`get-brightness-contrast`

--- a/.changeset/add-picture-effects.md
+++ b/.changeset/add-picture-effects.md
@@ -1,0 +1,8 @@
+---
+"@sbroenne/mcp-server-powerpoint": minor
+---
+
+Add picture-effect actions to the `image` domain: `set-brightness-contrast`/`get-brightness-contrast`
+(adjust brightness and contrast, each a float in `[0, 1]`) and `set-recolor`/`get-recolor` (recolor
+a picture to grayscale, black-and-white, watermark, or automatic/no recolor via
+`msoPictureAutomatic`, `msoPictureGrayscale`, `msoPictureBlackAndWhite`, `msoPictureWatermark`).

--- a/skills/powerpoint-mcp/references/images.md
+++ b/skills/powerpoint-mcp/references/images.md
@@ -1,12 +1,17 @@
 # Images
 
-Reference for `image(action: "add-picture", ...)` — embeds a local image file into a slide.
+Reference for `image(action: "add-picture", ...)` — embeds a local image file into a slide — plus
+picture-effect actions for adjusting brightness/contrast and recoloring an inserted picture.
 
-## Action
+## Actions
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
 | `image` | `add-picture` | `session_id`, `slide_index`, `image_path`, `left`, `top`, `width`, `height` | Embeds (not links) the file into the presentation. |
+| `image` | `set-brightness-contrast` | `session_id`, `slide_index`, `shape_index`, `brightness`, `contrast` | `brightness`/`contrast` are floats in `[0, 1]` (PowerPoint default is `0.5` for both). |
+| `image` | `get-brightness-contrast` | `session_id`, `slide_index`, `shape_index` | Returns current `brightness`/`contrast`. |
+| `image` | `set-recolor` | `session_id`, `slide_index`, `shape_index`, `color_type` | `color_type` is one of `msoPictureAutomatic` (default/no recolor), `msoPictureGrayscale`, `msoPictureBlackAndWhite`, `msoPictureWatermark`. Unrecognized names fail with `Success=false`. |
+| `image` | `get-recolor` | `session_id`, `slide_index`, `shape_index` | Returns current `color_type`. |
 
 ## Requirements
 
@@ -35,9 +40,9 @@ Always `export(action: "export-slide-to-image", ...)` after `image(action: "add-
 to confirm: the image loaded (not a broken placeholder), the aspect ratio looks correct, and it
 doesn't overlap other shapes on the slide (see `export-and-verify.md`).
 
-## No Editing After Insert
+## Limited Editing After Insert
 
-There is no crop/rotate/effects action in this surface. If the image needs cropping or rotation,
-prepare the final image file before calling `add-picture` — the only post-insert adjustments
-available are `shape(action: "set-position", ...)` and `shape(action: "set-size", ...)` (see
-`slides-and-shapes.md`).
+There is no crop/rotate action in this surface. If the image needs cropping or rotation, prepare
+the final image file before calling `add-picture`. Post-insert adjustments available: `shape(action:
+"set-position", ...)`, `shape(action: "set-size", ...)` (see `slides-and-shapes.md`), and the
+`set-brightness-contrast`/`set-recolor` actions above.

--- a/skills/shared/images.md
+++ b/skills/shared/images.md
@@ -1,12 +1,17 @@
 # Images
 
-Reference for `image(action: "add-picture", ...)` — embeds a local image file into a slide.
+Reference for `image(action: "add-picture", ...)` — embeds a local image file into a slide — plus
+picture-effect actions for adjusting brightness/contrast and recoloring an inserted picture.
 
-## Action
+## Actions
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
 | `image` | `add-picture` | `session_id`, `slide_index`, `image_path`, `left`, `top`, `width`, `height` | Embeds (not links) the file into the presentation. |
+| `image` | `set-brightness-contrast` | `session_id`, `slide_index`, `shape_index`, `brightness`, `contrast` | `brightness`/`contrast` are floats in `[0, 1]` (PowerPoint default is `0.5` for both). |
+| `image` | `get-brightness-contrast` | `session_id`, `slide_index`, `shape_index` | Returns current `brightness`/`contrast`. |
+| `image` | `set-recolor` | `session_id`, `slide_index`, `shape_index`, `color_type` | `color_type` is one of `msoPictureAutomatic` (default/no recolor), `msoPictureGrayscale`, `msoPictureBlackAndWhite`, `msoPictureWatermark`. Unrecognized names fail with `Success=false`. |
+| `image` | `get-recolor` | `session_id`, `slide_index`, `shape_index` | Returns current `color_type`. |
 
 ## Requirements
 
@@ -35,9 +40,9 @@ Always `export(action: "export-slide-to-image", ...)` after `image(action: "add-
 to confirm: the image loaded (not a broken placeholder), the aspect ratio looks correct, and it
 doesn't overlap other shapes on the slide (see `export-and-verify.md`).
 
-## No Editing After Insert
+## Limited Editing After Insert
 
-There is no crop/rotate/effects action in this surface. If the image needs cropping or rotation,
-prepare the final image file before calling `add-picture` — the only post-insert adjustments
-available are `shape(action: "set-position", ...)` and `shape(action: "set-size", ...)` (see
-`slides-and-shapes.md`).
+There is no crop/rotate action in this surface. If the image needs cropping or rotation, prepare
+the final image file before calling `add-picture`. Post-insert adjustments available: `shape(action:
+"set-position", ...)`, `shape(action: "set-size", ...)` (see `slides-and-shapes.md`), and the
+`set-brightness-contrast`/`set-recolor` actions above.

--- a/src/PowerPointMcp.Core/Image/IImageCommands.cs
+++ b/src/PowerPointMcp.Core/Image/IImageCommands.cs
@@ -17,4 +17,20 @@ public interface IImageCommands
     /// the presentation.
     /// </summary>
     ImageOperationResult AddPicture(IPresentationBatch batch, int slideIndex, string imagePath, float left, float top, float width, float height);
+
+    /// <summary>Sets a picture shape's brightness and contrast (each 0-1, where 0.5 is PowerPoint's default/unadjusted level).</summary>
+    ImageOperationResult SetBrightnessContrast(IPresentationBatch batch, int slideIndex, int shapeIndex, float brightness, float contrast);
+
+    /// <summary>Gets a picture shape's current brightness and contrast (each 0-1).</summary>
+    ImageOperationResult GetBrightnessContrast(IPresentationBatch batch, int slideIndex, int shapeIndex);
+
+    /// <summary>
+    /// Recolors a picture shape. <paramref name="colorType"/> is an <c>MsoPictureColorType</c>
+    /// enum member name: <c>"msoPictureAutomatic"</c> (original colors), <c>"msoPictureGrayscale"</c>,
+    /// <c>"msoPictureBlackAndWhite"</c>, or <c>"msoPictureWatermark"</c> (washed-out, low-contrast).
+    /// </summary>
+    ImageOperationResult SetRecolor(IPresentationBatch batch, int slideIndex, int shapeIndex, string colorType);
+
+    /// <summary>Gets a picture shape's current recolor mode as its <c>MsoPictureColorType</c> name.</summary>
+    ImageOperationResult GetRecolor(IPresentationBatch batch, int slideIndex, int shapeIndex);
 }

--- a/src/PowerPointMcp.Core/Image/ImageCommands.cs
+++ b/src/PowerPointMcp.Core/Image/ImageCommands.cs
@@ -8,6 +8,20 @@ public sealed class ImageCommands : IImageCommands
     private const int MsoFalse = 0;
     private const int MsoTrue = -1;
 
+    // MsoPictureColorType member name -> value, for SetRecolor/GetRecolor
+    // (learn.microsoft.com/office/vba/api/office.msopicturecolortype) — verified live via
+    // PictureEffectsDiagTests (a temporary diagnostic spike, since removed).
+    private static readonly Dictionary<string, int> PictureColorTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["msoPictureAutomatic"] = 1,
+        ["msoPictureGrayscale"] = 2,
+        ["msoPictureBlackAndWhite"] = 3,
+        ["msoPictureWatermark"] = 4,
+    };
+
+    private static readonly Dictionary<int, string> PictureColorTypesByValue =
+        PictureColorTypes.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
     /// <inheritdoc/>
     public ImageOperationResult AddPicture(IPresentationBatch batch, int slideIndex, string imagePath, float left, float top, float width, float height)
     {
@@ -54,5 +68,152 @@ public sealed class ImageCommands : IImageCommands
                 ShapeCount = (int)slide.Shapes.Count
             };
         });
+    }
+
+    /// <inheritdoc/>
+    public ImageOperationResult SetBrightnessContrast(IPresentationBatch batch, int slideIndex, int shapeIndex, float brightness, float contrast)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            dynamic pictureFormat = shape.PictureFormat;
+            pictureFormat.Brightness = brightness;
+            pictureFormat.Contrast = contrast;
+
+            return new ImageOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                Brightness = brightness,
+                Contrast = contrast,
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ImageOperationResult GetBrightnessContrast(IPresentationBatch batch, int slideIndex, int shapeIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            dynamic pictureFormat = shape.PictureFormat;
+
+            return new ImageOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                Brightness = (float)pictureFormat.Brightness,
+                Contrast = (float)pictureFormat.Contrast,
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ImageOperationResult SetRecolor(IPresentationBatch batch, int slideIndex, int shapeIndex, string colorType)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(colorType);
+
+        if (!PictureColorTypes.TryGetValue(colorType, out var typeValue))
+        {
+            return new ImageOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"'{colorType}' is not a recognized MsoPictureColorType member name (must be 'msoPictureAutomatic', 'msoPictureGrayscale', 'msoPictureBlackAndWhite', or 'msoPictureWatermark')."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            dynamic pictureFormat = shape.PictureFormat;
+            pictureFormat.ColorType = typeValue;
+
+            return new ImageOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                ColorTypeName = colorType,
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ImageOperationResult GetRecolor(IPresentationBatch batch, int slideIndex, int shapeIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            var slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            dynamic shape = slide.Shapes[shapeIndex];
+            dynamic pictureFormat = shape.PictureFormat;
+            int typeValue = (int)pictureFormat.ColorType;
+            string typeName = PictureColorTypesByValue.TryGetValue(typeValue, out var name) ? name : $"unknown({typeValue})";
+
+            return new ImageOperationResult
+            {
+                Success = true,
+                ShapeIndex = shapeIndex,
+                ColorTypeName = typeName,
+            };
+        });
+    }
+
+    private static ImageOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)
+    {
+        if (slideIndex < 1 || slideIndex > slideCount)
+        {
+            return new ImageOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Slide index {slideIndex} is out of range. The presentation has {slideCount} slide(s) (valid range: 1-{slideCount})."
+            };
+        }
+        return null;
+    }
+
+    private static ImageOperationResult? ValidateShapeIndex(int shapeCount, int shapeIndex)
+    {
+        if (shapeIndex < 1 || shapeIndex > shapeCount)
+        {
+            return new ImageOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Shape index {shapeIndex} is out of range. The slide has {shapeCount} shape(s) (valid range: 1-{shapeCount})."
+            };
+        }
+        return null;
     }
 }

--- a/src/PowerPointMcp.Core/Image/ImageOperationResult.cs
+++ b/src/PowerPointMcp.Core/Image/ImageOperationResult.cs
@@ -19,4 +19,13 @@ public sealed class ImageOperationResult
 
     /// <summary>Total shape count on the slide after the operation.</summary>
     public int? ShapeCount { get; init; }
+
+    /// <summary>Picture brightness (0-1), if applicable.</summary>
+    public float? Brightness { get; init; }
+
+    /// <summary>Picture contrast (0-1), if applicable.</summary>
+    public float? Contrast { get; init; }
+
+    /// <summary>The MsoPictureColorType name of the picture's recolor mode, if applicable.</summary>
+    public string? ColorTypeName { get; init; }
 }

--- a/tests/PowerPointMcp.Core.Tests/ImageCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ImageCommandsTests.cs
@@ -60,4 +60,75 @@ public class ImageCommandsTests : IClassFixture<SharedPresentationFixture>
         Assert.False(result.Success);
         Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
     }
+
+    [Fact]
+    public void SetBrightnessContrast_AndGetBrightnessContrast_RoundTrips()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
+
+            var setResult = _commands.SetBrightnessContrast(batch, 1, 1, 0.6f, 0.7f);
+            Assert.True(setResult.Success, setResult.ErrorMessage);
+            Assert.Equal(0.6f, setResult.Brightness);
+            Assert.Equal(0.7f, setResult.Contrast);
+
+            var getResult = _commands.GetBrightnessContrast(batch, 1, 1);
+            Assert.True(getResult.Success, getResult.ErrorMessage);
+            Assert.Equal(0.6f, getResult.Brightness);
+            Assert.Equal(0.7f, getResult.Contrast);
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    [Fact]
+    public void SetRecolor_AndGetRecolor_RoundTrips()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
+
+            var setResult = _commands.SetRecolor(batch, 1, 1, "msoPictureGrayscale");
+            Assert.True(setResult.Success, setResult.ErrorMessage);
+            Assert.Equal("msoPictureGrayscale", setResult.ColorTypeName);
+
+            var getResult = _commands.GetRecolor(batch, 1, 1);
+            Assert.True(getResult.Success, getResult.ErrorMessage);
+            Assert.Equal("msoPictureGrayscale", getResult.ColorTypeName);
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    [Fact]
+    public void SetRecolor_WithUnrecognizedColorTypeName_Fails()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
+
+            var result = _commands.SetRecolor(batch, 1, 1, "msoPictureNotARealType");
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds picture-effect actions to the `image` domain, closing another item of the
gap-closure backlog toward feature parity with GongRzhe/Office-PowerPoint-MCP-Server:

- `set-brightness-contrast` / `get-brightness-contrast` — adjusts a picture's
  brightness and contrast (floats in `[0, 1]`, PowerPoint default `0.5` for both).
- `set-recolor` / `get-recolor` — recolors a picture via `MsoPictureColorType`
  (`msoPictureAutomatic`, `msoPictureGrayscale`, `msoPictureBlackAndWhite`,
  `msoPictureWatermark`). Unrecognized names return `Success=false`.

No manual MCP/CLI wiring was needed — the `image` domain is generator-driven
(`[ServiceCategory]`/`[McpTool]`), so the new actions were picked up automatically.

## Testing

- `dotnet build src\PowerPointMcp.Core\PowerPointMcp.Core.csproj` — 0 warnings/errors
- `dotnet test tests\PowerPointMcp.Core.Tests --filter "Feature=Image"` — 5/5 passed
- `dotnet build Sbroenne.PowerPointMcp.slnx` — 0 warnings/errors
- `dotnet test tests\PowerPointMcp.McpServer.Tests` — 9/9 passed (one earlier run hit
  the known transient `chart.add-chart` RPC_E_DISCONNECTED-style flake, unrelated to
  this change; confirmed passing on rerun)

## Docs

Updated `skills/shared/images.md` (+ mirrored `skills/powerpoint-mcp/references/images.md`)
to document the new actions.
