### PR TITLE
Fix release workflow: VS Code extension version bump failure

### DIFF
--- a/.changeset/fix-release-vsix-version-flag.md
+++ b/.changeset/fix-release-vsix-version-flag.md
@@ -1,0 +1,8 @@
+---
+"powerpointmcp": patch
+---
+
+Fix the release workflow's "Update Extension Version" step failing with "Version not changed"
+whenever the release version coincidentally matches the VS Code extension's fixed baseline
+version (0.1.0, never committed back to the repo since the bump is ephemeral per-run). Adds
+`--allow-same-version` to the `npm version` call.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,10 @@ jobs:
       run: |
         $version = $env:VERSION
         cd vscode-extension
-        npm version "$version" --no-git-tag-version
+        # --allow-same-version: this ephemeral bump is never committed back to the repo (the
+        # extension's package.json baseline stays fixed), so a future release version can
+        # coincidentally match it — npm version would otherwise fail with "Version not changed".
+        npm version "$version" --no-git-tag-version --allow-same-version
       shell: pwsh
 
     - name: Sync Extension Changelog


### PR DESCRIPTION
Adds \--allow-same-version\ to the VS Code extension's \
pm version\ step in the release workflow.

## Root cause
\scode-extension/package.json\'s version has been hardcoded at \