### PR TITLE
ci: auto-merge the post-release changelog PR

### DIFF
--- a/.changeset/auto-merge-changelog-pr.md
+++ b/.changeset/auto-merge-changelog-pr.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": patch
+---
+
+**Release automation: auto-merge the changelog PR.** The post-release step that opens the `chore/changelog-vX` PR now also merges it (queued auto-merge, falling back to an immediate squash merge). Previously the PR was only created and left open until a maintainer merged it by hand, which could leave releases with a stale/missing CHANGELOG on `main`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -772,6 +772,16 @@ jobs:
           --title "chore: update CHANGELOG.md for v${VERSION} release" \
           --body "Automated post-release changelog update: compiles pending .changeset/*.md fragments into a new \`## [$VERSION]\` entry in CHANGELOG.md via \`scripts/Build-Changelog.ps1\`." \
           --label "documentation"
+
+        # Merge the changelog PR automatically. Previously this PR was only
+        # *created*, never merged, so it would sit open until a maintainer
+        # merged it by hand -- letting releases pile up with a stale/missing
+        # CHANGELOG on main. Prefer queued auto-merge (requires "Allow
+        # auto-merge" in repo settings); fall back to an immediate merge when
+        # auto-merge is disabled. The commit above uses [skip ci] so there are
+        # no required checks blocking the merge.
+        gh pr merge "$BRANCH" --squash --delete-branch --auto \
+          || gh pr merge "$BRANCH" --squash --delete-branch
       # Intentionally NOT continue-on-error: a silently swallowed failure here
       # (e.g. Actions lacking permission to create PRs) would leave a release
       # missing its changelog commit-back PR. Let this step fail loudly so it


### PR DESCRIPTION
The release workflow only *created* the `chore/changelog-vX` PR and left it open, requiring a manual merge every release (and risking a stale CHANGELOG on `main`). This adds a merge step right after `gh pr create` -- queued auto-merge with an immediate-merge fallback.

Mirrors the same fix just applied to the Excel MCP server. Includes a changeset.

Note: `Allow auto-merge` should be enabled in this repo's settings for the `--auto` path; the fallback immediate-merge covers the case where it isn't.