### PR TITLE
Expand image operations and enforce PIA interop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -148,6 +148,17 @@ a backstop in `Main`'s `finally`. Never let a PowerPoint process leak past MCP h
 surface, matching PowerPoint's native COM object model (`Slides(1)` is the first slide). Do not
 introduce 0-based indexing anywhere in Core, the MCP tools, or tests.
 
+## PIA-First COM Access (CRITICAL)
+
+All PowerPoint COM operations must use strongly typed members from the embedded
+`Microsoft.Office.Interop.PowerPoint` PIA whenever the restored PIA exposes the required API.
+Use typed Office/PowerPoint enums instead of raw integer constants.
+
+Only use `dynamic`, reflection, raw dispatch, or numeric COM enum values after confirming from the
+restored interop metadata that no typed PIA member/type exists. Keep such exceptions narrowly
+scoped, document the missing PIA surface in code, and cover the behavior with a real-COM
+integration test. Convenience is never a reason to bypass the PIA.
+
 ## Rule 1 / 1b — Success/ErrorMessage Invariant (CRITICAL)
 
 Core commands return `{Domain}OperationResult` with `Success`/`ErrorMessage`:

--- a/.github/instructions/architecture-patterns.instructions.md
+++ b/.github/instructions/architecture-patterns.instructions.md
@@ -89,6 +89,22 @@ the `PresentationBatch`'s dedicated STA thread — never access
 COM references in a `finally` block if the Core command holds intermediate `dynamic`/typed COM
 objects beyond what the PIA's NoPIA embedding already manages for you.
 
+### PIA-First Interop (MANDATORY)
+
+Use strongly typed `Microsoft.Office.Interop.PowerPoint` PIA objects, properties, methods, and
+enums throughout ComInterop and Core. Do not use `dynamic`, reflection, raw `IDispatch`, or integer
+enum constants when the restored PIA exposes a typed equivalent.
+
+Late binding is an exception, not a compatibility default. Before using it:
+
+1. Inspect the restored interop assembly metadata and confirm the required member/type is absent.
+2. Keep the late-bound call as narrow as possible inside the STA `batch.Execute` callback.
+3. Add a concise comment naming the missing PIA surface and why late binding is required.
+4. Prove the behavior with a real-PowerPoint COM integration test.
+
+If a typed Office enum is unavailable because only the PowerPoint PIA is embedded, prefer adding
+the appropriate PIA/reference support over replacing the enum with an unexplained integer.
+
 ## Exception Propagation Pattern (CRITICAL)
 
 **Core Commands: let exceptions propagate naturally** — do not suppress with a catch block that

--- a/.github/instructions/critical-rules.instructions.md
+++ b/.github/instructions/critical-rules.instructions.md
@@ -73,6 +73,21 @@ surface, and tests — matching PowerPoint's native COM object model. Never intr
 indexing in new code; a 0 or negative index is an expected validation failure
 (`Success=false`), not something to special-case as valid.
 
+## Rule: PIA-First COM Access
+
+**Always use strongly typed members from the embedded `Microsoft.Office.Interop.PowerPoint` PIA
+for PowerPoint COM access.** Use the corresponding typed Office/PowerPoint enum instead of raw
+integer constants whenever the referenced PIA exposes it.
+
+`dynamic`, reflection, raw dispatch, or numeric COM enum values are allowed only when the actual
+restored PIA does not expose the required member or type. Every exception must:
+
+1. Be confirmed against the restored interop metadata, not assumed from a web example.
+2. Include a concise code comment explaining the missing PIA surface.
+3. Have real-COM test coverage for the late-bound behavior.
+
+Convenience or shorter syntax is never sufficient justification for bypassing the PIA.
+
 ## Rule: Session Lifecycle Discipline
 
 - Every session (`PresentationSessionRegistry` entry) MUST be reachable from
@@ -100,6 +115,7 @@ Never commit, push, or merge without explicit user approval. No background or si
 | Success flag | NEVER `Success=true` with `ErrorMessage` | Confuses callers, silent failures |
 | No exception wrapping | Never catch-and-return-error inside Core | Preserves stack context, avoids double-wrapping |
 | 1-based indexing | Never introduce 0-based indices | Matches COM object model, avoids silent bugs |
+| PIA-first COM | Use typed PIA members/enums; late-bind only when the restored PIA lacks the API | Preserves compile-time safety and discoverability |
 
 **When Writing Code:**
 | Rule | Action | Why Critical |

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -119,18 +119,35 @@ of one flat tool per verb.
 
 Available command groups (in addition to `session` and `service`):
 
-`chart`, `image`, `layout`, `notes`, `presentation`, `shape`, `slide`, `table`, `textframe`
+`animation`, `chart`, `export`, `image`, `layout`, `master`, `notes`, `presentation`, `shape`, `slide`, `smartart`, `table`, `textframe`
 
 Run `pptcli <command> --help` for the live, authoritative list of actions and flags for that
 command — the table below is a summary generated from the same Core interfaces as the MCP tool
-surface, so it can lag a `--help` run for in-flight changes. See
-[`references/cli-commands.md`](./references/cli-commands.md) for the full command reference
-(all domains, actions, and parameters in one document).
+surface, so it can lag a `--help` run for in-flight changes.
+
+
+### `animation` — Animation commands: add/delete entrance, emphasis, and exit effects on a shape's slide timeline (Slide.TimeLine.MainSequence), and read/set a slide's transition (Slide.SlideShowTransition). Operates within an already-open , targeting a specific slide (and, for shape effects, a specific shape) by 1-based index.
+
+Actions: `add-effect`, `get-effect-count`, `delete-effect`, `get-transition`, `set-transition`
+
+| Flag | Description |
+|------|-------------|
+| `--slide-index` | (required) |
+| `--shape-index` | (required for: add-effect) |
+| `--effect-name` | (required for: add-effect) |
+| `--is-exit` | When true, the effect is applied as the shape leaving the slide (exit) rather than the     default entrance/emphasis behavior. |
+| `--trigger` | When the effect starts: "on-click" (default), "with-previous", or     "after-previous". |
+| `--effect-index` | (required for: delete-effect) |
+| `--transition-name` | (required for: set-transition) |
+| `--duration-seconds` |  |
+| `--advance-on-click` |  |
+| `--advance-on-time` |  |
+| `--advance-time-seconds` |  |
 
 
 ### `chart` — Chart lifecycle and data operations.
 
-Actions: `add-chart`, `get-chart-data`
+Actions: `add-chart`, `get-chart-data`, `add-series`, `set-chart-title`, `get-chart-title`, `set-axis-title`, `get-axis-title`, `set-legend-visibility`, `get-legend-visibility`, `replace-chart-data`
 
 | Flag | Description |
 |------|-------------|
@@ -140,24 +157,51 @@ Actions: `add-chart`, `get-chart-data`
 | `--top` | Top position in points. (required for: add-chart) |
 | `--width` | Width in points. (required for: add-chart) |
 | `--height` | Height in points. (required for: add-chart) |
-| `--categories` | Category labels (x-axis / pie slice labels). (required for: add-chart) |
-| `--series-name` | Name of the single data series. (required for: add-chart) |
-| `--values` | Data values, one per category. (required for: add-chart) |
-| `--shape-index` | (required for: get-chart-data) |
+| `--categories` | Category labels (x-axis / pie slice labels). (required for: add-chart, replace-chart-data) |
+| `--series-name` | Name of the single data series. (required for: add-chart, add-series) |
+| `--values` | Data values, one per category. (required for: add-chart, add-series) |
+| `--shape-index` | (required for: get-chart-data, add-series, set-chart-title, get-chart-title, set-axis-title, get-axis-title, set-legend-visibility, get-legend-visibility, replace-chart-data) |
+| `--title` | (required for: set-chart-title, set-axis-title) |
+| `--axis-type` | (required for: set-axis-title, get-axis-title) |
+| `--visible` | (required for: set-legend-visibility) |
+| `--series-names` | (required for: replace-chart-data) |
+| `--series-values` | (required for: replace-chart-data) |
+
+
+### `export` — Export commands: render presentation slides to raster image files. Operates within an already-open .
+
+Actions: `export-slide-to-image`, `export-all-slides-to-images`
+
+| Flag | Description |
+|------|-------------|
+| `--slide-index` | 1-based index of the slide to export. (required for: export-slide-to-image) |
+| `--output-path` | Full path for the output image file (e.g. C:\output\slide1.png). (required for: export-slide-to-image) |
+| `--format` | PowerPoint filter name for the image format (e.g. "PNG", "JPG", "GIF").     Defaults to "PNG". |
+| `--width` | Optional output width in pixels; 0 or null uses PowerPoint's default. |
+| `--height` | Optional output height in pixels; 0 or null uses PowerPoint's default. |
+| `--output-directory` | Directory where slide images will be written. Created if it does not exist.     PowerPoint names the output files Slide1.{ext}, Slide2.{ext}, etc. (required for: export-all-slides-to-images) |
 
 
 ### `image` — Image commands: embed a picture file into a slide. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
 
-Actions: `add-picture`
+Actions: `add-picture`, `set-brightness-contrast`, `get-brightness-contrast`, `set-recolor`, `get-recolor`, `set-crop`, `get-crop`
 
 | Flag | Description |
 |------|-------------|
 | `--slide-index` | (required) |
-| `--image-path` | (required) |
-| `--left` | (required) |
-| `--top` | (required) |
-| `--width` | (required) |
-| `--height` | (required) |
+| `--image-path` | (required for: add-picture) |
+| `--left` | (required for: add-picture) |
+| `--top` | (required for: add-picture) |
+| `--width` | (required for: add-picture) |
+| `--height` | (required for: add-picture) |
+| `--shape-index` | (required for: set-brightness-contrast, get-brightness-contrast, set-recolor, get-recolor, set-crop, get-crop) |
+| `--brightness` | (required for: set-brightness-contrast) |
+| `--contrast` | (required for: set-brightness-contrast) |
+| `--color-type` | (required for: set-recolor) |
+| `--crop-left` | (required for: set-crop) |
+| `--crop-top` | (required for: set-crop) |
+| `--crop-right` | (required for: set-crop) |
+| `--crop-bottom` | (required for: set-crop) |
 
 
 ### `layout` — Slide layout commands: apply/read a slide's built-in layout. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
@@ -168,6 +212,28 @@ Actions: `set-layout`, `get-layout`
 |------|-------------|
 | `--slide-index` | (required) |
 | `--layout-name` | (required for: set-layout) |
+
+
+### `master` — Slide master commands: read/edit the title and body placeholder fonts on the presentation's slide master, and read/edit the slide master's background fill color. Operates within an already-open . Changes here apply to every slide that inherits from the master (i.e. any slide that does not itself override the property), which is the practical "edit the master, not each slide" workflow PowerPoint's COM object model supports safely.
+
+Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `get-background-color`, `set-background-color`, `set-gradient-background`, `get-gradient-background`
+
+| Flag | Description |
+|------|-------------|
+| `--font-name` |  |
+| `--font-size` |  |
+| `--bold` |  |
+| `--red` | (required for: set-background-color) |
+| `--green` | (required for: set-background-color) |
+| `--blue` | (required for: set-background-color) |
+| `--red1` | (required for: set-gradient-background) |
+| `--green1` | (required for: set-gradient-background) |
+| `--blue1` | (required for: set-gradient-background) |
+| `--red2` | (required for: set-gradient-background) |
+| `--green2` | (required for: set-gradient-background) |
+| `--blue2` | (required for: set-gradient-background) |
+| `--gradient-style` |  |
+| `--gradient-variant` |  |
 
 
 ### `notes` — Speaker notes commands: set/get the notes text for a slide. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
@@ -182,42 +248,106 @@ Actions: `set-notes-text`, `get-notes-text`
 
 ### `presentation` — Presentation lifecycle commands: create, close, save.
 
-Actions: `create`, `open`, `save`, `apply-template`, `get-theme-name`
+Actions: `create`, `open`, `save`, `apply-template`, `get-theme-name`, `set-document-property`, `get-document-property`, `set-custom-property`, `get-custom-property`, `remove-custom-property`
 
 | Flag | Description |
 |------|-------------|
 | `--file-path` | (required for: create, open) |
 | `--is-macro-enabled` |  |
 | `--template-path` | Full path to a .potx/.potm/.pot template file (a .pptx/.pptm presentation may also be used as a template source, matching PowerPoint's own behavior). (required for: apply-template) |
+| `--property-name` | One of the supported built-in property names (case-insensitive). (required for: set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property) |
+| `--value` | The new value for the property. (required for: set-document-property, set-custom-property) |
 
 
 ### `shape` — Shape commands: add rectangles/text boxes, count, delete, reposition/resize. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
 
-Actions: `add-rectangle`, `add-text-box`, `get-count`, `delete`, `set-position`, `set-size`
+Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`, `delete`, `set-position`, `set-size`, `set-fill`, `get-fill`, `set-line`, `get-line`, `set-rotation`, `get-rotation`, `flip`, `set-z-order`, `set-shadow`, `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`, `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`, `set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`
 
 | Flag | Description |
 |------|-------------|
 | `--slide-index` | (required) |
-| `--left` | (required for: add-rectangle, add-text-box, set-position) |
-| `--top` | (required for: add-rectangle, add-text-box, set-position) |
-| `--width` | (required for: add-rectangle, add-text-box, set-size) |
-| `--height` | (required for: add-rectangle, add-text-box, set-size) |
+| `--left` | (required for: add-rectangle, add-text-box, add-auto-shape, set-position) |
+| `--top` | (required for: add-rectangle, add-text-box, add-auto-shape, set-position) |
+| `--width` | (required for: add-rectangle, add-text-box, add-auto-shape, set-size) |
+| `--height` | (required for: add-rectangle, add-text-box, add-auto-shape, set-size) |
 | `--text` | (required for: add-text-box) |
-| `--shape-index` | (required for: delete, set-position, set-size) |
+| `--shape-type` | (required for: add-auto-shape) |
+| `--begin-x` | (required for: add-line, add-connector) |
+| `--begin-y` | (required for: add-line, add-connector) |
+| `--end-x` | (required for: add-line, add-connector) |
+| `--end-y` | (required for: add-line, add-connector) |
+| `--connector-type` | (required for: add-connector) |
+| `--shape-index` | (required for: delete, set-position, set-size, set-fill, get-fill, set-line, get-line, set-rotation, get-rotation, flip, set-z-order, set-shadow, get-shadow, set-glow, get-glow, set-reflection, get-reflection, set-soft-edge, get-soft-edge, set-bevel, get-bevel, ungroup, set-name, get-name, set-alt-text, get-alt-text, set-hyperlink, get-hyperlink, remove-hyperlink) |
+| `--red` | (required for: set-fill, set-glow) |
+| `--green` | (required for: set-fill, set-glow) |
+| `--blue` | (required for: set-fill, set-glow) |
+| `--weight` |  |
+| `--dash-style` |  |
+| `--visible` | (required for: set-shadow, set-reflection) |
+| `--degrees` | (required for: set-rotation) |
+| `--direction` | (required for: flip) |
+| `--z-order-command` | (required for: set-z-order) |
+| `--transparency` |  |
+| `--blur` |  |
+| `--offset-x` |  |
+| `--offset-y` |  |
+| `--radius` | (required for: set-glow, set-soft-edge) |
+| `--size` |  |
+| `--bevel-type` | (required for: set-bevel) |
+| `--depth` |  |
+| `--inset` |  |
+| `--shape-indexes` | (required for: group) |
+| `--name` | (required for: set-name) |
+| `--alt-text` | (required for: set-alt-text) |
+| `--address` | (required for: set-hyperlink) |
+| `--screen-tip` |  |
 
 
-### `slide` — Slide lifecycle commands: add, delete, count. First domain built on top of the presentation lifecycle commands, operating within an already-open IPresentationBatch.
+### `slide` — Slide lifecycle commands: add, delete, count, duplicate, reorder, per-slide background color, and section management. First domain built on top of the presentation lifecycle commands, operating within an already-open IPresentationBatch.
 
-Actions: `add-blank`, `get-count`, `delete`
+Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-background-color`, `get-background-color`, `set-gradient-background`, `get-gradient-background`, `add-section`, `rename-section`, `delete-section`, `get-section-count`, `get-section-name`
 
 | Flag | Description |
 |------|-------------|
-| `--slide-index` | (required for: delete) |
+| `--slide-index` | (required for: delete, duplicate, move-to, set-background-color, get-background-color, set-gradient-background, get-gradient-background) |
+| `--to-position` | (required for: move-to) |
+| `--red` | (required for: set-background-color) |
+| `--green` | (required for: set-background-color) |
+| `--blue` | (required for: set-background-color) |
+| `--red1` | (required for: set-gradient-background) |
+| `--green1` | (required for: set-gradient-background) |
+| `--blue1` | (required for: set-gradient-background) |
+| `--red2` | (required for: set-gradient-background) |
+| `--green2` | (required for: set-gradient-background) |
+| `--blue2` | (required for: set-gradient-background) |
+| `--gradient-style` |  |
+| `--gradient-variant` |  |
+| `--section-index` | (required for: add-section, rename-section, delete-section, get-section-name) |
+| `--section-name` | (required for: rename-section) |
+| `--delete-slides` |  |
 
 
-### `table` — Table commands: add a table shape and read/write cell text. Operates within an already-open IPresentationBatch, targeting a specific slide and table shape by their 1-based indices.
+### `smartart` — SmartArt commands: add a SmartArt diagram to a slide from PowerPoint's built-in layout gallery, and add/read/update/delete/count the diagram's nodes. Operates within an already-open , targeting a specific slide and shape by 1-based index.
 
-Actions: `add-table`, `set-cell-text`, `get-cell-text`
+Actions: `add-smart-art`, `add-node`, `add-child-node`, `set-node-text`, `get-node-text`, `delete-node`, `get-node-count`
+
+| Flag | Description |
+|------|-------------|
+| `--slide-index` | (required) |
+| `--layout-name` | (required for: add-smart-art) |
+| `--left` | (required for: add-smart-art) |
+| `--top` | (required for: add-smart-art) |
+| `--width` | (required for: add-smart-art) |
+| `--height` | (required for: add-smart-art) |
+| `--shape-index` | (required for: add-node, add-child-node, set-node-text, get-node-text, delete-node, get-node-count) |
+| `--text` | (required for: add-node, add-child-node, set-node-text) |
+| `--parent-node-index` | (required for: add-child-node) |
+| `--node-index` | (required for: set-node-text, get-node-text, delete-node) |
+
+
+### `table` — Table commands: add a table shape, read/write cell text, insert/delete rows and columns, format cell fill and borders, and merge cells. Operates within an already-open IPresentationBatch, targeting a specific slide and table shape by their 1-based indices.
+
+Actions: `add-table`, `set-cell-text`, `get-cell-text`, `insert-row`, `delete-row`, `insert-column`, `delete-column`, `set-cell-fill`, `get-cell-fill`, `set-cell-border`, `get-cell-border`, `merge-cells`
 
 | Flag | Description |
 |------|-------------|
@@ -228,15 +358,26 @@ Actions: `add-table`, `set-cell-text`, `get-cell-text`
 | `--top` | (required for: add-table) |
 | `--width` | (required for: add-table) |
 | `--height` | (required for: add-table) |
-| `--shape-index` | (required for: set-cell-text, get-cell-text) |
-| `--row` | (required for: set-cell-text, get-cell-text) |
-| `--column` | (required for: set-cell-text, get-cell-text) |
+| `--shape-index` | (required for: set-cell-text, get-cell-text, insert-row, delete-row, insert-column, delete-column, set-cell-fill, get-cell-fill, set-cell-border, get-cell-border, merge-cells) |
+| `--row` | (required for: set-cell-text, get-cell-text, delete-row, set-cell-fill, get-cell-fill, set-cell-border, get-cell-border, merge-cells) |
+| `--column` | (required for: set-cell-text, get-cell-text, delete-column, set-cell-fill, get-cell-fill, set-cell-border, get-cell-border, merge-cells) |
 | `--text` | (required for: set-cell-text) |
+| `--before-row` |  |
+| `--before-column` |  |
+| `--red` | (required for: set-cell-fill) |
+| `--green` | (required for: set-cell-fill) |
+| `--blue` | (required for: set-cell-fill) |
+| `--border-type` | (required for: set-cell-border, get-cell-border) |
+| `--weight` |  |
+| `--dash-style` |  |
+| `--visible` |  |
+| `--merge-to-row` | (required for: merge-cells) |
+| `--merge-to-column` | (required for: merge-cells) |
 
 
-### `textframe` — Text frame commands: set/get text and basic font formatting (size, bold, color) for a shape's text range. Operates within an already-open IPresentationBatch, targeting a specific shape by its 1-based slide and shape index.
+### `textframe` — Text frame commands: set/get text and basic font formatting (size, bold, italic, underline, font name, color, alignment, bullets) for a shape's text range. Operates within an already-open IPresentationBatch, targeting a specific shape by its 1-based slide and shape index.
 
-Actions: `set-text`, `get-text`, `set-font-size`, `set-bold`, `set-font-color`
+Actions: `set-text`, `get-text`, `set-font-size`, `set-bold`, `set-font-color`, `set-italic`, `get-italic`, `set-underline`, `get-underline`, `set-font-name`, `get-font-name`, `set-alignment`, `get-alignment`, `set-bullet`, `get-bullet`, `set-auto-size`, `get-auto-size`
 
 | Flag | Description |
 |------|-------------|
@@ -248,6 +389,13 @@ Actions: `set-text`, `get-text`, `set-font-size`, `set-bold`, `set-font-color`
 | `--red` | (required for: set-font-color) |
 | `--green` | (required for: set-font-color) |
 | `--blue` | (required for: set-font-color) |
+| `--italic` | (required for: set-italic) |
+| `--underline` | (required for: set-underline) |
+| `--font-name` | (required for: set-font-name) |
+| `--alignment` | (required for: set-alignment) |
+| `--enabled` | (required for: set-bullet) |
+| `--character` |  |
+| `--auto-size` | (required for: set-auto-size) |
 
 
 

--- a/skills/powerpoint-cli/references/cli-commands.md
+++ b/skills/powerpoint-cli/references/cli-commands.md
@@ -77,19 +77,27 @@ already-open session.
 
 ### image
 
-Image commands: embed a picture file into a slide. Operates within an already-open session,
-targeting a specific slide by its 1-based index.
+Image commands: insert pictures and adjust picture formatting. Operates within an already-open
+session, targeting a specific slide and picture shape by their 1-based indices.
 
-**Actions:** `add-picture`
+**Actions:** `add-picture`, `set-brightness-contrast`, `get-brightness-contrast`, `set-recolor`, `get-recolor`, `set-crop`, `get-crop`
 
 | Parameter | Description |
 |-----------|-------------|
 | `--slide-index` | (required) |
-| `--image-path` | (required) |
-| `--left` | (required) |
-| `--top` | (required) |
-| `--width` | (required) |
-| `--height` | (required) |
+| `--shape-index` | (required for: set-brightness-contrast, get-brightness-contrast, set-recolor, get-recolor, set-crop, get-crop) |
+| `--image-path` | (required for: add-picture) |
+| `--left` | (required for: add-picture) |
+| `--top` | (required for: add-picture) |
+| `--width` | (required for: add-picture) |
+| `--height` | (required for: add-picture) |
+| `--brightness` | (required for: set-brightness-contrast) |
+| `--contrast` | (required for: set-brightness-contrast) |
+| `--color-type` | (required for: set-recolor) |
+| `--crop-left` | (required for: set-crop) |
+| `--crop-top` | (required for: set-crop) |
+| `--crop-right` | (required for: set-crop) |
+| `--crop-bottom` | (required for: set-crop) |
 
 ### layout
 

--- a/skills/powerpoint-mcp/SKILL.md
+++ b/skills/powerpoint-mcp/SKILL.md
@@ -30,7 +30,7 @@ Session-lifecycle tools (`create_presentation`, `open_presentation`, `save_prese
 |------|------|--------|------|
 | 1. Create (optional) | `create_presentation` | New file on disk, no session | Only for brand-new files |
 | 2. Open | `open_presentation` | Start a session, get `sessionId` | Always, before any edit |
-| 3. Build | `slide(action: "add-blank")`, `shape(action: "add-rectangle"/"add-text-box"/"add-auto-shape"/"add-line"/"add-connector")`, `table(action: "add-table")`, `chart(action: "add-chart")`, `image(action: "add-picture")` | Add structure and content | As needed |
+| 3. Build | `slide(action: "add-blank")`, `shape(action: "add-rectangle"/"add-text-box"/"add-auto-shape"/"add-line"/"add-connector")`, `table(action: "add-table")`, `chart(action: "add-chart")`, `image(action: "add-picture"/"set-brightness-contrast"/"get-brightness-contrast"/"set-recolor"/"get-recolor"/"set-crop"/"get-crop")` | Add structure and content | As needed |
 | 4. Format | `textframe(action: "set-font-size"/"set-bold"/"set-font-color")`, `layout(action: "set-layout")` | Apply formatting | After adding content |
 | 5. Animate (optional) | `animation(action: "add-effect"/"set-transition")` | Add entrance/emphasis/exit effects or slide transitions | After content/layout are final |
 | 6. Annotate | `notes(action: "set-notes-text")` | Add speaker notes | After each slide's content is final |
@@ -106,7 +106,7 @@ saved.
 | Tables | `table(action: "add-table"/"set-cell-text"/"get-cell-text"/"insert-row"/"delete-row"/"insert-column"/"delete-column"/"set-cell-fill"/"get-cell-fill"/"set-cell-border"/"get-cell-border"/"merge-cells")` |
 | Native charts | `chart(action: "add-chart"/"get-chart-data"/"add-series"/"set-chart-title"/"get-chart-title"/"set-axis-title"/"get-axis-title"/"set-legend-visibility"/"get-legend-visibility")` |
 | SmartArt diagrams | `smartart(action: "add-smart-art"/"add-node"/"add-child-node"/"set-node-text"/"get-node-text"/"delete-node"/"get-node-count")` |
-| Images | `image(action: "add-picture")` |
+| Images | `image(action: "add-picture"/"set-brightness-contrast"/"get-brightness-contrast"/"set-recolor"/"get-recolor"/"set-crop"/"get-crop")` |
 | Speaker notes | `notes(action: "set-notes-text"/"get-notes-text")` |
 | Slide layouts | `layout(action: "set-layout"/"get-layout")` |
 | Slide master title/body font, background color | `master(action: "get-title-font"/"set-title-font"/"get-body-font"/"set-body-font"/"get-background-color"/"set-background-color")` |
@@ -125,7 +125,7 @@ See `references/` for detailed guidance:
 - [Tables — add-table, cell text, row/column edits, fill/border formatting, merge](./references/tables.md)
 - [Charts — add-chart/add-series categories/series/values, titles, legend](./references/charts.md)
 - [SmartArt — add-smart-art layouts, node addressing, hierarchy diagrams](./references/smart-art.md)
-- [Images — add-picture](./references/images.md)
+- [Images — picture insertion and picture-format adjustments](./references/images.md)
 - [Speaker notes — set/get notes](./references/speaker-notes.md)
 - [Layouts — set/get slide layout](./references/layouts.md)
 - [Slide master — title/body font and background color](./references/master.md)

--- a/skills/powerpoint-mcp/references/images.md
+++ b/skills/powerpoint-mcp/references/images.md
@@ -1,7 +1,8 @@
 # Images
 
-Reference for `image(action: "add-picture", ...)` — embeds a local image file into a slide — plus
-picture-effect actions for adjusting brightness/contrast and recoloring an inserted picture.
+Reference for the image domain: `image(action: "add-picture", ...)` inserts a picture into a slide.
+The image domain provides 7 total actions: 1 insertion action (`add-picture`) plus 6 appearance actions: `set-brightness-contrast`, `get-brightness-contrast`,
+`set-recolor`, `get-recolor`, `set-crop`, and `get-crop`.
 
 ## Actions
 
@@ -12,6 +13,47 @@ picture-effect actions for adjusting brightness/contrast and recoloring an inser
 | `image` | `get-brightness-contrast` | `session_id`, `slide_index`, `shape_index` | Returns current `brightness`/`contrast`. |
 | `image` | `set-recolor` | `session_id`, `slide_index`, `shape_index`, `color_type` | `color_type` is one of `msoPictureAutomatic` (default/no recolor), `msoPictureGrayscale`, `msoPictureBlackAndWhite`, `msoPictureWatermark`. Unrecognized names fail with `Success=false`. |
 | `image` | `get-recolor` | `session_id`, `slide_index`, `shape_index` | Returns current `color_type`. |
+| `image` | `set-crop` | `session_id`, `slide_index`, `shape_index`, `crop_left`, `crop_top`, `crop_right`, `crop_bottom` | Crop edges in points from the picture's edges (L-T-R-B order). Negative values expand the displayed image. Requires a properly sized source image for meaningful geometry. |
+| `image` | `get-crop` | `session_id`, `slide_index`, `shape_index` | Returns current crop offsets in points (L-T-R-B). A fresh picture with no crop applied returns 0.0 for all four values. |
+
+## Crop Behavior
+
+When using `set-crop`, all four values are relative crop distances in points from the picture's
+edges. A positive value crops inward (hides content); a negative value expands the visible area
+outward (revealing areas beyond the original picture bounds in PowerPoint's rendering). PowerPoint
+allows negative crop values as a valid expansion mechanism.
+
+**Important:** Meaningful crop geometry requires a properly sized source image. The legacy test anomaly
+of a 1×1 pixel image should **never** be treated as normal user behavior — it is a degenerate case
+used only for testing framework integration and produces unintuitive crop results. Always use real,
+properly sized source images (e.g., 100×100 pixels minimum) when working with crop operations.
+
+Results from `get-crop` expose `cropLeft`, `cropTop`, `cropRight`, `cropBottom` as numeric
+floats (in points). A fresh picture with no crop applied returns 0.0 for all four values.
+These result fields are absent (null in JSON) only when the result comes from a non-crop operation
+(e.g., `get-recolor`) — they are never null simply because no crop has been applied.
+
+## PictureFormat Coverage
+
+The image domain exposes these `Microsoft.Office.Interop.PowerPoint.PictureFormat` properties and methods:
+
+| Member | Type | Status | Action | Notes |
+|--------|------|--------|--------|-------|
+| `Brightness` | Property | ✓ Exposed | `set-brightness-contrast`, `get-brightness-contrast` | Float [0, 1] scale. Default 0.5. |
+| `Contrast` | Property | ✓ Exposed | `set-brightness-contrast`, `get-brightness-contrast` | Float [0, 1] scale. Default 0.5. |
+| `ColorType` | Property | ✓ Exposed | `set-recolor`, `get-recolor` | MsoPictureColorType enum. |
+| `CropLeft` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from left edge. |
+| `CropTop` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from top edge. |
+| `CropRight` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from right edge. |
+| `CropBottom` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from bottom edge. |
+| `Crop` | Object | ⊘ Not exposed | — | Separate Office.Core Crop subobject with natural-image/display scaling semantics. Deliberately unexposed; direct scalar crop properties subsume its interface. |
+| `IncrementBrightness` | Method | ⊘ Not exposed | — | Already covered by idempotent absolute setter; live COM confirms increments clamp to [0, 1]. |
+| `IncrementContrast` | Method | ⊘ Not exposed | — | Already covered by idempotent absolute setter; live COM confirms increments clamp to [0, 1]. |
+| `TransparencyColor` | Property | ⊘ Not exposed | — | Live COM proved set/read/persistence on BMP, but deliberately unexposed: BMP defaults to msoTrue, no-key uses int.MinValue sentinel, exact color-key knowledge required, JPEG unsuitable, PNG supports alpha natively. |
+| `TransparentBackground` | Property | ⊘ Not exposed | — | Live COM proved set/read/persistence on BMP, but deliberately unexposed: defaults are format-dependent (BMP: msoTrue), exact behavior requires format-specific tuning. |
+| `Application` | Property | ⊘ Not exposed | — | Read-only, non-actionable object reference. |
+| `Creator` | Property | ⊘ Not exposed | — | Read-only, non-actionable object reference. |
+| `Parent` | Property | ⊘ Not exposed | — | Read-only, non-actionable object reference. |
 
 ## Requirements
 
@@ -30,6 +72,7 @@ picture-effect actions for adjusting brightness/contrast and recoloring an inser
 - Logos: small, corner-anchored, e.g. `width=80, height=80` near `left=20, top=20` (top-left) or
   `left=860, top=460` (bottom-right on a 960×540pt slide).
 - Full-slide product shots/photos: leave a title band at the top (`top ≥ 80`) unless the image is
+
   intentionally full-bleed.
 - Diagrams/screenshots next to explanatory text: place the image in one half of the slide
   (`width ≈ 420` on a 960pt-wide slide) with a text box in the other half.
@@ -42,7 +85,6 @@ doesn't overlap other shapes on the slide (see `export-and-verify.md`).
 
 ## Limited Editing After Insert
 
-There is no crop/rotate action in this surface. If the image needs cropping or rotation, prepare
-the final image file before calling `add-picture`. Post-insert adjustments available: `shape(action:
-"set-position", ...)`, `shape(action: "set-size", ...)` (see `slides-and-shapes.md`), and the
-`set-brightness-contrast`/`set-recolor` actions above.
+Post-insert adjustments available: `shape(action: "set-position", ...)`, `shape(action:
+"set-size", ...)` (see `slides-and-shapes.md`), and `set-brightness-contrast`, `set-recolor`,
+and `set-crop` actions (see above).

--- a/skills/shared/images.md
+++ b/skills/shared/images.md
@@ -1,7 +1,8 @@
 # Images
 
-Reference for `image(action: "add-picture", ...)` — embeds a local image file into a slide — plus
-picture-effect actions for adjusting brightness/contrast and recoloring an inserted picture.
+Reference for the image domain: `image(action: "add-picture", ...)` inserts a picture into a slide.
+The image domain provides 7 total actions: 1 insertion action (`add-picture`) plus 6 appearance actions: `set-brightness-contrast`, `get-brightness-contrast`,
+`set-recolor`, `get-recolor`, `set-crop`, and `get-crop`.
 
 ## Actions
 
@@ -12,6 +13,47 @@ picture-effect actions for adjusting brightness/contrast and recoloring an inser
 | `image` | `get-brightness-contrast` | `session_id`, `slide_index`, `shape_index` | Returns current `brightness`/`contrast`. |
 | `image` | `set-recolor` | `session_id`, `slide_index`, `shape_index`, `color_type` | `color_type` is one of `msoPictureAutomatic` (default/no recolor), `msoPictureGrayscale`, `msoPictureBlackAndWhite`, `msoPictureWatermark`. Unrecognized names fail with `Success=false`. |
 | `image` | `get-recolor` | `session_id`, `slide_index`, `shape_index` | Returns current `color_type`. |
+| `image` | `set-crop` | `session_id`, `slide_index`, `shape_index`, `crop_left`, `crop_top`, `crop_right`, `crop_bottom` | Crop edges in points from the picture's edges (L-T-R-B order). Negative values expand the displayed image. Requires a properly sized source image for meaningful geometry. |
+| `image` | `get-crop` | `session_id`, `slide_index`, `shape_index` | Returns current crop offsets in points (L-T-R-B). A fresh picture with no crop applied returns 0.0 for all four values. |
+
+## Crop Behavior
+
+When using `set-crop`, all four values are relative crop distances in points from the picture's
+edges. A positive value crops inward (hides content); a negative value expands the visible area
+outward (revealing areas beyond the original picture bounds in PowerPoint's rendering). PowerPoint
+allows negative crop values as a valid expansion mechanism.
+
+**Important:** Meaningful crop geometry requires a properly sized source image. The legacy test anomaly
+of a 1×1 pixel image should **never** be treated as normal user behavior — it is a degenerate case
+used only for testing framework integration and produces unintuitive crop results. Always use real,
+properly sized source images (e.g., 100×100 pixels minimum) when working with crop operations.
+
+Results from `get-crop` expose `cropLeft`, `cropTop`, `cropRight`, `cropBottom` as numeric
+floats (in points). A fresh picture with no crop applied returns 0.0 for all four values.
+These result fields are absent (null in JSON) only when the result comes from a non-crop operation
+(e.g., `get-recolor`) — they are never null simply because no crop has been applied.
+
+## PictureFormat Coverage
+
+The image domain exposes these `Microsoft.Office.Interop.PowerPoint.PictureFormat` properties and methods:
+
+| Member | Type | Status | Action | Notes |
+|--------|------|--------|--------|-------|
+| `Brightness` | Property | ✓ Exposed | `set-brightness-contrast`, `get-brightness-contrast` | Float [0, 1] scale. Default 0.5. |
+| `Contrast` | Property | ✓ Exposed | `set-brightness-contrast`, `get-brightness-contrast` | Float [0, 1] scale. Default 0.5. |
+| `ColorType` | Property | ✓ Exposed | `set-recolor`, `get-recolor` | MsoPictureColorType enum. |
+| `CropLeft` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from left edge. |
+| `CropTop` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from top edge. |
+| `CropRight` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from right edge. |
+| `CropBottom` | Property | ✓ Exposed | `set-crop`, `get-crop` | Direct scalar property, in points from bottom edge. |
+| `Crop` | Object | ⊘ Not exposed | — | Separate Office.Core Crop subobject with natural-image/display scaling semantics. Deliberately unexposed; direct scalar crop properties subsume its interface. |
+| `IncrementBrightness` | Method | ⊘ Not exposed | — | Already covered by idempotent absolute setter; live COM confirms increments clamp to [0, 1]. |
+| `IncrementContrast` | Method | ⊘ Not exposed | — | Already covered by idempotent absolute setter; live COM confirms increments clamp to [0, 1]. |
+| `TransparencyColor` | Property | ⊘ Not exposed | — | Live COM proved set/read/persistence on BMP, but deliberately unexposed: BMP defaults to msoTrue, no-key uses int.MinValue sentinel, exact color-key knowledge required, JPEG unsuitable, PNG supports alpha natively. |
+| `TransparentBackground` | Property | ⊘ Not exposed | — | Live COM proved set/read/persistence on BMP, but deliberately unexposed: defaults are format-dependent (BMP: msoTrue), exact behavior requires format-specific tuning. |
+| `Application` | Property | ⊘ Not exposed | — | Read-only, non-actionable object reference. |
+| `Creator` | Property | ⊘ Not exposed | — | Read-only, non-actionable object reference. |
+| `Parent` | Property | ⊘ Not exposed | — | Read-only, non-actionable object reference. |
 
 ## Requirements
 
@@ -30,6 +72,7 @@ picture-effect actions for adjusting brightness/contrast and recoloring an inser
 - Logos: small, corner-anchored, e.g. `width=80, height=80` near `left=20, top=20` (top-left) or
   `left=860, top=460` (bottom-right on a 960×540pt slide).
 - Full-slide product shots/photos: leave a title band at the top (`top ≥ 80`) unless the image is
+
   intentionally full-bleed.
 - Diagrams/screenshots next to explanatory text: place the image in one half of the slide
   (`width ≈ 420` on a 960pt-wide slide) with a text box in the other half.
@@ -42,7 +85,6 @@ doesn't overlap other shapes on the slide (see `export-and-verify.md`).
 
 ## Limited Editing After Insert
 
-There is no crop/rotate action in this surface. If the image needs cropping or rotation, prepare
-the final image file before calling `add-picture`. Post-insert adjustments available: `shape(action:
-"set-position", ...)`, `shape(action: "set-size", ...)` (see `slides-and-shapes.md`), and the
-`set-brightness-contrast`/`set-recolor` actions above.
+Post-insert adjustments available: `shape(action: "set-position", ...)`, `shape(action:
+"set-size", ...)` (see `slides-and-shapes.md`), and `set-brightness-contrast`, `set-recolor`,
+and `set-crop` actions (see above).

--- a/src/PowerPointMcp.ComInterop/ComInteropConstants.cs
+++ b/src/PowerPointMcp.ComInterop/ComInteropConstants.cs
@@ -1,3 +1,5 @@
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
 namespace Sbroenne.PowerPointMcp.ComInterop;
 
 /// <summary>
@@ -66,19 +68,22 @@ public static class ComInteropConstants
     /// PowerPoint Open XML Presentation format code (.pptx).
     /// PpSaveAsFileType.ppSaveAsOpenXMLPresentation = 24
     /// </summary>
-    public const int PpSaveAsOpenXmlPresentation = 24;
+    public const PowerPoint.PpSaveAsFileType PpSaveAsOpenXmlPresentation =
+        PowerPoint.PpSaveAsFileType.ppSaveAsOpenXMLPresentation;
 
     /// <summary>
     /// PowerPoint Open XML Macro-Enabled Presentation format code (.pptm).
     /// PpSaveAsFileType.ppSaveAsOpenXMLPresentationMacroEnabled = 25
     /// </summary>
-    public const int PpSaveAsOpenXmlPresentationMacroEnabled = 25;
+    public const PowerPoint.PpSaveAsFileType PpSaveAsOpenXmlPresentationMacroEnabled =
+        PowerPoint.PpSaveAsFileType.ppSaveAsOpenXMLPresentationMacroEnabled;
 
     /// <summary>
     /// PowerPoint Open XML Template format code (.potx).
     /// PpSaveAsFileType.ppSaveAsOpenXMLTemplate = 26
     /// </summary>
-    public const int PpSaveAsOpenXmlTemplate = 26;
+    public const PowerPoint.PpSaveAsFileType PpSaveAsOpenXmlTemplate =
+        PowerPoint.PpSaveAsFileType.ppSaveAsOpenXMLTemplate;
 
     #endregion
 }

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -193,13 +193,15 @@ internal sealed class PresentationBatch : IPresentationBatch
             OleMessageFilter.Register();
             DisableDesignerAutomationHang();
 
-            Type? appType = Type.GetTypeFromProgID("PowerPoint.Application");
-            if (appType == null)
+            PowerPoint.Application tempApp;
+            try
             {
-                throw new InvalidOperationException("Microsoft PowerPoint is not installed on this system.");
+                tempApp = new PowerPoint.Application();
             }
-
-            var tempApp = (PowerPoint.Application)Activator.CreateInstance(appType)!;
+            catch (COMException ex) when ((uint)ex.HResult == 0x80040154) // REGDB_E_CLASSNOTREG
+            {
+                throw new InvalidOperationException("Microsoft PowerPoint is not installed on this system.", ex);
+            }
             startupApp = tempApp;
 
             // NOTE: PowerPoint.Application.Visible and Presentations.Add/Open all take
@@ -246,7 +248,7 @@ internal sealed class PresentationBatch : IPresentationBatch
             }
 
             string fullPath = Path.GetFullPath(_presentationPath);
-            PowerPoint.Presentation presentation = OpenOrCreatePresentationCom(dynApp, fullPath, _createNewFile);
+            PowerPoint.Presentation presentation = OpenOrCreatePresentationCom(tempApp, fullPath, _createNewFile);
 
             startupPresentation = presentation;
             _app = tempApp;
@@ -285,10 +287,11 @@ internal sealed class PresentationBatch : IPresentationBatch
     /// within an already-running Application instance (e.g. shared test fixtures) without
     /// re-launching PowerPoint.
     /// </summary>
-    private static PowerPoint.Presentation OpenOrCreatePresentationCom(dynamic dynApp, string fullPath, bool createNewFile)
+    private static PowerPoint.Presentation OpenOrCreatePresentationCom(PowerPoint.Application app, string fullPath, bool createNewFile)
     {
         const int msoTrue = -1;
         const int msoFalse = 0;
+        dynamic dynPresentations = app.Presentations;
 
         PowerPoint.Presentation presentation;
 
@@ -302,16 +305,17 @@ internal sealed class PresentationBatch : IPresentationBatch
 
             // See RunStaThread's original NOTE: WithWindow must be msoTrue (chart in-place
             // activation needs a real document window), independent of Application.Visible.
-            presentation = (PowerPoint.Presentation)dynApp.Presentations.Add(msoTrue);
+            presentation = (PowerPoint.Presentation)dynPresentations.Add(msoTrue);
 
             // Presentations.Add() creates a presentation with ZERO slides — add one blank
             // slide so "create a new presentation" is immediately useful.
             presentation.Slides.Add(1, PowerPoint.PpSlideLayout.ppLayoutBlank);
 
-            int formatCode = string.Equals(Path.GetExtension(fullPath), ".pptm", StringComparison.OrdinalIgnoreCase)
+            PowerPoint.PpSaveAsFileType formatCode = string.Equals(Path.GetExtension(fullPath), ".pptm", StringComparison.OrdinalIgnoreCase)
                 ? ComInteropConstants.PpSaveAsOpenXmlPresentationMacroEnabled
                 : ComInteropConstants.PpSaveAsOpenXmlPresentation;
-            ((dynamic)presentation).SaveAs(fullPath, formatCode);
+            dynamic dynPresentation = presentation;
+            dynPresentation.SaveAs(fullPath, formatCode);
         }
         else
         {
@@ -320,7 +324,7 @@ internal sealed class PresentationBatch : IPresentationBatch
                 throw new FileNotFoundException($"PowerPoint file not found: {fullPath}.", fullPath);
             }
 
-            presentation = (PowerPoint.Presentation)dynApp.Presentations.Open(
+            presentation = (PowerPoint.Presentation)dynPresentations.Open(
                 fullPath,
                 msoFalse, // ReadOnly = false — we need to be able to Save()
                 msoFalse, // Untitled = false — see RunStaThread's original NOTE.
@@ -527,8 +531,7 @@ internal sealed class PresentationBatch : IPresentationBatch
                 ComUtilities.Release(ref oldPresentation);
             }
 
-            dynamic dynApp = _app!;
-            PowerPoint.Presentation newPresentation = OpenOrCreatePresentationCom(dynApp, fullPath, createNewFile);
+            PowerPoint.Presentation newPresentation = OpenOrCreatePresentationCom(_app!, fullPath, createNewFile);
             _presentation = newPresentation;
             _presentationPath = fullPath;
             _context = new PresentationContext(fullPath, _app!, newPresentation);

--- a/src/PowerPointMcp.Core/Animation/AnimationCommands.cs
+++ b/src/PowerPointMcp.Core/Animation/AnimationCommands.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Animation;
 
@@ -8,90 +9,91 @@ public sealed class AnimationCommands : IAnimationCommands
     private const int MsoTrue = -1;
     private const int MsoFalse = 0;
 
-    // MsoAnimTriggerType member -> value (learn.microsoft.com/office/vba/api/powerpoint.msoanimtriggertype).
-    private static readonly Dictionary<string, int> TriggerTypes = new(StringComparer.OrdinalIgnoreCase)
+    // MsoAnimTriggerType (PowerPoint namespace, embeddable without office.dll).
+    private static readonly Dictionary<string, PowerPoint.MsoAnimTriggerType> TriggerTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["on-click"] = 1,   // msoAnimTriggerOnPageClick
-        ["with-previous"] = 2,   // msoAnimTriggerWithPrevious
-        ["after-previous"] = 3,   // msoAnimTriggerAfterPrevious
+        ["on-click"] = PowerPoint.MsoAnimTriggerType.msoAnimTriggerOnPageClick,
+        ["with-previous"] = PowerPoint.MsoAnimTriggerType.msoAnimTriggerWithPrevious,
+        ["after-previous"] = PowerPoint.MsoAnimTriggerType.msoAnimTriggerAfterPrevious,
     };
 
-    // MsoAnimEffect member name -> value, a curated subset of the full (150+) enum covering the
+    // MsoAnimEffect (PowerPoint namespace, embeddable without office.dll). Curated subset of the
+    // full (150+) enum covering the
     // classic entrance/emphasis/exit effects authors most commonly need — verified against
     // learn.microsoft.com/office/vba/api/powerpoint.msoanimeffect. Extend this table (never guess
     // a value) if more effects are needed later.
-    private static readonly Dictionary<string, int> AnimEffects = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, PowerPoint.MsoAnimEffect> AnimEffects = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["msoAnimEffectAppear"] = 1,
-        ["msoAnimEffectFly"] = 2,
-        ["msoAnimEffectBlinds"] = 3,
-        ["msoAnimEffectBox"] = 4,
-        ["msoAnimEffectCheckerboard"] = 5,
-        ["msoAnimEffectCircle"] = 6,
-        ["msoAnimEffectDiamond"] = 8,
-        ["msoAnimEffectDissolve"] = 9,
-        ["msoAnimEffectFade"] = 10,
-        ["msoAnimEffectFlashOnce"] = 11,
-        ["msoAnimEffectPeek"] = 12,
-        ["msoAnimEffectPlus"] = 13,
-        ["msoAnimEffectRandomBars"] = 14,
-        ["msoAnimEffectSpiral"] = 15,
-        ["msoAnimEffectSplit"] = 16,
-        ["msoAnimEffectStretch"] = 17,
-        ["msoAnimEffectStrips"] = 18,
-        ["msoAnimEffectSwivel"] = 19,
-        ["msoAnimEffectWedge"] = 20,
-        ["msoAnimEffectWheel"] = 21,
-        ["msoAnimEffectWipe"] = 22,
-        ["msoAnimEffectZoom"] = 23,
-        ["msoAnimEffectBounce"] = 26,
-        ["msoAnimEffectCredits"] = 28,
-        ["msoAnimEffectGrowShrink"] = 59,
-        ["msoAnimEffectSpin"] = 61,
-        ["msoAnimEffectTransparency"] = 62,
-        ["msoAnimEffectChangeFillColor"] = 54,
-        ["msoAnimEffectChangeFontColor"] = 56,
+        ["msoAnimEffectAppear"] = PowerPoint.MsoAnimEffect.msoAnimEffectAppear,
+        ["msoAnimEffectFly"] = PowerPoint.MsoAnimEffect.msoAnimEffectFly,
+        ["msoAnimEffectBlinds"] = PowerPoint.MsoAnimEffect.msoAnimEffectBlinds,
+        ["msoAnimEffectBox"] = PowerPoint.MsoAnimEffect.msoAnimEffectBox,
+        ["msoAnimEffectCheckerboard"] = PowerPoint.MsoAnimEffect.msoAnimEffectCheckerboard,
+        ["msoAnimEffectCircle"] = PowerPoint.MsoAnimEffect.msoAnimEffectCircle,
+        ["msoAnimEffectDiamond"] = PowerPoint.MsoAnimEffect.msoAnimEffectDiamond,
+        ["msoAnimEffectDissolve"] = PowerPoint.MsoAnimEffect.msoAnimEffectDissolve,
+        ["msoAnimEffectFade"] = PowerPoint.MsoAnimEffect.msoAnimEffectFade,
+        ["msoAnimEffectFlashOnce"] = PowerPoint.MsoAnimEffect.msoAnimEffectFlashOnce,
+        ["msoAnimEffectPeek"] = PowerPoint.MsoAnimEffect.msoAnimEffectPeek,
+        ["msoAnimEffectPlus"] = PowerPoint.MsoAnimEffect.msoAnimEffectPlus,
+        ["msoAnimEffectRandomBars"] = PowerPoint.MsoAnimEffect.msoAnimEffectRandomBars,
+        ["msoAnimEffectSpiral"] = PowerPoint.MsoAnimEffect.msoAnimEffectSpiral,
+        ["msoAnimEffectSplit"] = PowerPoint.MsoAnimEffect.msoAnimEffectSplit,
+        ["msoAnimEffectStretch"] = PowerPoint.MsoAnimEffect.msoAnimEffectStretch,
+        ["msoAnimEffectStrips"] = PowerPoint.MsoAnimEffect.msoAnimEffectStrips,
+        ["msoAnimEffectSwivel"] = PowerPoint.MsoAnimEffect.msoAnimEffectSwivel,
+        ["msoAnimEffectWedge"] = PowerPoint.MsoAnimEffect.msoAnimEffectWedge,
+        ["msoAnimEffectWheel"] = PowerPoint.MsoAnimEffect.msoAnimEffectWheel,
+        ["msoAnimEffectWipe"] = PowerPoint.MsoAnimEffect.msoAnimEffectWipe,
+        ["msoAnimEffectZoom"] = PowerPoint.MsoAnimEffect.msoAnimEffectZoom,
+        ["msoAnimEffectBounce"] = PowerPoint.MsoAnimEffect.msoAnimEffectBounce,
+        ["msoAnimEffectCredits"] = PowerPoint.MsoAnimEffect.msoAnimEffectCredits,
+        ["msoAnimEffectGrowShrink"] = PowerPoint.MsoAnimEffect.msoAnimEffectGrowShrink,
+        ["msoAnimEffectSpin"] = PowerPoint.MsoAnimEffect.msoAnimEffectSpin,
+        ["msoAnimEffectTransparency"] = PowerPoint.MsoAnimEffect.msoAnimEffectTransparency,
+        ["msoAnimEffectChangeFillColor"] = PowerPoint.MsoAnimEffect.msoAnimEffectChangeFillColor,
+        ["msoAnimEffectChangeFontColor"] = PowerPoint.MsoAnimEffect.msoAnimEffectChangeFontColor,
     };
 
     // PpEntryEffect member name -> value, a curated subset of the full (150+) enum covering the
     // most common slide transitions — verified against
     // learn.microsoft.com/office/vba/api/powerpoint.ppentryeffect. Extend this table (never guess
     // a value) if more transitions are needed later.
-    private static readonly Dictionary<string, int> EntryEffects = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, PowerPoint.PpEntryEffect> EntryEffects = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["ppEffectNone"] = 0,
-        ["ppEffectCut"] = 257,
-        ["ppEffectCutThroughBlack"] = 258,
-        ["ppEffectRandom"] = 513,
-        ["ppEffectBlindsHorizontal"] = 769,
-        ["ppEffectBlindsVertical"] = 770,
-        ["ppEffectCheckerboardAcross"] = 1025,
-        ["ppEffectCheckerboardDown"] = 1026,
-        ["ppEffectCoverLeft"] = 1281,
-        ["ppEffectCoverUp"] = 1282,
-        ["ppEffectCoverRight"] = 1283,
-        ["ppEffectCoverDown"] = 1284,
-        ["ppEffectDissolve"] = 1537,
-        ["ppEffectFade"] = 1793,
-        ["ppEffectRandomBarsHorizontal"] = 2305,
-        ["ppEffectRandomBarsVertical"] = 2306,
-        ["ppEffectUncoverLeft"] = 2049,
-        ["ppEffectUncoverUp"] = 2050,
-        ["ppEffectUncoverRight"] = 2051,
-        ["ppEffectUncoverDown"] = 2052,
-        ["ppEffectWedge"] = 3856,
-        ["ppEffectCircleOut"] = 3845,
-        ["ppEffectDiamondOut"] = 3846,
-        ["ppEffectPlusOut"] = 3851,
-        ["ppEffectPushLeft"] = 3853,
-        ["ppEffectPushRight"] = 3854,
-        ["ppEffectPushUp"] = 3852,
-        ["ppEffectPushDown"] = 3855,
-        ["ppEffectNewsflash"] = 3850,
-        ["ppEffectFadeSmoothly"] = 3849,
+        ["ppEffectNone"] = PowerPoint.PpEntryEffect.ppEffectNone,
+        ["ppEffectCut"] = PowerPoint.PpEntryEffect.ppEffectCut,
+        ["ppEffectCutThroughBlack"] = PowerPoint.PpEntryEffect.ppEffectCutThroughBlack,
+        ["ppEffectRandom"] = PowerPoint.PpEntryEffect.ppEffectRandom,
+        ["ppEffectBlindsHorizontal"] = PowerPoint.PpEntryEffect.ppEffectBlindsHorizontal,
+        ["ppEffectBlindsVertical"] = PowerPoint.PpEntryEffect.ppEffectBlindsVertical,
+        ["ppEffectCheckerboardAcross"] = PowerPoint.PpEntryEffect.ppEffectCheckerboardAcross,
+        ["ppEffectCheckerboardDown"] = PowerPoint.PpEntryEffect.ppEffectCheckerboardDown,
+        ["ppEffectCoverLeft"] = PowerPoint.PpEntryEffect.ppEffectCoverLeft,
+        ["ppEffectCoverUp"] = PowerPoint.PpEntryEffect.ppEffectCoverUp,
+        ["ppEffectCoverRight"] = PowerPoint.PpEntryEffect.ppEffectCoverRight,
+        ["ppEffectCoverDown"] = PowerPoint.PpEntryEffect.ppEffectCoverDown,
+        ["ppEffectDissolve"] = PowerPoint.PpEntryEffect.ppEffectDissolve,
+        ["ppEffectFade"] = PowerPoint.PpEntryEffect.ppEffectFade,
+        ["ppEffectRandomBarsHorizontal"] = PowerPoint.PpEntryEffect.ppEffectRandomBarsHorizontal,
+        ["ppEffectRandomBarsVertical"] = PowerPoint.PpEntryEffect.ppEffectRandomBarsVertical,
+        ["ppEffectUncoverLeft"] = PowerPoint.PpEntryEffect.ppEffectUncoverLeft,
+        ["ppEffectUncoverUp"] = PowerPoint.PpEntryEffect.ppEffectUncoverUp,
+        ["ppEffectUncoverRight"] = PowerPoint.PpEntryEffect.ppEffectUncoverRight,
+        ["ppEffectUncoverDown"] = PowerPoint.PpEntryEffect.ppEffectUncoverDown,
+        ["ppEffectWedge"] = PowerPoint.PpEntryEffect.ppEffectWedge,
+        ["ppEffectCircleOut"] = PowerPoint.PpEntryEffect.ppEffectCircleOut,
+        ["ppEffectDiamondOut"] = PowerPoint.PpEntryEffect.ppEffectDiamondOut,
+        ["ppEffectPlusOut"] = PowerPoint.PpEntryEffect.ppEffectPlusOut,
+        ["ppEffectPushLeft"] = PowerPoint.PpEntryEffect.ppEffectPushLeft,
+        ["ppEffectPushRight"] = PowerPoint.PpEntryEffect.ppEffectPushRight,
+        ["ppEffectPushUp"] = PowerPoint.PpEntryEffect.ppEffectPushUp,
+        ["ppEffectPushDown"] = PowerPoint.PpEntryEffect.ppEffectPushDown,
+        ["ppEffectNewsflash"] = PowerPoint.PpEntryEffect.ppEffectNewsflash,
+        ["ppEffectFadeSmoothly"] = PowerPoint.PpEntryEffect.ppEffectFadeSmoothly,
     };
 
-    private static readonly Dictionary<int, string> EntryEffectsByValue =
+    private static readonly Dictionary<PowerPoint.PpEntryEffect, string> EntryEffectsByValue =
         EntryEffects.GroupBy(kvp => kvp.Value).ToDictionary(g => g.Key, g => g.First().Key);
 
     /// <inheritdoc/>
@@ -112,8 +114,8 @@ public sealed class AnimationCommands : IAnimationCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            var shapeValidation = ValidateShapeIndex((int)slide.Shapes.Count, shapeIndex);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
             if (!AnimEffects.TryGetValue(effectName, out var effectValue))
@@ -134,21 +136,28 @@ public sealed class AnimationCommands : IAnimationCommands
                 };
             }
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic sequence = slide.TimeLine.MainSequence;
-            dynamic effect = sequence.AddEffect(shape, effectValue);
-            effect.Exit = isExit ? MsoTrue : MsoFalse;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            PowerPoint.Sequence sequence = slide.TimeLine.MainSequence;
+            // Pre-capture append position: Count+1 before the call equals Count after (the new
+            // effect's 1-based index). Passing 0 explicitly sends an integer-out-of-range COM
+            // error — the VBA "default=0 means append" only works via COM's missing-arg protocol,
+            // not from an explicit .NET value. Any index > Count is documented to append.
+            int newIndex = sequence.Count + 1;
+            PowerPoint.Effect effect = sequence.AddEffect(
+                shape,
+                effectValue,
+                PowerPoint.MsoAnimateByLevel.msoAnimateLevelNone,
+                triggerValue,
+                newIndex);
+            dynamic dynEffect = effect;
+            dynEffect.Exit = isExit ? MsoTrue : MsoFalse;
             effect.Timing.TriggerType = triggerValue;
-
-            // Same NoPIA late-binding quirk documented in ShapeCommands — the newly-added effect
-            // is always appended, so its 1-based index is simply the new sequence Count.
-            int newIndex = (int)sequence.Count;
 
             return new AnimationOperationResult
             {
                 Success = true,
                 EffectIndex = newIndex,
-                EffectCount = (int)sequence.Count,
+                EffectCount = sequence.Count,
                 EffectName = effectName,
                 IsExit = isExit,
                 Trigger = trigger
@@ -166,10 +175,10 @@ public sealed class AnimationCommands : IAnimationCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            dynamic sequence = slide.TimeLine.MainSequence;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Sequence sequence = slide.TimeLine.MainSequence;
 
-            return new AnimationOperationResult { Success = true, EffectCount = (int)sequence.Count };
+            return new AnimationOperationResult { Success = true, EffectCount = sequence.Count };
         });
     }
 
@@ -183,9 +192,9 @@ public sealed class AnimationCommands : IAnimationCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            dynamic sequence = slide.TimeLine.MainSequence;
-            int effectCount = (int)sequence.Count;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Sequence sequence = slide.TimeLine.MainSequence;
+            int effectCount = sequence.Count;
 
             if (effectIndex < 1 || effectIndex > effectCount)
             {
@@ -196,14 +205,14 @@ public sealed class AnimationCommands : IAnimationCommands
                 };
             }
 
-            dynamic effect = sequence[effectIndex];
+            PowerPoint.Effect effect = sequence[effectIndex];
             effect.Delete();
 
             return new AnimationOperationResult
             {
                 Success = true,
                 EffectIndex = effectIndex,
-                EffectCount = (int)sequence.Count
+                EffectCount = sequence.Count
             };
         });
     }
@@ -218,7 +227,7 @@ public sealed class AnimationCommands : IAnimationCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             return ReadTransition(slide);
         });
     }
@@ -250,8 +259,8 @@ public sealed class AnimationCommands : IAnimationCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            dynamic transition = slide.SlideShowTransition;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.SlideShowTransition transition = slide.SlideShowTransition;
             transition.EntryEffect = transitionValue;
 
             if (durationSeconds is not null)
@@ -261,12 +270,14 @@ public sealed class AnimationCommands : IAnimationCommands
 
             if (advanceOnClick is not null)
             {
-                transition.AdvanceOnClick = advanceOnClick.Value ? MsoTrue : MsoFalse;
+                dynamic dynTransition = transition;
+                dynTransition.AdvanceOnClick = advanceOnClick.Value ? MsoTrue : MsoFalse;
             }
 
             if (advanceOnTime is not null)
             {
-                transition.AdvanceOnTime = advanceOnTime.Value ? MsoTrue : MsoFalse;
+                dynamic dynTransition = transition;
+                dynTransition.AdvanceOnTime = advanceOnTime.Value ? MsoTrue : MsoFalse;
             }
 
             if (advanceTimeSeconds is not null)
@@ -278,22 +289,23 @@ public sealed class AnimationCommands : IAnimationCommands
         });
     }
 
-    private static AnimationOperationResult ReadTransition(dynamic slide)
+    private static AnimationOperationResult ReadTransition(PowerPoint.Slide slide)
     {
-        dynamic transition = slide.SlideShowTransition;
-        int entryEffectValue = (int)transition.EntryEffect;
+        PowerPoint.SlideShowTransition transition = slide.SlideShowTransition;
+        PowerPoint.PpEntryEffect entryEffectValue = transition.EntryEffect;
         string transitionName = EntryEffectsByValue.TryGetValue(entryEffectValue, out var name)
             ? name
-            : $"unknown ({entryEffectValue})";
+            : $"unknown ({(int)entryEffectValue})";
+        dynamic dynTransition = transition;
 
         return new AnimationOperationResult
         {
             Success = true,
             TransitionName = transitionName,
-            DurationSeconds = (float)transition.Duration,
-            AdvanceOnClick = (int)transition.AdvanceOnClick == MsoTrue,
-            AdvanceOnTime = (int)transition.AdvanceOnTime == MsoTrue,
-            AdvanceTimeSeconds = (float)transition.AdvanceTime
+            DurationSeconds = transition.Duration,
+            AdvanceOnClick = (int)dynTransition.AdvanceOnClick == MsoTrue,
+            AdvanceOnTime = (int)dynTransition.AdvanceOnTime == MsoTrue,
+            AdvanceTimeSeconds = transition.AdvanceTime
         };
     }
 

--- a/src/PowerPointMcp.Core/Chart/ChartCommands.cs
+++ b/src/PowerPointMcp.Core/Chart/ChartCommands.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Runtime.InteropServices;
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Chart;
 
@@ -16,7 +17,7 @@ public sealed class ChartCommands : IChartCommands
     private const int XlColumnClustered = 51; // bar/column chart
     private const int XlLine = 4;
     private const int XlPie = 5;
-    private const int MsoTrue = -1; // MsoTriState.msoTrue — AddChart2's NewLayout param is MsoTriState, not bool.
+    private const int MsoTrue = -1; // MsoTriState.msoTrue for Office.Core-backed tri-state members (for example Shape.HasChart).
 
     /// <inheritdoc/>
     public ChartOperationResult AddChart(IPresentationBatch batch, int slideIndex, string chartType, float left, float top, float width, float height, IReadOnlyList<string> categories, string seriesName, IReadOnlyList<double> values)
@@ -58,22 +59,22 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
 
             // Shapes.AddChart2(Style, XlChartType, Left, Top, Width, Height, NewLayout) -> Shape
-            dynamic chartShape = slide.Shapes.AddChart2(-1, xlChartType.Value, left, top, width, height, MsoTrue);
-            dynamic chart = chartShape.Chart;
+            dynamic chartShape = ((dynamic)slide.Shapes).AddChart2(-1, xlChartType.Value, left, top, width, height, true);
+            PowerPoint.Chart chart = chartShape.Chart;
 
             WriteChartData(chart, categories, seriesName, values);
 
             // Same NoPIA .Index late-binding quirk as Shape domain — use Shapes.Count instead.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
 
             return new ChartOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count
+                ShapeCount = slide.Shapes.Count
             };
         });
     }
@@ -88,13 +89,13 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
             // NOTE: HasChart is MsoTriState (an int), not a C# bool — msoTrue = -1.
-            if ((int)shape.HasChart != -1)
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -103,15 +104,14 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             dynamic seriesCollection = chart.SeriesCollection();
             int seriesCount = (int)seriesCollection.Count;
             int categoryCount = 0;
             if (seriesCount > 0)
             {
                 dynamic firstSeries = seriesCollection.Item(1);
-                dynamic xValues = firstSeries.XValues;
-                categoryCount = (int)((Array)xValues).Length;
+                categoryCount = ReadNonEmptyXValues(firstSeries).Length;
             }
 
             return new ChartOperationResult
@@ -136,12 +136,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -150,7 +150,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             dynamic seriesCollection = RetryTransientChartRead(() => chart.SeriesCollection());
             int existingSeriesCount = RetryTransientChartRead(() => (int)seriesCollection.Count);
 
@@ -164,8 +164,8 @@ public sealed class ChartCommands : IChartCommands
             }
 
             dynamic firstSeries = RetryTransientChartRead(() => seriesCollection.Item(1));
-            dynamic existingXValues = RetryTransientChartRead(() => firstSeries.XValues);
-            int categoryCount = (int)((Array)existingXValues).Length;
+            Array existingXValues = ReadNonEmptyXValues(firstSeries);
+            int categoryCount = existingXValues.Length;
 
             if (values.Count != categoryCount)
             {
@@ -176,13 +176,8 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            // NOTE (discovered via real integration test, not assumed): re-entering the chart's
-            // embedded data workbook (Chart.ChartData.Activate()/.Workbook) a second time, after
-            // AddChart already Activate()d/Quit()'d it once via WriteChartData, deterministically
-            // throws COMException(0xB0D7019E) — not a transient race (10x200ms and 30x500ms
-            // retries both still failed every time). SeriesCollection.NewSeries() sets series
-            // data directly via the chart's COM object model instead, without touching the
-            // embedded workbook at all, avoiding that failure mode entirely.
+            // SeriesCollection is backed by Excel interop types that are not present in the
+            // embedded PowerPoint PIA. Keep this boundary narrowly late-bound.
             dynamic newSeries = seriesCollection.NewSeries();
             newSeries.Values = values.ToArray();
             newSeries.XValues = existingXValues;
@@ -238,12 +233,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -252,14 +247,10 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
 
-            // NOTE (discovered via real integration test, not assumed): re-entering the chart's
-            // embedded data workbook (Chart.ChartData.Activate()/.Workbook) a second time, after
-            // AddChart already Activate()d/Quit()'d it once via WriteChartData, deterministically
-            // throws COMException(0xB0D7019E) — not a transient race. As with AddSeries above, we
-            // avoid the embedded workbook entirely and manipulate SeriesCollection directly:
-            // delete all existing series, then add fresh series with the new categories/values.
+            // Avoid the embedded Excel workbook and update its late-bound SeriesCollection
+            // directly, because Excel interop types are not part of the embedded PowerPoint PIA.
             dynamic seriesCollection = RetryTransientChartRead(() => chart.SeriesCollection());
             int existingSeriesCount = RetryTransientChartRead(() => (int)seriesCollection.Count);
             for (int i = existingSeriesCount; i >= 1; i--)
@@ -306,12 +297,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -320,7 +311,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             chart.HasTitle = true;
             chart.ChartTitle.Text = title;
 
@@ -344,12 +335,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -358,7 +349,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             bool hasTitle = (bool)chart.HasTitle;
             string? title = hasTitle ? (string)chart.ChartTitle.Text : null;
 
@@ -379,7 +370,7 @@ public sealed class ChartCommands : IChartCommands
         ArgumentNullException.ThrowIfNull(axisType);
         ArgumentNullException.ThrowIfNull(title);
 
-        int? xlAxisType = ResolveAxisType(axisType);
+        PowerPoint.XlAxisType? xlAxisType = ResolveAxisType(axisType);
         if (xlAxisType is null)
         {
             return new ChartOperationResult
@@ -394,12 +385,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -408,7 +399,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             dynamic axis = chart.Axes(xlAxisType.Value);
             axis.HasTitle = true;
             axis.AxisTitle.Text = title;
@@ -430,7 +421,7 @@ public sealed class ChartCommands : IChartCommands
         ArgumentNullException.ThrowIfNull(batch);
         ArgumentNullException.ThrowIfNull(axisType);
 
-        int? xlAxisType = ResolveAxisType(axisType);
+        PowerPoint.XlAxisType? xlAxisType = ResolveAxisType(axisType);
         if (xlAxisType is null)
         {
             return new ChartOperationResult
@@ -445,12 +436,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -459,7 +450,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             dynamic axis = chart.Axes(xlAxisType.Value);
             bool hasTitle = (bool)axis.HasTitle;
             string? title = hasTitle ? (string)axis.AxisTitle.Text : null;
@@ -485,12 +476,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -499,7 +490,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             chart.HasLegend = visible;
 
             return new ChartOperationResult
@@ -512,6 +503,10 @@ public sealed class ChartCommands : IChartCommands
     }
 
     /// <inheritdoc/>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1822:Mark members as static",
+        Justification = "Kept as an instance command method for command-class consistency.")]
     public ChartOperationResult GetLegendVisibility(IPresentationBatch batch, int slideIndex, int shapeIndex)
     {
         ArgumentNullException.ThrowIfNull(batch);
@@ -521,12 +516,12 @@ public sealed class ChartCommands : IChartCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            if ((int)shape.HasChart != MsoTrue)
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            if ((int)((dynamic)shape).HasChart != MsoTrue)
             {
                 return new ChartOperationResult
                 {
@@ -535,7 +530,7 @@ public sealed class ChartCommands : IChartCommands
                 };
             }
 
-            dynamic chart = shape.Chart;
+            PowerPoint.Chart chart = shape.Chart;
             bool visible = (bool)chart.HasLegend;
 
             return new ChartOperationResult
@@ -547,175 +542,32 @@ public sealed class ChartCommands : IChartCommands
         });
     }
 
-    private const int XlCategory = 1; // XlAxisType.xlCategory
-    private const int XlValue = 2; // XlAxisType.xlValue
-
-    private static int? ResolveAxisType(string axisType) => axisType.ToLowerInvariant() switch
+    private static PowerPoint.XlAxisType? ResolveAxisType(string axisType) => axisType.ToLowerInvariant() switch
     {
-        "category" => XlCategory,
-        "value" => XlValue,
+        "category" => PowerPoint.XlAxisType.xlCategory,
+        "value" => PowerPoint.XlAxisType.xlValue,
         _ => null
     };
 
-    private static void WriteChartData(dynamic chart, IReadOnlyList<string> categories, string seriesName, IReadOnlyList<double> values)
+    private static void WriteChartData(PowerPoint.Chart chart, IReadOnlyList<string> categories, string seriesName, IReadOnlyList<double> values)
     {
-        // Modern (AddChart2) charts store their data in an embedded mini Excel workbook,
-        // reachable via Chart.ChartData.Workbook. We write cells late-bound via dynamic to
-        // avoid any dependency on the Excel interop assembly.
-        dynamic chartData = chart.ChartData;
-        chartData.Activate();
-
-        // NOTE (discovered via real integration test, not assumed): immediately after
-        // ChartData.Activate(), the embedded mini-Excel process that hosts the chart's data
-        // workbook is still starting up out-of-process; accessing ChartData.Workbook right away
-        // intermittently throws a generic COMException(0x80004005). Retry briefly until the
-        // out-of-process workbook is ready.
-        dynamic? workbook = null;
-        Exception? lastError = null;
-        for (int attempt = 0; attempt < 10 && workbook is null; attempt++)
+        // SeriesCollection is backed by Excel types that are not present in the embedded
+        // PowerPoint PIA, so this is a deliberately narrow late-bound boundary.
+        dynamic seriesCollection = RetryTransientChartRead(() => chart.SeriesCollection());
+        int existingSeriesCount = RetryTransientChartRead(() => (int)seriesCollection.Count);
+        for (int i = existingSeriesCount; i >= 1; i--)
         {
-            try
-            {
-                workbook = chartData.Workbook;
-            }
-            catch (Exception ex)
-            {
-                lastError = ex;
-                System.Threading.Thread.Sleep(200);
-            }
-        }
-        if (workbook is null)
-        {
-            throw new InvalidOperationException("Timed out waiting for the chart's embedded data workbook to become available.", lastError);
+            dynamic existingSeries = seriesCollection.Item(i);
+            existingSeries.Delete();
         }
 
-        dynamic worksheet = workbook.Worksheets[1];
-
-        // NOTE (discovered via real integration test, not assumed): during a sustained
-        // multi-hour PowerPoint session, the embedded chart-data workbook's out-of-process
-        // Excel host can transiently drop its RPC connection mid-call, surfacing as
-        // COMException(0x80010108 RPC_E_DISCONNECTED, "the object invoked has disconnected
-        // from its clients") on the very NEXT dynamic dispatch (e.g. a Cells[...].Value2
-        // write or a UsedRange access), even though Workbook itself resolved fine moments
-        // earlier. This is transient — retrying the same call shortly after succeeds. Only
-        // this specific HResult is retried; any other exception (bad argument, logic error)
-        // propagates immediately without a retry.
-        RetryOnDisconnect(() =>
-        {
-            worksheet.Cells[1, 1].Value2 = "Category";
-            worksheet.Cells[1, 2].Value2 = seriesName;
-
-            for (int i = 0; i < categories.Count; i++)
-            {
-                worksheet.Cells[i + 2, 1].Value2 = categories[i];
-                worksheet.Cells[i + 2, 2].Value2 = values[i];
-            }
-        });
-
-        // Clear any leftover default sample rows below our data.
-        dynamic usedRange = null!;
-        int usedRowCount = 0;
-        RetryOnDisconnect(() =>
-        {
-            usedRange = worksheet.UsedRange;
-            usedRowCount = (int)usedRange.Rows.Count;
-        });
-        int dataRowCount = categories.Count + 1; // + header row
-        if (usedRowCount > dataRowCount)
-        {
-            // NOTE: build the range from an A1-style string address rather than
-            // worksheet.Range[cellA, cellB] (two-Cells-object indexer) — the latter
-            // intermittently throws ArgumentException ("Could not convert argument 0") when
-            // both operands are themselves dynamic COM proxies from the embedded chart-data
-            // workbook. A plain string address avoids the ambiguous dynamic-to-dynamic
-            // indexer dispatch entirely.
-            RetryOnDisconnect(() =>
-            {
-                dynamic extraRange = worksheet.Range[$"A{dataRowCount + 1}:B{usedRowCount}"];
-                extraRange.ClearContents();
-            });
-        }
-
-        // NOTE (discovered via real integration test, not assumed): calling
-        // chart.SetSourceData(...) with a Range *object* (whether via `dynamic` DLR binding or
-        // Type.InvokeMember) fails against the modern (AddChart2) chart engine — the Range lives
-        // in the embedded chart-data workbook's process and PowerPoint's chart engine cannot
-        // resolve it as a valid Source argument here (DISP_E_TYPEMISMATCH / "Could not convert
-        // argument 0"). The modern chart engine instead expects Source as a plain sheet-qualified
-        // A1-style STRING reference (e.g. "Sheet1!$A$1:$B$4"), which SetSourceData resolves
-        // against the chart's own ChartData.Workbook internally. Using a string avoids passing a
-        // cross-process COM object entirely.
-        string worksheetName = worksheet.Name;
-        string sourceAddress = $"{worksheetName}!$A$1:$B${dataRowCount}";
-        object chartObj = chart;
-        chartObj.GetType().InvokeMember(
-            "SetSourceData",
-            System.Reflection.BindingFlags.InvokeMethod,
-            null,
-            chartObj,
-            [sourceAddress],
-            System.Globalization.CultureInfo.InvariantCulture);
-
-        // NOTE (discovered via real integration test, not assumed): Chart.SetSourceData commits
-        // the chart data and often auto-closes the embedded chart-data Excel workbook/process as
-        // part of that commit. A subsequent explicit Quit() on an already-closed workbook then
-        // throws COMException(0x80010108 RPC_E_DISCONNECTED, "the object invoked has
-        // disconnected from its clients"). Quit() is still attempted (some PowerPoint/Office
-        // versions do NOT auto-close it), but failures are expected/best-effort here.
-        try
-        {
-            workbook.Application.Quit();
-        }
-        catch (COMException)
-        {
-            // Embedded workbook was already closed by SetSourceData — nothing to do.
-        }
+        dynamic newSeries = seriesCollection.NewSeries();
+        newSeries.Values = values.ToArray();
+        newSeries.XValues = categories.ToArray();
+        newSeries.Name = seriesName;
     }
 
-    // RPC_E_DISCONNECTED — thrown when a late-bound COM call reaches an object whose
-    // out-of-process server (here, the embedded chart-data mini-Excel host) has dropped the
-    // RPC connection. Bounded, fast-fail retry: a handful of short-backoff attempts is enough
-    // to ride out a transient disconnect, while a genuinely broken COM state still fails
-    // quickly instead of hanging.
-    private const int RpcEDisconnected = unchecked((int)0x80010108);
-    private const int DisconnectRetryAttempts = 4;
-    private const int DisconnectRetryDelayMs = 150;
-
-    /// <summary>
-    /// Runs <paramref name="action"/>, retrying only on COMException(RPC_E_DISCONNECTED)
-    /// (see <see cref="RpcEDisconnected"/>). Any other exception — including a bad argument
-    /// or logic error — propagates immediately without a retry, since only the transient
-    /// disconnect is safe to silently retry.
-    /// </summary>
-    private static void RetryOnDisconnect(Action action)
-    {
-        for (int attempt = 1; attempt <= DisconnectRetryAttempts; attempt++)
-        {
-            try
-            {
-                action();
-                return;
-            }
-            catch (COMException ex) when (ex.HResult == RpcEDisconnected)
-            {
-                if (attempt == DisconnectRetryAttempts)
-                {
-                    throw new InvalidOperationException(
-                        $"The chart's embedded data workbook disconnected from its COM client (RPC_E_DISCONNECTED) after {DisconnectRetryAttempts} attempts while writing chart data.",
-                        ex);
-                }
-                System.Threading.Thread.Sleep(DisconnectRetryDelayMs);
-            }
-        }
-    }
-
-    // NOTE (discovered via real integration test, not assumed): accessing chart properties
-    // (e.g. Chart.SeriesCollection()) immediately after AddChart's WriteChartData has just
-    // Activate()d/written to/Quit()'d the embedded chart-data workbook is intermittently
-    // unstable — the chart engine can still be settling, surfacing generic COMExceptions with
-    // varying HResults (observed: 0x800706BA "RPC server is unavailable", 0x800706BE "the
-    // remote procedure call failed") rather than the specific RPC_E_DISCONNECTED handled by
-    // RetryOnDisconnect above. A short bounded retry rides out this settling window.
+    // Chart writes can settle asynchronously; a short bounded retry handles transient reads.
     private const int TransientReadRetryAttempts = 10;
     private const int TransientReadRetryDelayMs = 300;
 
@@ -747,6 +599,23 @@ public sealed class ChartCommands : IChartCommands
             }
         }
         throw new InvalidOperationException("Unreachable.", lastError);
+    }
+
+    private static Array ReadNonEmptyXValues(dynamic series)
+    {
+        Array xValues = Array.Empty<object>();
+        for (int attempt = 1; attempt <= TransientReadRetryAttempts; attempt++)
+        {
+            xValues = RetryTransientChartRead(() => (Array)series.XValues);
+            if (xValues.Length > 0 || attempt == TransientReadRetryAttempts)
+            {
+                return xValues;
+            }
+
+            Thread.Sleep(TransientReadRetryDelayMs);
+        }
+
+        return xValues;
     }
 
     private static ChartOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)

--- a/src/PowerPointMcp.Core/Chart/IChartCommands.cs
+++ b/src/PowerPointMcp.Core/Chart/IChartCommands.cs
@@ -60,6 +60,9 @@ public interface IChartCommands
     /// <summary>Shows or hides the chart's legend.</summary>
     ChartOperationResult SetLegendVisibility(IPresentationBatch batch, int slideIndex, int shapeIndex, bool visible);
 
+    /// <summary>Gets whether the chart's legend is visible.</summary>
+    ChartOperationResult GetLegendVisibility(IPresentationBatch batch, int slideIndex, int shapeIndex);
+
     /// <summary>
     /// Replaces ALL of an existing chart's data (categories and every series) in one call — the
     /// chart's previous categories and series are discarded and replaced wholesale. Unlike

--- a/src/PowerPointMcp.Core/Image/IImageCommands.cs
+++ b/src/PowerPointMcp.Core/Image/IImageCommands.cs
@@ -9,12 +9,12 @@ namespace Sbroenne.PowerPointMcp.Core.Image;
 /// </summary>
 [ServiceCategory("image", "Image")]
 [McpTool("image", Title = "Image Operations", Destructive = true, Category = "content",
-    Description = "Embed a picture file into a slide in an open presentation session.")]
+    Description = "Insert pictures into slides and adjust picture appearance with brightness/contrast, recolor, and crop operations.")]
 public interface IImageCommands
 {
     /// <summary>
-    /// Adds a picture from a local file to the given slide, embedded (not linked) into
-    /// the presentation.
+    /// Adds a picture from a local file to the given slide as an embedded shape (not linked to the
+    /// source file).
     /// </summary>
     ImageOperationResult AddPicture(IPresentationBatch batch, int slideIndex, string imagePath, float left, float top, float width, float height);
 
@@ -33,4 +33,22 @@ public interface IImageCommands
 
     /// <summary>Gets a picture shape's current recolor mode as its <c>MsoPictureColorType</c> name.</summary>
     ImageOperationResult GetRecolor(IPresentationBatch batch, int slideIndex, int shapeIndex);
+
+    /// <summary>
+    /// Sets the crop offsets (in points) for all four sides of a picture shape.
+    /// <paramref name="cropLeft"/>, <paramref name="cropTop"/>, <paramref name="cropRight"/>, and
+    /// <paramref name="cropBottom"/> specify the amount to crop from each edge. Negative values are
+    /// valid and expand the visible area beyond the image boundary; no clamping is applied.
+    /// Units: points (1 pt = 1/72 inch). Applies to picture and linked-picture shapes only.
+    /// </summary>
+    ImageOperationResult SetCrop(IPresentationBatch batch, int slideIndex, int shapeIndex,
+        float cropLeft, float cropTop, float cropRight, float cropBottom);
+
+    /// <summary>
+    /// Gets the current crop offsets (in points) for all four sides of a picture shape.
+    /// Returns <see cref="ImageOperationResult.CropLeft"/>, <see cref="ImageOperationResult.CropTop"/>,
+    /// <see cref="ImageOperationResult.CropRight"/>, and <see cref="ImageOperationResult.CropBottom"/>.
+    /// Applies to picture and linked-picture shapes only.
+    /// </summary>
+    ImageOperationResult GetCrop(IPresentationBatch batch, int slideIndex, int shapeIndex);
 }

--- a/src/PowerPointMcp.Core/Image/ImageCommands.cs
+++ b/src/PowerPointMcp.Core/Image/ImageCommands.cs
@@ -1,22 +1,31 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Image;
 
 /// <inheritdoc cref="IImageCommands"/>
 public sealed class ImageCommands : IImageCommands
 {
-    private const int MsoFalse = 0;
-    private const int MsoTrue = -1;
+    // MsoTriState values from Microsoft.Office.Core — office.dll is not referenced/embedded,
+    // so passed as raw ints via dynamic late binding (same pattern as ShapeCommands.cs).
+    private const int MsoFalse = 0;   // MsoTriState.msoFalse
+    private const int MsoTrue  = -1;  // MsoTriState.msoTrue
+
+    // MsoShapeType values for picture-shape validation.
+    // Shape.Type is Microsoft.Office.Core.MsoShapeType (Office.Core — not embedded);
+    // read via (int)((dynamic)shape).Type and compared against these named constants.
+    private const int MsoPicture       = 13; // MsoShapeType.msoPicture
+    private const int MsoLinkedPicture = 11; // MsoShapeType.msoLinkedPicture
 
     // MsoPictureColorType member name -> value, for SetRecolor/GetRecolor
     // (learn.microsoft.com/office/vba/api/office.msopicturecolortype) — verified live via
     // PictureEffectsDiagTests (a temporary diagnostic spike, since removed).
     private static readonly Dictionary<string, int> PictureColorTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["msoPictureAutomatic"] = 1,
-        ["msoPictureGrayscale"] = 2,
+        ["msoPictureAutomatic"]     = 1,
+        ["msoPictureGrayscale"]     = 2,
         ["msoPictureBlackAndWhite"] = 3,
-        ["msoPictureWatermark"] = 4,
+        ["msoPictureWatermark"]     = 4,
     };
 
     private static readonly Dictionary<int, string> PictureColorTypesByValue =
@@ -53,19 +62,19 @@ public sealed class ImageCommands : IImageCommands
             }
 
             // Shapes.AddPicture(FileName, LinkToFile, SaveWithDocument, Left, Top, Width, Height)
-            // — LinkToFile/SaveWithDocument are Microsoft.Office.Core.MsoTriState (office.dll)
-            // typed, so called late-bound via dynamic with the raw int constants, same pattern
-            // as elsewhere in this project. LinkToFile=False, SaveWithDocument=True embeds the
-            // image directly in the .pptx rather than linking to the external file.
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.Shapes.AddPicture(fullImagePath, MsoFalse, MsoTrue, left, top, width, height);
-            int newIndex = (int)slide.Shapes.Count; // always appended
+            // — LinkToFile/SaveWithDocument are Microsoft.Office.Core.MsoTriState (office.dll),
+            // so called late-bound via dynamic with the raw int constants (same pattern as
+            // ShapeCommands.cs). LinkToFile=False, SaveWithDocument=True embeds the image
+            // directly in the .pptx rather than linking to the external file.
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            ((dynamic)slide.Shapes).AddPicture(fullImagePath, MsoFalse, MsoTrue, left, top, width, height);
+            int newIndex = slide.Shapes.Count; // always appended
 
             return new ImageOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count
+                ShapeCount = slide.Shapes.Count
             };
         });
     }
@@ -75,17 +84,24 @@ public sealed class ImageCommands : IImageCommands
     {
         ArgumentNullException.ThrowIfNull(batch);
 
+        // Pre-COM range validation (Rule 1b: checked before touching COM, not catch-and-return).
+        var rangeValidation = ValidateBrightnessContrastRange(brightness, contrast);
+        if (rangeValidation is not null) return rangeValidation;
+
         return batch.Execute((ctx, ct) =>
         {
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            var slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic pictureFormat = shape.PictureFormat;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            var typeValidation = ValidatePictureShape(shape, slideIndex, shapeIndex);
+            if (typeValidation is not null) return typeValidation;
+
+            PowerPoint.PictureFormat pictureFormat = shape.PictureFormat;
             pictureFormat.Brightness = brightness;
             pictureFormat.Contrast = contrast;
 
@@ -109,19 +125,22 @@ public sealed class ImageCommands : IImageCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            var slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic pictureFormat = shape.PictureFormat;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            var typeValidation = ValidatePictureShape(shape, slideIndex, shapeIndex);
+            if (typeValidation is not null) return typeValidation;
+
+            PowerPoint.PictureFormat pictureFormat = shape.PictureFormat;
 
             return new ImageOperationResult
             {
                 Success = true,
                 ShapeIndex = shapeIndex,
-                Brightness = (float)pictureFormat.Brightness,
-                Contrast = (float)pictureFormat.Contrast,
+                Brightness = pictureFormat.Brightness,
+                Contrast = pictureFormat.Contrast,
             };
         });
     }
@@ -146,13 +165,17 @@ public sealed class ImageCommands : IImageCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            var slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic pictureFormat = shape.PictureFormat;
-            pictureFormat.ColorType = typeValue;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            var typeValidation = ValidatePictureShape(shape, slideIndex, shapeIndex);
+            if (typeValidation is not null) return typeValidation;
+
+            // PictureFormat.ColorType is MsoPictureColorType (Microsoft.Office.Core — not embedded);
+            // assigned via dynamic late binding with the pre-validated integer value.
+            ((dynamic)shape.PictureFormat).ColorType = typeValue;
 
             return new ImageOperationResult
             {
@@ -173,14 +196,18 @@ public sealed class ImageCommands : IImageCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            var slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic pictureFormat = shape.PictureFormat;
-            int typeValue = (int)pictureFormat.ColorType;
-            string typeName = PictureColorTypesByValue.TryGetValue(typeValue, out var name) ? name : $"unknown({typeValue})";
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            var typeValidation = ValidatePictureShape(shape, slideIndex, shapeIndex);
+            if (typeValidation is not null) return typeValidation;
+
+            // PictureFormat.ColorType is MsoPictureColorType (Microsoft.Office.Core — not embedded);
+            // read via dynamic late binding.
+            int rawColorType = (int)((dynamic)shape.PictureFormat).ColorType;
+            string typeName = PictureColorTypesByValue.TryGetValue(rawColorType, out var name) ? name : $"unknown({rawColorType})";
 
             return new ImageOperationResult
             {
@@ -189,6 +216,122 @@ public sealed class ImageCommands : IImageCommands
                 ColorTypeName = typeName,
             };
         });
+    }
+
+    /// <inheritdoc/>
+    public ImageOperationResult SetCrop(IPresentationBatch batch, int slideIndex, int shapeIndex,
+        float cropLeft, float cropTop, float cropRight, float cropBottom)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            var typeValidation = ValidatePictureShape(shape, slideIndex, shapeIndex);
+            if (typeValidation is not null) return typeValidation;
+
+            // CropLeft/Top/Right/Bottom are typed float properties on the embedded PIA.
+            // Negative values are valid (expand visible area beyond image boundary); no clamping.
+            PowerPoint.PictureFormat pictureFormat = shape.PictureFormat;
+            pictureFormat.CropLeft   = cropLeft;
+            pictureFormat.CropTop    = cropTop;
+            pictureFormat.CropRight  = cropRight;
+            pictureFormat.CropBottom = cropBottom;
+
+            return new ImageOperationResult
+            {
+                Success    = true,
+                ShapeIndex = shapeIndex,
+                CropLeft   = pictureFormat.CropLeft,
+                CropTop    = pictureFormat.CropTop,
+                CropRight  = pictureFormat.CropRight,
+                CropBottom = pictureFormat.CropBottom,
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ImageOperationResult GetCrop(IPresentationBatch batch, int slideIndex, int shapeIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            var typeValidation = ValidatePictureShape(shape, slideIndex, shapeIndex);
+            if (typeValidation is not null) return typeValidation;
+
+            PowerPoint.PictureFormat pictureFormat = shape.PictureFormat;
+
+            return new ImageOperationResult
+            {
+                Success    = true,
+                ShapeIndex = shapeIndex,
+                CropLeft   = pictureFormat.CropLeft,
+                CropTop    = pictureFormat.CropTop,
+                CropRight  = pictureFormat.CropRight,
+                CropBottom = pictureFormat.CropBottom,
+            };
+        });
+    }
+
+    /// <summary>
+    /// Validates that brightness and contrast are each in [0, 1].
+    /// Called before <c>batch.Execute</c> so range errors are caught without touching COM.
+    /// </summary>
+    private static ImageOperationResult? ValidateBrightnessContrastRange(float brightness, float contrast)
+    {
+        if (brightness < 0f || brightness > 1f)
+        {
+            return new ImageOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Brightness {brightness} is out of range; must be between 0 and 1 (inclusive)."
+            };
+        }
+        if (contrast < 0f || contrast > 1f)
+        {
+            return new ImageOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Contrast {contrast} is out of range; must be between 0 and 1 (inclusive)."
+            };
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="shape"/> is a picture or linked picture (required before
+    /// accessing <c>PictureFormat</c> members). <c>Shape.Type</c> is
+    /// <c>Microsoft.Office.Core.MsoShapeType</c> (Office.Core — not embedded), so the check
+    /// uses dynamic late binding with named integer constants.
+    /// </summary>
+    private static ImageOperationResult? ValidatePictureShape(PowerPoint.Shape shape, int slideIndex, int shapeIndex)
+    {
+        int shapeType = (int)((dynamic)shape).Type;
+        if (shapeType != MsoPicture && shapeType != MsoLinkedPicture)
+        {
+            return new ImageOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Shape {shapeIndex} on slide {slideIndex} is not a picture (shape type={shapeType}). PictureFormat operations require a picture or linked picture shape."
+            };
+        }
+        return null;
     }
 
     private static ImageOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)

--- a/src/PowerPointMcp.Core/Image/ImageOperationResult.cs
+++ b/src/PowerPointMcp.Core/Image/ImageOperationResult.cs
@@ -1,7 +1,7 @@
 namespace Sbroenne.PowerPointMcp.Core.Image;
 
 /// <summary>
-/// Result of an image operation (add picture).
+/// Result of an image operation.
 /// </summary>
 /// <remarks>
 /// Follows the same Success/ErrorMessage invariant as the other domain results (Rule 1).
@@ -28,4 +28,16 @@ public sealed class ImageOperationResult
 
     /// <summary>The MsoPictureColorType name of the picture's recolor mode, if applicable.</summary>
     public string? ColorTypeName { get; init; }
+
+    /// <summary>Crop offset for the left edge of the picture, in points. Null when not applicable.</summary>
+    public float? CropLeft { get; init; }
+
+    /// <summary>Crop offset for the top edge of the picture, in points. Null when not applicable.</summary>
+    public float? CropTop { get; init; }
+
+    /// <summary>Crop offset for the right edge of the picture, in points. Null when not applicable.</summary>
+    public float? CropRight { get; init; }
+
+    /// <summary>Crop offset for the bottom edge of the picture, in points. Null when not applicable.</summary>
+    public float? CropBottom { get; init; }
 }

--- a/src/PowerPointMcp.Core/Master/MasterCommands.cs
+++ b/src/PowerPointMcp.Core/Master/MasterCommands.cs
@@ -115,8 +115,8 @@ public sealed class MasterCommands : IMasterCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic master = ctx.Presentation.SlideMaster;
-            int rgb = (int)master.Background.Fill.ForeColor.RGB;
+            PowerPoint.Master master = GetSlideMaster(ctx);
+            int rgb = master.Background.Fill.ForeColor.RGB;
 
             return new MasterOperationResult { Success = true, ColorRgb = rgb };
         });
@@ -133,7 +133,7 @@ public sealed class MasterCommands : IMasterCommands
             // function), not the more common 0x00RRGGBB.
             int rgb = red + (green << 8) + (blue << 16);
 
-            dynamic master = ctx.Presentation.SlideMaster;
+            PowerPoint.Master master = GetSlideMaster(ctx);
             master.Background.Fill.Solid();
             master.Background.Fill.ForeColor.RGB = rgb;
 
@@ -165,12 +165,13 @@ public sealed class MasterCommands : IMasterCommands
             int rgb1 = red1 + (green1 << 8) + (blue1 << 16);
             int rgb2 = red2 + (green2 << 8) + (blue2 << 16);
 
-            dynamic master = ctx.Presentation.SlideMaster;
+            PowerPoint.Master master = GetSlideMaster(ctx);
             // TwoColorGradient() must be called BEFORE setting ForeColor/BackColor — it resets
             // both colors to PowerPoint's defaults as a side effect (verified via diagnostic spike).
-            master.Background.Fill.TwoColorGradient(styleValue, gradientVariant);
-            master.Background.Fill.ForeColor.RGB = rgb1;
-            master.Background.Fill.BackColor.RGB = rgb2;
+            dynamic fill = master.Background.Fill;
+            fill.TwoColorGradient(styleValue, gradientVariant);
+            fill.ForeColor.RGB = rgb1;
+            fill.BackColor.RGB = rgb2;
 
             return new MasterOperationResult
             {
@@ -190,8 +191,9 @@ public sealed class MasterCommands : IMasterCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic master = ctx.Presentation.SlideMaster;
-            int fillType = (int)master.Background.Fill.Type;
+            PowerPoint.Master master = GetSlideMaster(ctx);
+            dynamic fill = master.Background.Fill;
+            int fillType = (int)fill.Type;
             const int MsoFillGradient = 3;
             if (fillType != MsoFillGradient)
             {
@@ -202,10 +204,10 @@ public sealed class MasterCommands : IMasterCommands
                 };
             }
 
-            int rgb1 = (int)master.Background.Fill.ForeColor.RGB;
-            int rgb2 = (int)master.Background.Fill.BackColor.RGB;
-            int styleValue = (int)master.Background.Fill.GradientStyle;
-            int variant = (int)master.Background.Fill.GradientVariant;
+            int rgb1 = (int)fill.ForeColor.RGB;
+            int rgb2 = (int)fill.BackColor.RGB;
+            int styleValue = (int)fill.GradientStyle;
+            int variant = (int)fill.GradientVariant;
             string? styleName = GradientStylesByValue.GetValueOrDefault(styleValue);
 
             return new MasterOperationResult
@@ -226,21 +228,21 @@ public sealed class MasterCommands : IMasterCommands
     /// condition for masters built from unusual/blank layouts, handled by callers as a validation
     /// failure (Rule 1b).
     /// </summary>
-    private static dynamic? FindPlaceholder(PresentationContext ctx, PowerPoint.PpPlaceholderType type)
+    private static PowerPoint.Shape? FindPlaceholder(PresentationContext ctx, PowerPoint.PpPlaceholderType type)
     {
-        dynamic master = ctx.Presentation.SlideMaster;
-        int shapeCount = (int)master.Shapes.Count;
+        PowerPoint.Master master = GetSlideMaster(ctx);
+        int shapeCount = master.Shapes.Count;
 
         for (int i = 1; i <= shapeCount; i++)
         {
-            dynamic shape = master.Shapes[i];
-            bool hasPlaceholder = (int)shape.Type == 14 /* msoPlaceholder */;
+            PowerPoint.Shape shape = master.Shapes[i];
+            bool hasPlaceholder = (int)((dynamic)shape).Type == 14 /* msoPlaceholder */;
             if (!hasPlaceholder)
             {
                 continue;
             }
 
-            var placeholderType = (PowerPoint.PpPlaceholderType)shape.PlaceholderFormat.Type;
+            PowerPoint.PpPlaceholderType placeholderType = shape.PlaceholderFormat.Type;
             if (placeholderType == type)
             {
                 return shape;
@@ -250,12 +252,21 @@ public sealed class MasterCommands : IMasterCommands
         return null;
     }
 
-    private static MasterOperationResult ReadFont(dynamic placeholder)
+    private static PowerPoint.Master GetSlideMaster(PresentationContext ctx)
     {
-        string fontName = (string)placeholder.TextFrame.TextRange.Font.Name;
-        float fontSize = (float)placeholder.TextFrame.TextRange.Font.Size;
-        bool bold = (int)placeholder.TextFrame.TextRange.Font.Bold == MsoTrue;
-        int colorRgb = (int)placeholder.TextFrame.TextRange.Font.Color.RGB;
+        // The embedded NoPIA getter for Presentation.SlideMaster hangs indefinitely in live
+        // PowerPoint. Dispatch only that getter through IDispatch, then return to typed PIA access.
+        dynamic presentation = ctx.Presentation;
+        return (PowerPoint.Master)presentation.SlideMaster;
+    }
+
+    private static MasterOperationResult ReadFont(PowerPoint.Shape placeholder)
+    {
+        dynamic font = placeholder.TextFrame.TextRange.Font;
+        string fontName = (string)font.Name;
+        float fontSize = (float)font.Size;
+        bool bold = (int)font.Bold == MsoTrue;
+        int colorRgb = (int)font.Color.RGB;
 
         return new MasterOperationResult
         {
@@ -268,7 +279,7 @@ public sealed class MasterCommands : IMasterCommands
     }
 
     private static MasterOperationResult ApplyFont(
-        dynamic placeholder,
+        PowerPoint.Shape placeholder,
         string? fontName,
         float? fontSize,
         bool? bold,
@@ -276,19 +287,21 @@ public sealed class MasterCommands : IMasterCommands
         byte? green,
         byte? blue)
     {
+        dynamic font = placeholder.TextFrame.TextRange.Font;
+
         if (fontName is not null)
         {
-            placeholder.TextFrame.TextRange.Font.Name = fontName;
+            font.Name = fontName;
         }
 
         if (fontSize is not null)
         {
-            placeholder.TextFrame.TextRange.Font.Size = fontSize.Value;
+            font.Size = fontSize.Value;
         }
 
         if (bold is not null)
         {
-            placeholder.TextFrame.TextRange.Font.Bold = bold.Value ? MsoTrue : MsoFalse;
+            font.Bold = bold.Value ? MsoTrue : MsoFalse;
         }
 
         if (red is not null || green is not null || blue is not null)
@@ -296,7 +309,7 @@ public sealed class MasterCommands : IMasterCommands
             // Missing channels default to 0 — callers are expected to pass all three together
             // when setting color (mirrors TextFrameCommands.SetFontColor's all-or-nothing shape).
             int rgb = (red ?? 0) + ((green ?? 0) << 8) + ((blue ?? 0) << 16);
-            placeholder.TextFrame.TextRange.Font.Color.RGB = rgb;
+            font.Color.RGB = rgb;
         }
 
         // Re-read from the placeholder so the result reflects the values actually applied

--- a/src/PowerPointMcp.Core/Notes/NotesCommands.cs
+++ b/src/PowerPointMcp.Core/Notes/NotesCommands.cs
@@ -1,10 +1,13 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Notes;
 
 /// <inheritdoc cref="INotesCommands"/>
 public sealed class NotesCommands : INotesCommands
 {
+    private const int MsoShapePlaceholder = 14;
+
     /// <inheritdoc/>
     public NotesOperationResult SetNotesText(IPresentationBatch batch, int slideIndex, string text)
     {
@@ -16,7 +19,7 @@ public sealed class NotesCommands : INotesCommands
             var validation = ValidateSlideIndex(ctx, slideIndex);
             if (validation is not null) return validation;
 
-            dynamic notesTextShape = FindNotesTextShape(ctx, slideIndex);
+            PowerPoint.Shape notesTextShape = FindNotesTextShape(ctx, slideIndex);
             notesTextShape.TextFrame.TextRange.Text = text;
 
             return new NotesOperationResult { Success = true, NotesText = text };
@@ -33,7 +36,7 @@ public sealed class NotesCommands : INotesCommands
             var validation = ValidateSlideIndex(ctx, slideIndex);
             if (validation is not null) return validation;
 
-            dynamic notesTextShape = FindNotesTextShape(ctx, slideIndex);
+            PowerPoint.Shape notesTextShape = FindNotesTextShape(ctx, slideIndex);
             string text = (string)notesTextShape.TextFrame.TextRange.Text;
 
             return new NotesOperationResult { Success = true, NotesText = text };
@@ -50,7 +53,7 @@ public sealed class NotesCommands : INotesCommands
     /// is ppPlaceholderBody rather than hard-coding index 2, in case a custom notes master
     /// reorders placeholders.
     /// </remarks>
-    private static dynamic FindNotesTextShape(PresentationContext ctx, int slideIndex)
+    private static PowerPoint.Shape FindNotesTextShape(PresentationContext ctx, int slideIndex)
     {
         dynamic notesPage = ctx.Presentation.Slides[slideIndex].NotesPage;
         dynamic shapes = notesPage.Shapes;
@@ -59,13 +62,14 @@ public sealed class NotesCommands : INotesCommands
         for (int i = 1; i <= count; i++)
         {
             dynamic shape = shapes[i];
-            bool isPlaceholder = (int)shape.Type == 14; // msoPlaceholder
+            bool isPlaceholder = (int)shape.Type == MsoShapePlaceholder;
             if (!isPlaceholder) continue;
 
-            int placeholderType = (int)shape.PlaceholderFormat.Type;
-            if (placeholderType == 2) // PpPlaceholderType.ppPlaceholderBody
+            PowerPoint.PpPlaceholderType placeholderType =
+                (PowerPoint.PpPlaceholderType)shape.PlaceholderFormat.Type;
+            if (placeholderType == PowerPoint.PpPlaceholderType.ppPlaceholderBody)
             {
-                return shape;
+                return (PowerPoint.Shape)shape;
             }
         }
 

--- a/src/PowerPointMcp.Core/Shape/ShapeCommands.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeCommands.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Shape;
 
@@ -18,9 +19,9 @@ public sealed class ShapeCommands : IShapeCommands
     // PowerPoint.PpActionSetting.ppMouseClick / Office.MsoPresentationTarget-related action
     // constants — office.dll types, so used as raw ints per the project's dynamic-COM
     // convention (see MsoShapeRectangle above). Verified live via ActionSettings(ppMouseClick).
-    private const int MsoMouseClick = 1; // PpActionSetting.ppMouseClick
-    private const int PpActionNone = 0; // PpActionType.ppActionNone
-    private const int PpActionHyperlink = 7; // PpActionType.ppActionHyperlink
+    private const PowerPoint.PpMouseActivation MouseClickActivation = PowerPoint.PpMouseActivation.ppMouseClick;
+    private const PowerPoint.PpActionType PpActionNone = PowerPoint.PpActionType.ppActionNone;
+    private const PowerPoint.PpActionType PpActionHyperlink = PowerPoint.PpActionType.ppActionHyperlink;
 
     // MsoShadowStyle constant for SetShadow — verified live via ShapeEffectsDiagTests (a
     // temporary diagnostic spike, since removed): shape.Shadow.Type = 20 ("offset" style shadow)
@@ -149,20 +150,21 @@ public sealed class ShapeCommands : IShapeCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.Shapes.AddShape(MsoShapeRectangle, left, top, width, height);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynShapes = slide.Shapes;
+            dynShapes.AddShape(MsoShapeRectangle, left, top, width, height);
             // NOTE: discovered via integration test — accessing the newly-added shape's
             // .Index property dynamically threw a RuntimeBinderException ("'System.__ComObject'
             // does not contain a definition for 'Index'"), a NoPIA/late-binding quirk on the
             // COM object returned from AddShape. Sidestepped entirely: since shapes are always
             // appended, the new shape's 1-based index is simply the new Shapes.Count.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
 
             return new ShapeOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count
+                ShapeCount = slide.Shapes.Count
             };
         });
     }
@@ -178,17 +180,18 @@ public sealed class ShapeCommands : IShapeCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            dynamic shape = slide.Shapes.AddTextbox(MsoTextOrientationHorizontal, left, top, width, height);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynShapes = slide.Shapes;
+            PowerPoint.Shape shape = dynShapes.AddTextbox(MsoTextOrientationHorizontal, left, top, width, height);
             shape.TextFrame.TextRange.Text = text;
             // Same NoPIA late-binding quirk as AddRectangle — avoid shape.Index, use Count.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
 
             return new ShapeOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count
+                ShapeCount = slide.Shapes.Count
             };
         });
     }
@@ -213,16 +216,17 @@ public sealed class ShapeCommands : IShapeCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.Shapes.AddShape(typeValue, left, top, width, height);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynShapes = slide.Shapes;
+            dynShapes.AddShape(typeValue, left, top, width, height);
             // Same NoPIA late-binding quirk as AddRectangle — avoid shape.Index, use Count.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
 
             return new ShapeOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count,
+                ShapeCount = slide.Shapes.Count,
                 ShapeTypeName = shapeType
             };
         });
@@ -238,16 +242,16 @@ public sealed class ShapeCommands : IShapeCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             slide.Shapes.AddLine(beginX, beginY, endX, endY);
             // Same NoPIA late-binding quirk as AddRectangle — avoid shape.Index, use Count.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
 
             return new ShapeOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count,
+                ShapeCount = slide.Shapes.Count,
                 BeginX = beginX,
                 BeginY = beginY,
                 EndX = endX,
@@ -276,16 +280,17 @@ public sealed class ShapeCommands : IShapeCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.Shapes.AddConnector(typeValue, beginX, beginY, endX, endY);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynShapes = slide.Shapes;
+            dynShapes.AddConnector(typeValue, beginX, beginY, endX, endY);
             // Same NoPIA late-binding quirk as AddRectangle — avoid shape.Index, use Count.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
 
             return new ShapeOperationResult
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count,
+                ShapeCount = slide.Shapes.Count,
                 ConnectorTypeName = connectorType,
                 BeginX = beginX,
                 BeginY = beginY,
@@ -408,7 +413,7 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
             int rgb = red + (green << 8) + (blue << 16);
             shape.Fill.Solid();
             shape.Fill.ForeColor.RGB = rgb;
@@ -431,8 +436,8 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            int rgb = (int)shape.Fill.ForeColor.RGB;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            int rgb = shape.Fill.ForeColor.RGB;
 
             return new ShapeOperationResult { Success = true, ShapeIndex = shapeIndex, ColorRgb = rgb };
         });
@@ -475,27 +480,28 @@ public sealed class ShapeCommands : IShapeCommands
                 dashStyleValue = resolvedDashStyle;
             }
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            dynamic line = shape.Line;
 
             if (red is not null || green is not null || blue is not null)
             {
                 int rgb = (red ?? 0) + ((green ?? 0) << 8) + ((blue ?? 0) << 16);
-                shape.Line.ForeColor.RGB = rgb;
+                line.ForeColor.RGB = rgb;
             }
 
             if (weight is not null)
             {
-                shape.Line.Weight = weight.Value;
+                line.Weight = weight.Value;
             }
 
             if (dashStyleValue is not null)
             {
-                shape.Line.DashStyle = dashStyleValue.Value;
+                line.DashStyle = dashStyleValue.Value;
             }
 
             if (visible is not null)
             {
-                shape.Line.Visible = visible.Value ? MsoTrue : MsoFalse;
+                line.Visible = visible.Value ? MsoTrue : MsoFalse;
             }
 
             return ReadLine(shape, shapeIndex);
@@ -516,7 +522,7 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
             return ReadLine(shape, shapeIndex);
         });
     }
@@ -968,8 +974,8 @@ public sealed class ShapeCommands : IShapeCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            int shapeCount = (int)slide.Shapes.Count;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            int shapeCount = slide.Shapes.Count;
 
             if (shapeIndexes.Count < 2)
             {
@@ -987,10 +993,10 @@ public sealed class ShapeCommands : IShapeCommands
             }
 
             object[] indexArray = shapeIndexes.Select(i => (object)i).ToArray();
-            dynamic range = slide.Shapes.Range(indexArray);
+            PowerPoint.ShapeRange range = slide.Shapes.Range(indexArray);
             range.Group();
 
-            return new ShapeOperationResult { Success = true, ShapeCount = (int)slide.Shapes.Count };
+            return new ShapeOperationResult { Success = true, ShapeCount = slide.Shapes.Count };
         });
     }
 
@@ -1004,19 +1010,19 @@ public sealed class ShapeCommands : IShapeCommands
             var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
             if (slideValidation is not null) return slideValidation;
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            var shapeValidation = ValidateShapeIndex((int)slide.Shapes.Count, shapeIndex);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic ungrouped = shape.Ungroup();
-            int ungroupedCount = (int)ungrouped.Count;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            PowerPoint.ShapeRange ungrouped = shape.Ungroup();
+            int ungroupedCount = ungrouped.Count;
 
             return new ShapeOperationResult
             {
                 Success = true,
                 UngroupedShapeCount = ungroupedCount,
-                ShapeCount = (int)slide.Shapes.Count
+                ShapeCount = slide.Shapes.Count
             };
         });
     }
@@ -1078,10 +1084,10 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
             shape.AlternativeText = altText;
 
-            return new ShapeOperationResult { Success = true, ShapeIndex = shapeIndex, AltText = (string)shape.AlternativeText };
+            return new ShapeOperationResult { Success = true, ShapeIndex = shapeIndex, AltText = shape.AlternativeText };
         });
     }
 
@@ -1099,9 +1105,9 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
 
-            return new ShapeOperationResult { Success = true, ShapeIndex = shapeIndex, AltText = (string)shape.AlternativeText };
+            return new ShapeOperationResult { Success = true, ShapeIndex = shapeIndex, AltText = shape.AlternativeText };
         });
     }
 
@@ -1120,11 +1126,11 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
             // ActionSettings(ppMouseClick).Hyperlink.Address — verified live: setting Address
             // automatically flips the action setting's Action to ppActionHyperlink; no separate
             // "enable hyperlink" step is needed.
-            dynamic actionSetting = shape.ActionSettings[MsoMouseClick];
+            PowerPoint.ActionSetting actionSetting = shape.ActionSettings[MouseClickActivation];
             actionSetting.Hyperlink.Address = address;
             if (screenTip is not null)
             {
@@ -1136,8 +1142,8 @@ public sealed class ShapeCommands : IShapeCommands
                 Success = true,
                 ShapeIndex = shapeIndex,
                 HasHyperlink = true,
-                HyperlinkAddress = (string)actionSetting.Hyperlink.Address,
-                HyperlinkScreenTip = (string)actionSetting.Hyperlink.ScreenTip
+                HyperlinkAddress = actionSetting.Hyperlink.Address,
+                HyperlinkScreenTip = actionSetting.Hyperlink.ScreenTip
             };
         });
     }
@@ -1156,9 +1162,9 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic actionSetting = shape.ActionSettings[MsoMouseClick];
-            int action = (int)actionSetting.Action;
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            PowerPoint.ActionSetting actionSetting = shape.ActionSettings[MouseClickActivation];
+            PowerPoint.PpActionType action = actionSetting.Action;
             bool hasHyperlink = action == PpActionHyperlink;
 
             return new ShapeOperationResult
@@ -1166,8 +1172,8 @@ public sealed class ShapeCommands : IShapeCommands
                 Success = true,
                 ShapeIndex = shapeIndex,
                 HasHyperlink = hasHyperlink,
-                HyperlinkAddress = hasHyperlink ? (string)actionSetting.Hyperlink.Address : null,
-                HyperlinkScreenTip = hasHyperlink ? (string)actionSetting.Hyperlink.ScreenTip : null
+                HyperlinkAddress = hasHyperlink ? actionSetting.Hyperlink.Address : null,
+                HyperlinkScreenTip = hasHyperlink ? actionSetting.Hyperlink.ScreenTip : null
             };
         });
     }
@@ -1186,8 +1192,8 @@ public sealed class ShapeCommands : IShapeCommands
             var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
             if (shapeValidation is not null) return shapeValidation;
 
-            dynamic shape = slide.Shapes[shapeIndex];
-            dynamic actionSetting = shape.ActionSettings[MsoMouseClick];
+            PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+            PowerPoint.ActionSetting actionSetting = shape.ActionSettings[MouseClickActivation];
             actionSetting.Action = PpActionNone;
 
             return new ShapeOperationResult
@@ -1199,15 +1205,16 @@ public sealed class ShapeCommands : IShapeCommands
         });
     }
 
-    private static ShapeOperationResult ReadLine(dynamic shape, int shapeIndex)
+    private static ShapeOperationResult ReadLine(PowerPoint.Shape shape, int shapeIndex)
     {
-        int rgb = (int)shape.Line.ForeColor.RGB;
-        float weight = (float)shape.Line.Weight;
-        int dashStyleValue = (int)shape.Line.DashStyle;
+        dynamic line = shape.Line;
+        int rgb = (int)line.ForeColor.RGB;
+        float weight = (float)line.Weight;
+        int dashStyleValue = (int)line.DashStyle;
         string dashStyleName = LineDashStylesByValue.TryGetValue(dashStyleValue, out var name)
             ? name
             : $"unknown ({dashStyleValue})";
-        bool visible = (int)shape.Line.Visible == MsoTrue;
+        bool visible = (int)line.Visible == MsoTrue;
 
         return new ShapeOperationResult
         {

--- a/src/PowerPointMcp.Core/Slide/SlideCommands.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideCommands.cs
@@ -116,8 +116,8 @@ public sealed class SlideCommands : ISlideCommands
 
             // Duplicate() returns a SlideRange containing the single new slide, inserted
             // immediately after the source slide.
-            dynamic duplicateRange = ctx.Presentation.Slides[slideIndex].Duplicate();
-            int newSlideIndex = (int)duplicateRange[1].SlideIndex;
+            PowerPoint.SlideRange duplicateRange = ctx.Presentation.Slides[slideIndex].Duplicate();
+            int newSlideIndex = duplicateRange[1].SlideIndex;
 
             return new SlideOperationResult
             {
@@ -185,8 +185,9 @@ public sealed class SlideCommands : ISlideCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.FollowMasterBackground = MsoFalse;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynSlide = slide;
+            dynSlide.FollowMasterBackground = MsoFalse;
             int rgb = red + (green << 8) + (blue << 16);
             slide.Background.Fill.Solid();
             slide.Background.Fill.ForeColor.RGB = rgb;
@@ -219,9 +220,10 @@ public sealed class SlideCommands : ISlideCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            bool followsMaster = (int)slide.FollowMasterBackground == MsoTrue;
-            int rgb = (int)slide.Background.Fill.ForeColor.RGB;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynSlide = slide;
+            bool followsMaster = (int)dynSlide.FollowMasterBackground == MsoTrue;
+            int rgb = slide.Background.Fill.ForeColor.RGB;
 
             return new SlideOperationResult
             {
@@ -269,13 +271,15 @@ public sealed class SlideCommands : ISlideCommands
             int rgb1 = red1 + (green1 << 8) + (blue1 << 16);
             int rgb2 = red2 + (green2 << 8) + (blue2 << 16);
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.FollowMasterBackground = MsoFalse;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynSlide = slide;
+            dynSlide.FollowMasterBackground = MsoFalse;
             // TwoColorGradient() must be called BEFORE setting ForeColor/BackColor — it resets
             // both colors to PowerPoint's defaults as a side effect (verified via diagnostic spike).
-            slide.Background.Fill.TwoColorGradient(styleValue, gradientVariant);
-            slide.Background.Fill.ForeColor.RGB = rgb1;
-            slide.Background.Fill.BackColor.RGB = rgb2;
+            dynamic fill = slide.Background.Fill;
+            fill.TwoColorGradient(styleValue, gradientVariant);
+            fill.ForeColor.RGB = rgb1;
+            fill.BackColor.RGB = rgb2;
 
             return new SlideOperationResult
             {
@@ -308,8 +312,9 @@ public sealed class SlideCommands : ISlideCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            int fillType = (int)slide.Background.Fill.Type;
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic fill = slide.Background.Fill;
+            int fillType = (int)fill.Type;
             const int MsoFillGradient = 3;
             if (fillType != MsoFillGradient)
             {
@@ -321,10 +326,10 @@ public sealed class SlideCommands : ISlideCommands
                 };
             }
 
-            int rgb1 = (int)slide.Background.Fill.ForeColor.RGB;
-            int rgb2 = (int)slide.Background.Fill.BackColor.RGB;
-            int styleValue = (int)slide.Background.Fill.GradientStyle;
-            int variant = (int)slide.Background.Fill.GradientVariant;
+            int rgb1 = (int)fill.ForeColor.RGB;
+            int rgb2 = (int)fill.BackColor.RGB;
+            int styleValue = (int)fill.GradientStyle;
+            int variant = (int)fill.GradientVariant;
             string? styleName = GradientStylesByValue.GetValueOrDefault(styleValue);
 
             return new SlideOperationResult
@@ -347,8 +352,8 @@ public sealed class SlideCommands : ISlideCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic sectionProperties = ctx.Presentation.SectionProperties;
-            int currentCount = (int)sectionProperties.Count;
+            PowerPoint.SectionProperties sectionProperties = ctx.Presentation.SectionProperties;
+            int currentCount = sectionProperties.Count;
 
             if (sectionIndex < 1 || sectionIndex > currentCount + 1)
             {
@@ -361,14 +366,14 @@ public sealed class SlideCommands : ISlideCommands
             }
 
             int newSectionIndex = sectionName is null
-                ? (int)sectionProperties.AddSection(sectionIndex)
-                : (int)sectionProperties.AddSection(sectionIndex, sectionName);
+                ? sectionProperties.AddSection(sectionIndex)
+                : sectionProperties.AddSection(sectionIndex, sectionName);
 
             return new SlideOperationResult
             {
                 Success = true,
                 SectionIndex = newSectionIndex,
-                SectionCount = (int)sectionProperties.Count
+                SectionCount = sectionProperties.Count
             };
         });
     }
@@ -381,8 +386,8 @@ public sealed class SlideCommands : ISlideCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic sectionProperties = ctx.Presentation.SectionProperties;
-            int currentCount = (int)sectionProperties.Count;
+            PowerPoint.SectionProperties sectionProperties = ctx.Presentation.SectionProperties;
+            int currentCount = sectionProperties.Count;
 
             if (sectionIndex < 1 || sectionIndex > currentCount)
             {
@@ -413,8 +418,8 @@ public sealed class SlideCommands : ISlideCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic sectionProperties = ctx.Presentation.SectionProperties;
-            int currentCount = (int)sectionProperties.Count;
+            PowerPoint.SectionProperties sectionProperties = ctx.Presentation.SectionProperties;
+            int currentCount = sectionProperties.Count;
 
             if (sectionIndex < 1 || sectionIndex > currentCount)
             {
@@ -435,7 +440,7 @@ public sealed class SlideCommands : ISlideCommands
             {
                 Success = true,
                 SectionIndex = sectionIndex,
-                SectionCount = (int)sectionProperties.Count
+                SectionCount = sectionProperties.Count
             };
         });
     }
@@ -447,11 +452,11 @@ public sealed class SlideCommands : ISlideCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic sectionProperties = ctx.Presentation.SectionProperties;
+            PowerPoint.SectionProperties sectionProperties = ctx.Presentation.SectionProperties;
             return new SlideOperationResult
             {
                 Success = true,
-                SectionCount = (int)sectionProperties.Count
+                SectionCount = sectionProperties.Count
             };
         });
     }
@@ -463,8 +468,8 @@ public sealed class SlideCommands : ISlideCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic sectionProperties = ctx.Presentation.SectionProperties;
-            int currentCount = (int)sectionProperties.Count;
+            PowerPoint.SectionProperties sectionProperties = ctx.Presentation.SectionProperties;
+            int currentCount = sectionProperties.Count;
 
             if (sectionIndex < 1 || sectionIndex > currentCount)
             {
@@ -476,7 +481,7 @@ public sealed class SlideCommands : ISlideCommands
                 };
             }
 
-            string name = (string)sectionProperties.Name(sectionIndex);
+            string name = sectionProperties.Name(sectionIndex);
 
             return new SlideOperationResult
             {

--- a/src/PowerPointMcp.Core/SmartArt/SmartArtCommands.cs
+++ b/src/PowerPointMcp.Core/SmartArt/SmartArtCommands.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.SmartArt;
 
@@ -36,10 +37,11 @@ public sealed class SmartArtCommands : ISmartArtCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
-            slide.Shapes.AddSmartArt(layout, left, top, width, height);
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            dynamic dynShapes = slide.Shapes;
+            dynShapes.AddSmartArt(layout, left, top, width, height);
             // Same NoPIA late-binding quirk as ShapeCommands.AddRectangle — avoid shape.Index, use Count.
-            int newIndex = (int)slide.Shapes.Count;
+            int newIndex = slide.Shapes.Count;
             dynamic newShape = slide.Shapes[newIndex];
             int nodeCount = (int)newShape.SmartArt.AllNodes.Count;
 
@@ -47,7 +49,7 @@ public sealed class SmartArtCommands : ISmartArtCommands
             {
                 Success = true,
                 ShapeIndex = newIndex,
-                ShapeCount = (int)slide.Shapes.Count,
+                ShapeCount = slide.Shapes.Count,
                 LayoutName = layoutName,
                 NodeCount = nodeCount
             };
@@ -337,13 +339,13 @@ public sealed class SmartArtCommands : ISmartArtCommands
         var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
         if (slideValidation is not null) return slideValidation;
 
-        dynamic slide = ctx.Presentation.Slides[slideIndex];
-        int shapeCount = (int)slide.Shapes.Count;
+        PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+        int shapeCount = slide.Shapes.Count;
         var shapeValidation = ValidateShapeIndex(shapeCount, shapeIndex);
         if (shapeValidation is not null) return shapeValidation;
 
-        dynamic shape = slide.Shapes[shapeIndex];
-        bool hasSmartArt = (int)shape.HasSmartArt == MsoTrue;
+        PowerPoint.Shape shape = slide.Shapes[shapeIndex];
+        bool hasSmartArt = (int)((dynamic)shape).HasSmartArt == MsoTrue;
         if (!hasSmartArt)
         {
             return new SmartArtOperationResult
@@ -353,7 +355,7 @@ public sealed class SmartArtCommands : ISmartArtCommands
             };
         }
 
-        smartArt = shape.SmartArt;
+        smartArt = ((dynamic)shape).SmartArt;
         return null;
     }
 

--- a/src/PowerPointMcp.Core/Table/TableCommands.cs
+++ b/src/PowerPointMcp.Core/Table/TableCommands.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Table;
 
@@ -9,14 +10,14 @@ public sealed class TableCommands : ITableCommands
     private const int MsoFalse = 0;
 
     // PpBorderType, verified against learn.microsoft.com/office/vba/api/powerpoint.ppbordertype.
-    private static readonly Dictionary<string, int> BorderTypes = new()
+    private static readonly Dictionary<string, PowerPoint.PpBorderType> BorderTypes = new()
     {
-        ["ppBorderTop"] = 1,
-        ["ppBorderLeft"] = 2,
-        ["ppBorderBottom"] = 3,
-        ["ppBorderRight"] = 4,
-        ["ppBorderDiagonalDown"] = 5,
-        ["ppBorderDiagonalUp"] = 6,
+        ["ppBorderTop"] = PowerPoint.PpBorderType.ppBorderTop,
+        ["ppBorderLeft"] = PowerPoint.PpBorderType.ppBorderLeft,
+        ["ppBorderBottom"] = PowerPoint.PpBorderType.ppBorderBottom,
+        ["ppBorderRight"] = PowerPoint.PpBorderType.ppBorderRight,
+        ["ppBorderDiagonalDown"] = PowerPoint.PpBorderType.ppBorderDiagonalDown,
+        ["ppBorderDiagonalUp"] = PowerPoint.PpBorderType.ppBorderDiagonalUp,
     };
 
     // MsoLineDashStyle, verified against learn.microsoft.com/office/vba/api/office.msolinedashstyle
@@ -53,12 +54,12 @@ public sealed class TableCommands : ITableCommands
                 };
             }
 
-            dynamic slide = ctx.Presentation.Slides[slideIndex];
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
             // Shapes.AddTable(NumRows, NumColumns, Left, Top, Width, Height) — all parameters
             // are plain ints/floats defined on the PowerPoint interop's own Shapes interface,
             // no office.dll-typed enum involved (unlike AddShape/AddTextbox).
             slide.Shapes.AddTable(rows, columns, left, top, width, height);
-            int newShapeIndex = (int)slide.Shapes.Count; // always appended — see Shape domain notes
+            int newShapeIndex = slide.Shapes.Count; // always appended — see Shape domain notes
 
             return new TableOperationResult
             {
@@ -78,7 +79,7 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
             table!.Cell(row, column).Shape.TextFrame.TextRange.Text = text;
@@ -94,7 +95,7 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
             string text = (string)table!.Cell(row, column).Shape.TextFrame.TextRange.Text;
@@ -104,13 +105,13 @@ public sealed class TableCommands : ITableCommands
     }
 
     private static TableOperationResult? ValidateTableShape(
-        PresentationContext ctx, int slideIndex, int shapeIndex, int row, int column, out dynamic? table)
+        PresentationContext ctx, int slideIndex, int shapeIndex, int row, int column, out PowerPoint.Table? table)
     {
         var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out table);
         if (validation is not null) return validation;
 
-        int rowCount = (int)table!.Rows.Count;
-        int colCount = (int)table.Columns.Count;
+        int rowCount = table!.Rows.Count;
+        int colCount = table.Columns.Count;
         if (row < 1 || row > rowCount)
         {
             return new TableOperationResult
@@ -132,7 +133,7 @@ public sealed class TableCommands : ITableCommands
     }
 
     private static TableOperationResult? ValidateTableShapeOnly(
-        PresentationContext ctx, int slideIndex, int shapeIndex, out dynamic? table)
+        PresentationContext ctx, int slideIndex, int shapeIndex, out PowerPoint.Table? table)
     {
         table = null;
 
@@ -146,7 +147,7 @@ public sealed class TableCommands : ITableCommands
             };
         }
 
-        dynamic slide = ctx.Presentation.Slides[slideIndex];
+        PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
         int shapeCount = slide.Shapes.Count;
         if (shapeIndex < 1 || shapeIndex > shapeCount)
         {
@@ -158,7 +159,7 @@ public sealed class TableCommands : ITableCommands
         }
 
         dynamic shape = slide.Shapes[shapeIndex];
-        bool hasTable = (int)shape.HasTable != 0; // HasTable is MsoTriState-like tri-state int
+        bool hasTable = (int)shape.HasTable == MsoTrue;
         if (!hasTable)
         {
             return new TableOperationResult
@@ -168,7 +169,7 @@ public sealed class TableCommands : ITableCommands
             };
         }
 
-        table = shape.Table;
+        table = (PowerPoint.Table)shape.Table;
         return null;
     }
 
@@ -179,10 +180,10 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out dynamic? table);
+            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
-            int rowCount = (int)table!.Rows.Count;
+            int rowCount = table!.Rows.Count;
             if (beforeRow is not null && (beforeRow < 1 || beforeRow > rowCount))
             {
                 return new TableOperationResult
@@ -201,7 +202,7 @@ public sealed class TableCommands : ITableCommands
                 table.Rows.Add(beforeRow.Value);
             }
 
-            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = (int)table.Rows.Count, ColumnCount = (int)table.Columns.Count };
+            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = table.Rows.Count, ColumnCount = table.Columns.Count };
         });
     }
 
@@ -212,10 +213,10 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out dynamic? table);
+            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
-            int rowCount = (int)table!.Rows.Count;
+            int rowCount = table!.Rows.Count;
             if (row < 1 || row > rowCount)
             {
                 return new TableOperationResult
@@ -227,7 +228,7 @@ public sealed class TableCommands : ITableCommands
 
             table.Rows[row].Delete();
 
-            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = (int)table.Rows.Count, ColumnCount = (int)table.Columns.Count };
+            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = table.Rows.Count, ColumnCount = table.Columns.Count };
         });
     }
 
@@ -238,10 +239,10 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out dynamic? table);
+            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
-            int colCount = (int)table!.Columns.Count;
+            int colCount = table!.Columns.Count;
             if (beforeColumn is not null && (beforeColumn < 1 || beforeColumn > colCount))
             {
                 return new TableOperationResult
@@ -260,7 +261,7 @@ public sealed class TableCommands : ITableCommands
                 table.Columns.Add(beforeColumn.Value);
             }
 
-            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = (int)table.Rows.Count, ColumnCount = (int)table.Columns.Count };
+            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = table.Rows.Count, ColumnCount = table.Columns.Count };
         });
     }
 
@@ -271,10 +272,10 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out dynamic? table);
+            var validation = ValidateTableShapeOnly(ctx, slideIndex, shapeIndex, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
-            int colCount = (int)table!.Columns.Count;
+            int colCount = table!.Columns.Count;
             if (column < 1 || column > colCount)
             {
                 return new TableOperationResult
@@ -286,7 +287,7 @@ public sealed class TableCommands : ITableCommands
 
             table.Columns[column].Delete();
 
-            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = (int)table.Rows.Count, ColumnCount = (int)table.Columns.Count };
+            return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, RowCount = table.Rows.Count, ColumnCount = table.Columns.Count };
         });
     }
 
@@ -297,11 +298,11 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
             int rgb = red + (green << 8) + (blue << 16);
-            dynamic cellShape = table!.Cell(row, column).Shape;
+            PowerPoint.Shape cellShape = table!.Cell(row, column).Shape;
             cellShape.Fill.Solid();
             cellShape.Fill.ForeColor.RGB = rgb;
 
@@ -316,11 +317,11 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
-            dynamic cellShape = table!.Cell(row, column).Shape;
-            int rgb = (int)cellShape.Fill.ForeColor.RGB;
+            PowerPoint.Shape cellShape = table!.Cell(row, column).Shape;
+            int rgb = cellShape.Fill.ForeColor.RGB;
 
             return new TableOperationResult { Success = true, ShapeIndex = shapeIndex, ColorRgb = rgb };
         });
@@ -346,7 +347,7 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
             if (!BorderTypes.TryGetValue(borderType, out var borderTypeValue))
@@ -372,7 +373,7 @@ public sealed class TableCommands : ITableCommands
                 dashStyleValue = resolvedDashStyle;
             }
 
-            dynamic border = table!.Cell(row, column).Borders[borderTypeValue];
+            PowerPoint.LineFormat border = table!.Cell(row, column).Borders[borderTypeValue];
 
             if (red is not null || green is not null || blue is not null)
             {
@@ -387,12 +388,14 @@ public sealed class TableCommands : ITableCommands
 
             if (dashStyleValue is not null)
             {
-                border.DashStyle = dashStyleValue.Value;
+                dynamic dynBorder = border;
+                dynBorder.DashStyle = dashStyleValue.Value;
             }
 
             if (visible is not null)
             {
-                border.Visible = visible.Value ? MsoTrue : MsoFalse;
+                dynamic dynBorder = border;
+                dynBorder.Visible = visible.Value ? MsoTrue : MsoFalse;
             }
 
             return ReadBorder(border, shapeIndex, borderType);
@@ -407,7 +410,7 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
             if (!BorderTypes.TryGetValue(borderType, out var borderTypeValue))
@@ -419,7 +422,7 @@ public sealed class TableCommands : ITableCommands
                 };
             }
 
-            dynamic border = table!.Cell(row, column).Borders[borderTypeValue];
+            PowerPoint.LineFormat border = table!.Cell(row, column).Borders[borderTypeValue];
             return ReadBorder(border, shapeIndex, borderType);
         });
     }
@@ -431,11 +434,11 @@ public sealed class TableCommands : ITableCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out dynamic? table);
+            var validation = ValidateTableShape(ctx, slideIndex, shapeIndex, row, column, out PowerPoint.Table? table);
             if (validation is not null) return validation;
 
-            int rowCount = (int)table!.Rows.Count;
-            int colCount = (int)table.Columns.Count;
+            int rowCount = table!.Rows.Count;
+            int colCount = table.Columns.Count;
             if (mergeToRow < 1 || mergeToRow > rowCount)
             {
                 return new TableOperationResult
@@ -459,12 +462,13 @@ public sealed class TableCommands : ITableCommands
         });
     }
 
-    private static TableOperationResult ReadBorder(dynamic border, int shapeIndex, string borderType)
+    private static TableOperationResult ReadBorder(PowerPoint.LineFormat border, int shapeIndex, string borderType)
     {
-        int rgb = (int)border.ForeColor.RGB;
-        float weight = (float)border.Weight;
-        int dashStyleValue = (int)border.DashStyle;
-        bool visible = (int)border.Visible == MsoTrue;
+        int rgb = border.ForeColor.RGB;
+        float weight = border.Weight;
+        dynamic dynBorder = border;
+        int dashStyleValue = (int)dynBorder.DashStyle;
+        bool visible = (int)dynBorder.Visible == MsoTrue;
 
         LineDashStylesByValue.TryGetValue(dashStyleValue, out var dashStyleName);
 
@@ -480,4 +484,3 @@ public sealed class TableCommands : ITableCommands
         };
     }
 }
-

--- a/src/PowerPointMcp.Core/TextFrame/TextFrameCommands.cs
+++ b/src/PowerPointMcp.Core/TextFrame/TextFrameCommands.cs
@@ -1,5 +1,6 @@
 using Sbroenne.PowerPointMcp.ComInterop.Session;
 using System.Linq;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.TextFrame;
 
@@ -10,37 +11,37 @@ public sealed class TextFrameCommands : ITextFrameCommands
     private const int MsoFalse = 0;
 
     // PpBulletType (curated: only the members meaningful for a simple on/off toggle).
-    private const int PpBulletNone = 0;
-    private const int PpBulletUnnumbered = 1;
+    private const PowerPoint.PpBulletType PpBulletNone = PowerPoint.PpBulletType.ppBulletNone;
+    private const PowerPoint.PpBulletType PpBulletUnnumbered = PowerPoint.PpBulletType.ppBulletUnnumbered;
 
     // PpParagraphAlignment, verified against learn.microsoft.com/office/vba/api/powerpoint.ppparagraphalignment.
     // ppAlignmentMixed (-2) is intentionally excluded from the settable dictionary (it's a
     // read-only "mixed state across paragraphs" indicator, not a value you can set).
-    private static readonly Dictionary<string, int> ParagraphAlignments = new()
+    private static readonly Dictionary<string, PowerPoint.PpParagraphAlignment> ParagraphAlignments = new()
     {
-        ["ppAlignLeft"] = 1,
-        ["ppAlignCenter"] = 2,
-        ["ppAlignRight"] = 3,
-        ["ppAlignJustify"] = 4,
-        ["ppAlignDistribute"] = 5,
-        ["ppAlignThaiDistribute"] = 6,
-        ["ppAlignJustifyLow"] = 7,
+        ["ppAlignLeft"] = PowerPoint.PpParagraphAlignment.ppAlignLeft,
+        ["ppAlignCenter"] = PowerPoint.PpParagraphAlignment.ppAlignCenter,
+        ["ppAlignRight"] = PowerPoint.PpParagraphAlignment.ppAlignRight,
+        ["ppAlignJustify"] = PowerPoint.PpParagraphAlignment.ppAlignJustify,
+        ["ppAlignDistribute"] = PowerPoint.PpParagraphAlignment.ppAlignDistribute,
+        ["ppAlignThaiDistribute"] = PowerPoint.PpParagraphAlignment.ppAlignThaiDistribute,
+        ["ppAlignJustifyLow"] = PowerPoint.PpParagraphAlignment.ppAlignJustifyLow,
     };
 
-    private static readonly Dictionary<int, string> ParagraphAlignmentsByValue =
+    private static readonly Dictionary<PowerPoint.PpParagraphAlignment, string> ParagraphAlignmentsByValue =
         ParagraphAlignments.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
 
     // PpAutoSize, verified against learn.microsoft.com/office/vba/api/powerpoint.ppautosize.
     // ppAutoSizeMixed (-2) is intentionally excluded from the settable dictionary (it's a
     // read-only "mixed state across shapes" indicator, not a value you can set).
-    private static readonly Dictionary<string, int> AutoSizeModes = new()
+    private static readonly Dictionary<string, PowerPoint.PpAutoSize> AutoSizeModes = new()
     {
-        ["ppAutoSizeNone"] = 0,
-        ["ppAutoSizeShapeToFitText"] = 1,
-        ["ppAutoSizeTextToFitShape"] = 2,
+        ["ppAutoSizeNone"] = PowerPoint.PpAutoSize.ppAutoSizeNone,
+        ["ppAutoSizeShapeToFitText"] = PowerPoint.PpAutoSize.ppAutoSizeShapeToFitText,
+        ["ppAutoSizeTextToFitShape"] = (PowerPoint.PpAutoSize)2,
     };
 
-    private static readonly Dictionary<int, string> AutoSizeModesByValue =
+    private static readonly Dictionary<PowerPoint.PpAutoSize, string> AutoSizeModesByValue =
         AutoSizeModes.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
 
     /// <inheritdoc/>
@@ -54,7 +55,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             shape.TextFrame.TextRange.Text = text;
 
             return new TextFrameOperationResult { Success = true, Text = text };
@@ -71,7 +72,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             string text = (string)shape.TextFrame.TextRange.Text;
 
             return new TextFrameOperationResult { Success = true, Text = text };
@@ -88,7 +89,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             shape.TextFrame.TextRange.Font.Size = fontSize;
 
             return new TextFrameOperationResult { Success = true, FontSize = fontSize };
@@ -105,10 +106,10 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            // Font.Bold is typed as Microsoft.Office.Core.MsoTriState (office.dll) — set via
-            // dynamic with the raw int constant, same pattern as elsewhere in this project.
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            shape.TextFrame.TextRange.Font.Bold = bold ? MsoTrue : MsoFalse;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            // Font tri-state properties are Microsoft.Office.Core-typed; keep the property write late-bound.
+            dynamic font = shape.TextFrame.TextRange.Font;
+            font.Bold = bold ? MsoTrue : MsoFalse;
 
             return new TextFrameOperationResult { Success = true, Bold = bold };
         });
@@ -128,7 +129,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
             // function), not the more common 0x00RRGGBB.
             int rgb = red + (green << 8) + (blue << 16);
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             shape.TextFrame.TextRange.Font.Color.RGB = rgb;
 
             return new TextFrameOperationResult { Success = true, ColorRgb = rgb };
@@ -145,8 +146,9 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            shape.TextFrame.TextRange.Font.Italic = italic ? MsoTrue : MsoFalse;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            dynamic font = shape.TextFrame.TextRange.Font;
+            font.Italic = italic ? MsoTrue : MsoFalse;
 
             return new TextFrameOperationResult { Success = true, Italic = italic };
         });
@@ -162,8 +164,9 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            bool italic = (int)shape.TextFrame.TextRange.Font.Italic == MsoTrue;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            dynamic font = shape.TextFrame.TextRange.Font;
+            bool italic = (int)font.Italic == MsoTrue;
 
             return new TextFrameOperationResult { Success = true, Italic = italic };
         });
@@ -179,8 +182,9 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            shape.TextFrame.TextRange.Font.Underline = underline ? MsoTrue : MsoFalse;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            dynamic font = shape.TextFrame.TextRange.Font;
+            font.Underline = underline ? MsoTrue : MsoFalse;
 
             return new TextFrameOperationResult { Success = true, Underline = underline };
         });
@@ -196,8 +200,9 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            bool underline = (int)shape.TextFrame.TextRange.Font.Underline == MsoTrue;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            dynamic font = shape.TextFrame.TextRange.Font;
+            bool underline = (int)font.Underline == MsoTrue;
 
             return new TextFrameOperationResult { Success = true, Underline = underline };
         });
@@ -214,7 +219,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             shape.TextFrame.TextRange.Font.Name = fontName;
 
             return new TextFrameOperationResult { Success = true, FontName = fontName };
@@ -231,7 +236,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             string fontName = (string)shape.TextFrame.TextRange.Font.Name;
 
             return new TextFrameOperationResult { Success = true, FontName = fontName };
@@ -258,7 +263,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
                 };
             }
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             shape.TextFrame.TextRange.ParagraphFormat.Alignment = alignmentValue;
 
             return new TextFrameOperationResult { Success = true, Alignment = alignment };
@@ -275,8 +280,8 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            int alignmentValue = (int)shape.TextFrame.TextRange.ParagraphFormat.Alignment;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.PpParagraphAlignment alignmentValue = shape.TextFrame.TextRange.ParagraphFormat.Alignment;
 
             if (!ParagraphAlignmentsByValue.TryGetValue(alignmentValue, out var alignmentName))
             {
@@ -310,8 +315,11 @@ public sealed class TextFrameCommands : ITextFrameCommands
                 };
             }
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            dynamic bullet = shape.TextFrame.TextRange.ParagraphFormat.Bullet;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            // ParagraphFormat.Bullet's embedded signature references Office.MsoTriState from
+            // office.dll, which this project deliberately does not load. Keep only this boundary
+            // late-bound; the containing PowerPoint shape and PpBulletType values remain typed.
+            dynamic bullet = ((dynamic)shape.TextFrame.TextRange.ParagraphFormat).Bullet;
 
             bullet.Type = enabled ? PpBulletUnnumbered : PpBulletNone;
             if (enabled && character is not null)
@@ -338,10 +346,10 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            dynamic bullet = shape.TextFrame.TextRange.ParagraphFormat.Bullet;
-            int bulletType = (int)bullet.Type;
-            bool enabled = bulletType != PpBulletNone;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            // See SetBullet: the Bullet getter depends on Office.MsoTriState from office.dll.
+            dynamic bullet = ((dynamic)shape.TextFrame.TextRange.ParagraphFormat).Bullet;
+            bool enabled = (int)bullet.Type != (int)PpBulletNone;
 
             return new TextFrameOperationResult
             {
@@ -372,7 +380,7 @@ public sealed class TextFrameCommands : ITextFrameCommands
                 };
             }
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
             shape.TextFrame.AutoSize = autoSizeValue;
 
             return new TextFrameOperationResult { Success = true, AutoSize = autoSize };
@@ -389,8 +397,8 @@ public sealed class TextFrameCommands : ITextFrameCommands
             var validation = ValidateIndices(ctx, slideIndex, shapeIndex);
             if (validation is not null) return validation;
 
-            dynamic shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
-            int autoSizeValue = (int)shape.TextFrame.AutoSize;
+            PowerPoint.Shape shape = ctx.Presentation.Slides[slideIndex].Shapes[shapeIndex];
+            PowerPoint.PpAutoSize autoSizeValue = shape.TextFrame.AutoSize;
 
             if (!AutoSizeModesByValue.TryGetValue(autoSizeValue, out var autoSizeName))
             {
@@ -417,7 +425,8 @@ public sealed class TextFrameCommands : ITextFrameCommands
             };
         }
 
-        int shapeCount = ctx.Presentation.Slides[slideIndex].Shapes.Count;
+        PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+        int shapeCount = slide.Shapes.Count;
         if (shapeIndex < 1 || shapeIndex > shapeCount)
         {
             return new TextFrameOperationResult

--- a/src/PowerPointMcp.Generators/ServiceRegistryGenerator.cs
+++ b/src/PowerPointMcp.Generators/ServiceRegistryGenerator.cs
@@ -962,6 +962,7 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
             // Description from interface XML doc
             var description = (cat.XmlDocSummary ?? "")
+                .Replace("\\", "\\\\")
                 .Replace("\"", "\\\"\"")
                 .Replace("\r", "")
                 .Replace("\n", " ")
@@ -1025,6 +1026,7 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
                 }
 
                 var paramDescription = baseDescription
+                    .Replace("\\", "\\\\")
                     .Replace("\"", "\\\"\"");  // Escape quotes for JSON in verbatim string
 
                 sb.AppendLine("        {");

--- a/tests/PowerPointMcp.Core.Tests/ImageCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ImageCommandsTests.cs
@@ -1,3 +1,4 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Image;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 
@@ -125,6 +126,506 @@ public class ImageCommandsTests : IClassFixture<SharedPresentationFixture>
 
             Assert.False(result.Success);
             Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    // ─── SetCrop / GetCrop — permanent red tests (TDD: red before Parker implements) ─
+    //
+    // CONTRACT (to be implemented by Parker in IImageCommands / ImageCommands):
+    //
+    //   ImageOperationResult SetCrop(
+    //       IPresentationBatch batch,
+    //       int slideIndex,
+    //       int shapeIndex,
+    //       float cropLeft,   // points, left edge; L-T-R-B ordering throughout
+    //       float cropTop,    // points, top edge
+    //       float cropRight,  // points, right edge
+    //       float cropBottom) // points, bottom edge
+    //
+    //   ImageOperationResult GetCrop(
+    //       IPresentationBatch batch,
+    //       int slideIndex,
+    //       int shapeIndex)
+    //
+    // ImageOperationResult additions required:
+    //   public float? CropLeft   { get; init; }
+    //   public float? CropTop    { get; init; }
+    //   public float? CropRight  { get; init; }
+    //   public float? CropBottom { get; init; }
+    //
+    // EMPIRICAL BASIS (from passing COM investigation tests below):
+    //   • CropLeft/Top/Right/Bottom are in POINTS, not fractions or percentages.
+    //   • Round-trip precision: < 0.001 pt; tolerance for tests: 0.01 pt.
+    //   • The four sides are independent; setting one does not affect the others.
+    //   • Default is 0.0 for all four sides immediately after AddPicture.
+    //   • A properly-sized source image (≥ 50×50 px BMP) is required for reliable
+    //     round-trip; the 1×1-pixel PNG helper overflows EMU arithmetic (see
+    //     CreateProperSizeTestImageFile doc comment below).
+    //   • Negative crop values are valid COM inputs; they expand the visible area
+    //     beyond the natural image boundary. No range validation needed.
+    //
+    // THESE TESTS CURRENTLY FAIL TO COMPILE (CS1061) because SetCrop, GetCrop, and
+    // CropLeft/Top/Right/Bottom do not yet exist. That is the intentional TDD red state.
+
+    /// <summary>
+    /// Primary round-trip: set all four sides with distinct values, assert SetCrop
+    /// result carries applied values, then verify via GetCrop.
+    /// </summary>
+    [Fact]
+    public void SetCrop_AndGetCrop_RoundTrip_AllFourSides()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile(); // 50×50 BMP required
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            // L=5, T=3, R=7, B=2 — distinct values confirm no cross-side pollution.
+            var setResult = _commands.SetCrop(batch, 1, 1,
+                cropLeft: 5f, cropTop: 3f, cropRight: 7f, cropBottom: 2f);
+
+            Assert.True(setResult.Success, setResult.ErrorMessage);
+            Assert.Null(setResult.ErrorMessage);
+            Assert.NotNull(setResult.CropLeft);
+            Assert.InRange(setResult.CropLeft!.Value,  5f - 0.01f, 5f + 0.01f);
+            Assert.InRange(setResult.CropTop!.Value,   3f - 0.01f, 3f + 0.01f);
+            Assert.InRange(setResult.CropRight!.Value, 7f - 0.01f, 7f + 0.01f);
+            Assert.InRange(setResult.CropBottom!.Value,2f - 0.01f, 2f + 0.01f);
+
+            var getResult = _commands.GetCrop(batch, 1, 1);
+
+            Assert.True(getResult.Success, getResult.ErrorMessage);
+            Assert.Null(getResult.ErrorMessage);
+            Assert.NotNull(getResult.CropLeft);
+            Assert.InRange(getResult.CropLeft!.Value,  5f - 0.01f, 5f + 0.01f);
+            Assert.InRange(getResult.CropTop!.Value,   3f - 0.01f, 3f + 0.01f);
+            Assert.InRange(getResult.CropRight!.Value, 7f - 0.01f, 7f + 0.01f);
+            Assert.InRange(getResult.CropBottom!.Value,2f - 0.01f, 2f + 0.01f);
+        }
+        finally { File.Delete(imagePath); }
+    }
+
+    /// <summary>
+    /// Verifies that GetCrop returns all-zero crop values on a
+    /// freshly-added picture (no crop applied yet) — matching the COM invariant.
+    /// </summary>
+    [Fact]
+    public void GetCrop_OnFreshlyAddedPicture_ReturnsAllZeroes()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            var result = _commands.GetCrop(batch, 1, 1);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Null(result.ErrorMessage);
+            Assert.NotNull(result.CropLeft);
+            Assert.Equal(0f, result.CropLeft!.Value);
+            Assert.Equal(0f, result.CropTop!.Value);
+            Assert.Equal(0f, result.CropRight!.Value);
+            Assert.Equal(0f, result.CropBottom!.Value);
+        }
+        finally { File.Delete(imagePath); }
+    }
+
+    /// <summary>
+    /// Verifies that crop values survive Save → reopen: the
+    /// values stored by SetCrop are faithfully read back by GetCrop after the
+    /// presentation is closed and re-opened from disk.
+    /// </summary>
+    [Fact]
+    public void SetCrop_Persistence_AfterSaveAndReopen()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            var setResult = _commands.SetCrop(batch, 1, 1,
+                cropLeft: 8f, cropTop: 4f, cropRight: 6f, cropBottom: 3f);
+            Assert.True(setResult.Success, setResult.ErrorMessage);
+
+            _presentationCommands.Save(batch);
+            _fixture.ReopenCurrentPresentation();
+
+            var getResult = _commands.GetCrop(batch, 1, 1);
+
+            Assert.True(getResult.Success, getResult.ErrorMessage);
+            Assert.NotNull(getResult.CropLeft);
+            Assert.InRange(getResult.CropLeft!.Value,  8f - 0.01f, 8f + 0.01f);
+            Assert.InRange(getResult.CropTop!.Value,   4f - 0.01f, 4f + 0.01f);
+            Assert.InRange(getResult.CropRight!.Value, 6f - 0.01f, 6f + 0.01f);
+            Assert.InRange(getResult.CropBottom!.Value,3f - 0.01f, 3f + 0.01f);
+        }
+        finally { File.Delete(imagePath); }
+    }
+
+    /// <summary>
+    /// SetCrop on a non-picture shape must return Success=false
+    /// with a non-empty error message — not throw an unhandled COM exception.
+    /// </summary>
+    [Fact]
+    public void SetCrop_OnNonPictureShape_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        AddNonPictureShape(batch); // shape 1 is a text box
+
+        var result = _commands.SetCrop(batch, 1, 1,
+            cropLeft: 5f, cropTop: 3f, cropRight: 7f, cropBottom: 2f);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    /// <summary>
+    /// GetCrop on a non-picture shape must return Success=false
+    /// with a non-empty error message — not throw an unhandled COM exception.
+    /// </summary>
+    [Fact]
+    public void GetCrop_OnNonPictureShape_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        AddNonPictureShape(batch);
+
+        var result = _commands.GetCrop(batch, 1, 1);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    /// <summary>
+    /// SetCrop with an out-of-range slide index must return
+    /// Success=false (validated before any COM call, consistent with other Image methods).
+    /// </summary>
+    [Fact]
+    public void SetCrop_WithInvalidSlideIndex_ReturnsFailure()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            var result = _commands.SetCrop(batch, 99, 1, 5f, 3f, 7f, 2f);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+        finally { File.Delete(imagePath); }
+    }
+
+    /// <summary>
+    /// SetCrop with an out-of-range shape index must return
+    /// Success=false (validated before any COM call).
+    /// </summary>
+    [Fact]
+    public void SetCrop_WithInvalidShapeIndex_ReturnsFailure()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            var result = _commands.SetCrop(batch, 1, 99, 5f, 3f, 7f, 2f);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+        finally { File.Delete(imagePath); }
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Adds a text box to slide 1 of the current presentation so tests can exercise
+    /// PictureFormat operations on a shape that is NOT a picture. Uses direct COM
+    /// dispatch (msoTextOrientationHorizontal = 1) — does not go through ShapeCommands.
+    /// </summary>
+    private static void AddNonPictureShape(IPresentationBatch batch) =>
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic slide = ctx.Presentation.Slides[1];
+            slide.Shapes.AddTextbox(1, 10.0f, 10.0f, 200.0f, 50.0f); // 1 = msoTextOrientationHorizontal
+        });
+
+    /// <summary>
+    /// Creates a 50×50-pixel BMP at 96 DPI (≈37.5 pt natural size), which is large
+    /// enough for PowerPoint to correctly honour the explicit Width/Height passed to
+    /// AddPicture and produce stable PictureFormat crop round-trip behaviour.
+    /// <para>
+    /// Background: the 1×1-pixel PNG produced by
+    /// <see cref="CoreTestHelper.CreateUniqueTestImageFile"/> is too small — PowerPoint
+    /// internally rescales the shape when its CropLeft is set (empirically: setting
+    /// CropLeft=5 on a 100-pt-display shape with a 1×1-pixel source reads back as −2.85
+    /// and expands the shape to ≈480 pt). Any test asserting a crop round-trip must use
+    /// a properly-sized source image; this factory provides one.
+    /// </para>
+    /// </summary>
+    private static string CreateProperSizeTestImageFile()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests");
+        Directory.CreateDirectory(dir);
+        string path = Path.Combine(dir, $"pptmcp-test-50px-{Guid.NewGuid():N}.bmp");
+
+        const int W = 50, H = 50;
+        int rowStride = (W * 3 + 3) / 4 * 4;   // BMP rows are 4-byte aligned
+        byte[] bmp = new byte[54 + rowStride * H];
+
+        // BITMAPFILEHEADER (14 bytes)
+        bmp[0] = 0x42; bmp[1] = 0x4D;                           // "BM" signature
+        BitConverter.GetBytes(bmp.Length).CopyTo(bmp, 2);        // total file size
+        BitConverter.GetBytes(54).CopyTo(bmp, 10);               // pixel data offset
+
+        // BITMAPINFOHEADER (40 bytes at offset 14)
+        BitConverter.GetBytes(40).CopyTo(bmp, 14);               // header size
+        BitConverter.GetBytes(W).CopyTo(bmp, 18);                // width in pixels
+        BitConverter.GetBytes(-H).CopyTo(bmp, 22);               // height — negative = top-down rows
+        bmp[26] = 1;                                              // colour planes = 1
+        bmp[28] = 24;                                             // bits per pixel = 24 (RGB)
+        BitConverter.GetBytes(3780).CopyTo(bmp, 38);             // X pixels per metre ≈ 96 DPI
+        BitConverter.GetBytes(3780).CopyTo(bmp, 42);             // Y pixels per metre ≈ 96 DPI
+
+        // Pixel data: solid blue, stored as B G R (BMP byte order)
+        for (int y = 0; y < H; y++)
+            for (int x = 0; x < W; x++)
+            {
+                int i = 54 + y * rowStride + x * 3;
+                bmp[i] = 180; bmp[i + 1] = 100; bmp[i + 2] = 0;
+            }
+
+        File.WriteAllBytes(path, bmp);
+        return path;
+    }
+
+    // ─── Non-picture shape: PictureFormat operations must fail gracefully ─────────
+    // ImageCommands validates the shape type before accessing PictureFormat.
+    // These tests verify that operations on non-picture shapes return Success=false
+    // with appropriate error messages instead of throwing exceptions.
+
+    [Fact]
+    public void SetBrightnessContrast_OnNonPictureShape_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        AddNonPictureShape(batch);  // shape 1 is a text box, not a picture
+
+        var result = _commands.SetBrightnessContrast(batch, 1, 1, 0.6f, 0.7f);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void GetBrightnessContrast_OnNonPictureShape_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        AddNonPictureShape(batch);
+
+        var result = _commands.GetBrightnessContrast(batch, 1, 1);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void SetRecolor_OnNonPictureShape_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        AddNonPictureShape(batch);
+
+        var result = _commands.SetRecolor(batch, 1, 1, "msoPictureGrayscale");
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void GetRecolor_OnNonPictureShape_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        AddNonPictureShape(batch);
+
+        var result = _commands.GetRecolor(batch, 1, 1);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    // ─── Brightness / contrast out-of-range validation ─────────────────────────
+    // IImageCommands documents brightness and contrast as floats in [0, 1].
+    // These tests verify that out-of-range values are validated and return Success=false
+    // with appropriate error messages instead of passing invalid values to COM.
+
+    [Fact]
+    public void SetBrightnessContrast_WithBrightnessAboveOne_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
+
+            var result = _commands.SetBrightnessContrast(batch, 1, 1, 1.5f, 0.5f);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    [Fact]
+    public void SetBrightnessContrast_WithContrastBelowZero_ReturnsFailure_NotException()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 10f, 10f, 100f, 100f);
+
+            var result = _commands.SetBrightnessContrast(batch, 1, 1, 0.5f, -0.1f);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    // ─── PictureFormat crop: COM contract documentation ────────────────────────────
+    // These tests access PictureFormat.Crop* directly via batch.Execute because
+    // IImageCommands does not yet expose SetCrop/GetCrop operations.  They document
+    // the exact COM semantics (units, round-trip precision, independence of the four
+    // sides) that any future SetCrop/GetCrop implementation must satisfy.
+    //
+    // KEY FINDING from COM investigation:
+    //   • Crop values are in POINTS (absolute, not percentages or fractions).
+    //   • Round-trip precision: < 0.001 pt error for values in 0–50 pt range.
+    //   • The four sides are independent; setting one does not affect the others.
+    //   • Source-image size matters: for the 1×1-pixel CoreTestHelper PNG, setting
+    //     CropLeft=5 reads back as −2.85 and the shape expands to ≈480 pt — an EMU
+    //     arithmetic overflow artefact of the near-zero natural image size. A properly-
+    //     sized source (≥ a few pixels) round-trips cleanly at the tolerances asserted
+    //     below. Any SetCrop/GetCrop implementation MUST use or document this constraint.
+    //   • Default ColorType = 1 (msoPictureAutomatic); default Brightness = Contrast = 0.5.
+
+    [Fact]
+    public void PictureFormat_CropValues_AreAllZero_AfterAddPicture()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            var (cropLeft, cropTop, cropRight, cropBottom) = batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ctx.Presentation.Slides[1];
+                dynamic pf = slide.Shapes[1].PictureFormat;
+                return ((float)pf.CropLeft, (float)pf.CropTop,
+                        (float)pf.CropRight, (float)pf.CropBottom);
+            });
+
+            Assert.Equal(0f, cropLeft);
+            Assert.Equal(0f, cropTop);
+            Assert.Equal(0f, cropRight);
+            Assert.Equal(0f, cropBottom);
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    [Fact]
+    public void PictureFormat_CropLeft_SetAndReadBack_RoundTrips_WithinSubPointTolerance()
+    {
+        // Crop values are in points. Observed round-trip precision: < 0.001 pt
+        // (e.g. set 10 pt → read back 9.999646 pt; set 5 pt → 5.000198 pt).
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ctx.Presentation.Slides[1];
+                dynamic shape = slide.Shapes[1];
+                shape.PictureFormat.CropLeft = 10f;
+            });
+            float cropLeft = batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ctx.Presentation.Slides[1];
+                dynamic shape = slide.Shapes[1];
+                return (float)shape.PictureFormat.CropLeft;
+            });
+
+            Assert.InRange(cropLeft, 10f - 0.01f, 10f + 0.01f);
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    [Fact]
+    public void PictureFormat_AllFourCropSides_SetAndReadBack_Independently_WithinTolerance()
+    {
+        // Verifies that each crop side is stored independently (setting L=5, T=3, R=7, B=2
+        // does not bleed into other sides) and that all four round-trip within 0.01 pt.
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string imagePath = CreateProperSizeTestImageFile();
+        try
+        {
+            _commands.AddPicture(batch, 1, imagePath, 0f, 0f, 100f, 100f);
+
+            batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ctx.Presentation.Slides[1];
+                dynamic pf = slide.Shapes[1].PictureFormat;
+                pf.CropLeft = 5f; pf.CropTop = 3f; pf.CropRight = 7f; pf.CropBottom = 2f;
+            });
+            var (cl, ctop, cr, cb) = batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ctx.Presentation.Slides[1];
+                dynamic pf = slide.Shapes[1].PictureFormat;
+                return ((float)pf.CropLeft, (float)pf.CropTop,
+                        (float)pf.CropRight, (float)pf.CropBottom);
+            });
+
+            Assert.InRange(cl,   5f - 0.01f, 5f + 0.01f);
+            Assert.InRange(ctop, 3f - 0.01f, 3f + 0.01f);
+            Assert.InRange(cr,   7f - 0.01f, 7f + 0.01f);
+            Assert.InRange(cb,   2f - 0.01f, 2f + 0.01f);
         }
         finally
         {

--- a/tests/PowerPointMcp.Core.Tests/PiaMigrationBehaviorTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PiaMigrationBehaviorTests.cs
@@ -1,0 +1,143 @@
+using Sbroenne.PowerPointMcp.Core.Notes;
+using Sbroenne.PowerPointMcp.Core.Slide;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>
+/// Real-COM integration tests covering the specific dynamic COM patterns in
+/// <see cref="NotesCommands"/> that are most sensitive to the PIA migration.
+/// </summary>
+/// <remarks>
+/// <para>Why these tests exist alongside <see cref="NotesCommandsTests"/>:</para>
+/// <list type="bullet">
+///   <item><b>Empty-notes placeholder scan</b> — <c>NotesCommands.FindNotesTextShape</c> walks
+///   the notes page's Shapes collection dynamically (<c>shape.Type == 14</c> / msoPlaceholder,
+///   <c>shape.PlaceholderFormat.Type == 2</c> / ppPlaceholderBody). The existing Notes tests
+///   only exercise this path after text has been <em>set</em>. This test exercises the scan on
+///   a completely untouched slide, verifying that the placeholder is found and an empty string
+///   is returned rather than an exception thrown. If the PIA migration changes the
+///   <c>isPlaceholder</c> comparison (e.g., wrong enum value), <c>FindNotesTextShape</c> throws
+///   <see cref="InvalidOperationException"/> — this test catches that regression.</item>
+///   <item><b>Multi-slide notes access</b> — the existing round-trip test only uses slide 1.
+///   This tests slide 2, exercising the <c>ctx.Presentation.Slides[slideIndex].NotesPage</c>
+///   dynamic access with a non-first index.</item>
+/// </list>
+/// <para>No mocking. Requires a live PowerPoint COM instance. Serialized via
+/// <c>xunit.runner.json</c> (<c>maxParallelThreads: 1</c>).</para>
+/// </remarks>
+[Trait("Category", "Integration")]
+[Trait("Feature", "Notes")]
+public class PiaMigrationBehaviorTests : IClassFixture<SharedPresentationFixture>
+{
+    private readonly SharedPresentationFixture _fixture;
+    private readonly NotesCommands _notesCommands = new();
+    private readonly SlideCommands _slideCommands = new();
+
+    public PiaMigrationBehaviorTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetNotesText</c> on a freshly-created slide that has never had any
+    /// notes text set returns <c>Success = true</c> with empty (or null) text rather than
+    /// throwing an exception.
+    /// </summary>
+    /// <remarks>
+    /// This directly exercises <c>NotesCommands.FindNotesTextShape</c>'s dynamic placeholder
+    /// scan: it must locate the body placeholder (<c>shape.Type == 14</c>,
+    /// <c>shape.PlaceholderFormat.Type == 2</c>) on an untouched notes page and read its
+    /// (empty) text without throwing. If the PIA migration introduces an off-by-one or
+    /// wrong-enum comparison in the <c>isPlaceholder</c> check, the scan finds nothing and
+    /// throws <see cref="InvalidOperationException"/>, which propagates out of
+    /// <c>batch.Execute</c> as an unhandled exception (Rule 1b). This test catches that.
+    /// </remarks>
+    [Fact]
+    public void GetNotesText_OnFreshSlide_WithNoTextSet_ReturnsSuccessWithEmptyText()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        // A fresh presentation has slide 1 with no notes text yet.
+        var result = _notesCommands.GetNotesText(batch, 1);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Null(result.ErrorMessage);
+        // PowerPoint's default body placeholder text is an empty string — not null, not a
+        // prompt like "Click to add notes" (that's rendered in the UI but not stored as text).
+        Assert.NotNull(result.NotesText);
+        Assert.Equal(string.Empty, result.NotesText);
+    }
+
+    /// <summary>
+    /// Verifies that <c>SetNotesText</c> and <c>GetNotesText</c> work correctly on slide 2
+    /// of a two-slide presentation.
+    /// </summary>
+    /// <remarks>
+    /// The existing <see cref="NotesCommandsTests.SetNotesText_ThenGetNotesText_RoundTrips_AndPersistsAfterSave"/>
+    /// test only uses slide index 1. This test exercises the <c>ctx.Presentation.Slides[2].NotesPage</c>
+    /// access (dynamic dispatch with a non-first index) and confirms the placeholder scan
+    /// succeeds on slide 2 as well. A migration bug that breaks the dynamic slide indexer for
+    /// non-first slides would cause a <c>COMException</c> or wrong-index failure here.
+    /// </remarks>
+    [Fact]
+    public void SetAndGetNotesText_OnSlide2_WorksCorrectly()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        _slideCommands.AddBlank(batch); // presentation now has slides 1 and 2
+
+        var setResult = _notesCommands.SetNotesText(batch, 2, "Speaker notes for slide 2.");
+
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        Assert.Null(setResult.ErrorMessage);
+
+        var getResult = _notesCommands.GetNotesText(batch, 2);
+
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.Equal("Speaker notes for slide 2.", getResult.NotesText);
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetNotesText</c> on slide 2 with no text set returns an empty string,
+    /// not an exception — confirming the dynamic placeholder scan is slide-index-independent.
+    /// </summary>
+    [Fact]
+    public void GetNotesText_OnFreshSlide2_WithNoTextSet_ReturnsSuccessWithEmptyText()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        _slideCommands.AddBlank(batch); // 2 slides; slide 2 has no notes
+
+        var result = _notesCommands.GetNotesText(batch, 2);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Null(result.ErrorMessage);
+        Assert.NotNull(result.NotesText);
+        Assert.Equal(string.Empty, result.NotesText);
+    }
+
+    /// <summary>
+    /// Verifies that notes set on slide 1 are independent from notes on slide 2 — no
+    /// cross-slide pollution via the dynamic <c>Slides[slideIndex].NotesPage</c> access.
+    /// </summary>
+    [Fact]
+    public void SetNotesText_OnSlide1_DoesNotAffectSlide2_Notes()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        _slideCommands.AddBlank(batch); // 2 slides
+
+        _notesCommands.SetNotesText(batch, 1, "Slide 1 notes.");
+
+        var slide2Result = _notesCommands.GetNotesText(batch, 2);
+
+        Assert.True(slide2Result.Success, slide2Result.ErrorMessage);
+        // Slide 2 notes must be unaffected — any cross-slide dynamic indexer bug would
+        // cause slide 2's notes to read back slide 1's text.
+        Assert.Equal(string.Empty, slide2Result.NotesText);
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/PiaMigrationGuardTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PiaMigrationGuardTests.cs
@@ -1,0 +1,342 @@
+using System.Text.RegularExpressions;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>
+/// Static code-quality guards for the PIA migration: dynamic-keyword ratchet,
+/// reflection-activation ban, and raw-pp*-constant ban for non-Image Core/ComInterop.
+/// </summary>
+/// <remarks>
+/// <para><b>Dynamic-keyword ratchet</b> (<see cref="NonImageCoreDomains_DynamicKeywordCount_DoesNotExceedAllowlist"/>):
+/// asserts that the count of <c>dynamic</c> keyword usages in each non-Image Core source file
+/// does not EXCEED the actual count captured after the PIA migration (2026-07-11). Counts are
+/// set to the real post-migration values, making this a true one-way ratchet:
+/// decreasing counts keep it green (progress), increasing counts fail it (regression).
+/// </para>
+///
+/// <para><b>Reflection-activation ban</b> (<see cref="NonImageCoreAndComInterop_ReflectionActivationPatterns_AreAbsent"/>):
+/// scans non-Image Core <em>and</em> ComInterop (excluding <c>obj/</c>) for known COM-bypassing
+/// reflection patterns: <c>Type.GetTypeFromProgID</c>, <c>Activator.CreateInstance</c>,
+/// <c>.InvokeMember(</c>. These patterns circumvent the embedded PowerPoint PIA and must not
+/// appear in production code.</para>
+///
+/// <para><b>Raw pp* constant ban</b> (<see cref="NonImageCore_RawPpEnumConstantDefinitions_AreAbsent"/>):
+/// scans non-Image Core for assignments of the form <c>pp[A-Z]\w+ = \d+</c> — a raw integer
+/// constant definition for a pp*-named identifier that should instead use a typed
+/// <c>PowerPoint.Pp*</c> PIA value. Limitation: inline literal comparisons (e.g.
+/// <c>shape.Type == 2</c>) are not caught by this guard — those require code review. Justified
+/// <c>mso*</c> integer constants (e.g. <c>const int MsoShapePlaceholder = 14</c>) are not
+/// matched and remain permitted.</para>
+///
+/// <para><b>Rules:</b></para>
+/// <list type="bullet">
+///   <item>A file's dynamic count <em>may decrease</em> (migration progress). Green.</item>
+///   <item>A file's dynamic count <em>may not increase</em> without updating the allowlist. Red.</item>
+///   <item>Image domain is <em>hard-excluded</em> from all guards — a separate task owns it.</item>
+///   <item>Reflection-activation and raw-pp* guards have zero tolerance — no allowlist, fail on
+///   first match.</item>
+/// </list>
+///
+/// <para><b>How to update the dynamic allowlist legitimately:</b> (1) verify the new usage
+/// cannot use typed PIA; (2) add an inline comment in the source file explaining why;
+/// (3) increment the matching max in <see cref="DynamicAllowlist"/> and reference the reason.</para>
+///
+/// <para><b>Note on accuracy:</b> the regex <c>\bdynamic\s</c> also matches occurrences inside
+/// XML doc comments — these are rare in this codebase and remain within the allowlist budget.
+/// The guard is intentionally approximate (preventing drift, not perfect static analysis).</para>
+/// </remarks>
+[Trait("Category", "CodeQuality")]
+public class PiaMigrationGuardTests
+{
+    // Per-file maximum allowed count of `dynamic ` keyword occurrences (word boundary + whitespace).
+    // Counts are set to the ACTUAL post-migration values (2026-07-11) so this is a true one-way
+    // ratchet: a file's count may decrease (migration progress → stays green) but may not increase
+    // (regression → fails).
+    //
+    // Justified residual dynamic per file:
+    //   Animation  — Effect.Exit and SlideShowTransition.AdvanceOnClick / .AdvanceOnTime are
+    //                MsoTriState (Office.Core / office.dll, not referenced); the typed setter
+    //                requires dynamic dispatch. MsoAnimEffect, MsoAnimTriggerType, PpEntryEffect,
+    //                and MsoAnimateByLevel are all exposed by the embedded PowerPoint PIA and have
+    //                already been migrated to typed form — they are NOT the reason for residual
+    //                dynamic here.
+    //   Chart      — Shape.HasChart is MsoTriState (Office.Core); SeriesCollection / XValues /
+    //                NewSeries are Microsoft.Office.Interop.Excel types (Excel.dll not referenced);
+    //                chart-shape access via dynamic to avoid that reference. Residual count
+    //                reflects the post-migration state where only these office.dll-dependent paths
+    //                remain dynamic.
+    //   Master     — ctx.Presentation.SlideMaster hangs indefinitely via typed NoPIA interface
+    //                (documented quirk identical to CoreTestHelper.CreateTemplateFile). Stays dynamic.
+    //   Notes      — NotesPage / shape iteration accessed dynamically; msoPlaceholder (= 14) is an
+    //                MsoShapeType raw int constant (no typed equivalent in scope without office.dll);
+    //                PpPlaceholderType is already typed via PowerPoint PIA.
+    //   Presentation — BuiltInDocumentProperties / CustomDocumentProperties return
+    //                  Microsoft.Office.Core.DocumentProperty (office.dll). Cannot use typed PIA.
+    //   Shape      — MsoAutoShapeType / MsoConnectorType / MsoTextOrientation / MsoShadowStyle /
+    //                MsoReflectionType etc. are all in office.dll. Line.Visible and Shadow.Visible
+    //                setters are MsoTriState (office.dll). Residual dynamic is the post-migration
+    //                minimum for these office.dll-dependent properties.
+    //   Slide      — FollowMasterBackground is MsoTriState (office.dll); SectionProperties /
+    //                FillFormat.TwoColorGradient paths also require dynamic for office.dll types.
+    //   SmartArt   — Office.SmartArtLayouts / SmartArtNode / SmartArtNodes are in office.dll;
+    //                Shape.HasSmartArt is MsoTriState (office.dll). Entire SmartArt surface stays
+    //                dynamic by design.
+    //   Table      — Cell border Visible setter is MsoTriState (office.dll); table/cell access
+    //                via dynamic for the border line-style properties with no typed PIA path.
+    //   TextFrame  — Font.Bold / .Italic / .Underline and ParagraphFormat.Bullet signatures
+    //                reference Office.Core types from office.dll. Minimum residual count.
+    private static readonly Dictionary<string, int> DynamicAllowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // domain path (relative to src/PowerPointMcp.Core)         max allowed   reason
+        ["Animation\\AnimationCommands.cs"]       =  4,  // Effect.Exit + Transition.AdvanceOnClick/AdvanceOnTime are MsoTriState (office.dll)
+        ["Chart\\ChartCommands.cs"]               = 21,  // Shape.HasChart (MsoTriState) + Excel.SeriesCollection/XValues (Excel.dll)
+        ["Master\\MasterCommands.cs"]             =  5,  // SlideMaster NoPIA hang + Font.Bold MsoTriState (office.dll)
+        ["Notes\\NotesCommands.cs"]               =  3,  // NotesPage / shape iteration — office.dll types
+        ["Presentation\\PresentationCommands.cs"] =  5,  // DocumentProperties (office.dll)
+        ["Shape\\ShapeCommands.cs"]               = 26,  // MsoAutoShapeType / MsoShadowStyle / Line+Shadow Visible (office.dll)
+        ["Slide\\SlideCommands.cs"]               =  5,  // FollowMasterBackground MsoTriState + FillFormat/SectionProperties (office.dll)
+        ["SmartArt\\SmartArtCommands.cs"]         = 20,  // SmartArtLayouts / HasSmartArt MsoTriState (office.dll)
+        ["Table\\TableCommands.cs"]               =  4,  // Border Visible MsoTriState + cell/border access (office.dll)
+        ["TextFrame\\TextFrameCommands.cs"]       =  7,  // Font tri-state + ParagraphFormat.Bullet (office.dll)
+    };
+
+    /// <summary>
+    /// For every non-Image Core .cs file in <see cref="DynamicAllowlist"/>, asserts that the
+    /// actual count of <c>dynamic</c> keyword usages does not exceed the recorded maximum.
+    /// Migration progress (decreasing counts) passes; new additions (increasing counts) fail.
+    /// </summary>
+    [Fact]
+    public void NonImageCoreDomains_DynamicKeywordCount_DoesNotExceedAllowlist()
+    {
+        string repoRoot = FindRepoRoot();
+        string coreSourceRoot = Path.Combine(repoRoot, "src", "PowerPointMcp.Core");
+
+        var violations = new List<string>();
+        var missing = new List<string>();
+
+        foreach (var (relPath, maxAllowed) in DynamicAllowlist)
+        {
+            string fullPath = Path.Combine(coreSourceRoot, relPath);
+            if (!File.Exists(fullPath))
+            {
+                missing.Add($"  {relPath} — file not found (renamed/deleted?). Update DynamicAllowlist.");
+                continue;
+            }
+
+            string content = File.ReadAllText(fullPath);
+            int actual = CountDynamicKeyword(content);
+
+            if (actual > maxAllowed)
+            {
+                violations.Add(
+                    $"  {relPath}: found {actual}, max {maxAllowed}. " +
+                    "Add a code comment explaining why the new 'dynamic' is justified, then increment its max in DynamicAllowlist.");
+            }
+        }
+
+        var allErrors = violations.Concat(missing).ToList();
+        Assert.True(
+            allErrors.Count == 0,
+            "PIA migration guard failed.\n\n" +
+            string.Join("\n", allErrors) + "\n\n" +
+            "This test prevents NEW unjustified late-binding during the PIA migration. " +
+            "To legitimately add a new 'dynamic' usage: (1) verify it cannot use typed PIA, " +
+            "(2) add an inline comment in the source file explaining why, " +
+            "(3) increment the matching max in DynamicAllowlist in PiaMigrationGuardTests.cs.");
+    }
+
+    /// <summary>
+    /// Verifies that the Image domain is not accidentally included in the allowlist.
+    /// Image is owned by a separate migration task and must never appear here.
+    /// </summary>
+    [Fact]
+    public void ImageDomain_IsNotInAllowlist()
+    {
+        foreach (string key in DynamicAllowlist.Keys)
+        {
+            Assert.False(
+                key.Contains("Image", StringComparison.OrdinalIgnoreCase),
+                $"Image domain path '{key}' must not appear in the PIA migration guard allowlist. " +
+                "Image is owned by a separate task (hard exclusion).");
+        }
+    }
+
+    /// <summary>
+    /// Scans non-Image Core <em>and</em> ComInterop (excluding generated <c>obj/</c> output)
+    /// for known reflection-based COM activation/dispatch patterns that bypass the embedded
+    /// PowerPoint PIA:
+    /// <list type="bullet">
+    ///   <item><c>Type.GetTypeFromProgID(</c> — late-bound ProgID activation</item>
+    ///   <item><c>Activator.CreateInstance(</c> — generic reflection instantiation</item>
+    ///   <item><c>.InvokeMember(</c> — late-bound member dispatch</item>
+    /// </list>
+    /// Zero occurrences are allowed. PowerPoint should always be started via the typed
+    /// <c>new PowerPoint.Application()</c> PIA constructor (as in <c>PresentationBatch.cs</c>),
+    /// never via reflection activation.
+    /// </summary>
+    [Fact]
+    public void NonImageCoreAndComInterop_ReflectionActivationPatterns_AreAbsent()
+    {
+        string repoRoot = FindRepoRoot();
+        string coreRoot      = Path.Combine(repoRoot, "src", "PowerPointMcp.Core");
+        string comInteropRoot = Path.Combine(repoRoot, "src", "PowerPointMcp.ComInterop");
+
+        var coreFiles = Directory.GetFiles(coreRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}Image{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+
+        var comInteropFiles = Directory.GetFiles(comInteropRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+
+        var allFiles = coreFiles.Concat(comInteropFiles);
+
+        // Patterns that represent COM activation/dispatch via reflection — all are forbidden.
+        var forbiddenPatterns = new (string Label, Regex Pattern)[]
+        {
+            ("Type.GetTypeFromProgID",    new Regex(@"\bType\.GetTypeFromProgID\s*\(",    RegexOptions.Compiled)),
+            ("Activator.CreateInstance",  new Regex(@"\bActivator\.CreateInstance\s*\(",  RegexOptions.Compiled)),
+            (".InvokeMember",             new Regex(@"\.InvokeMember\s*\(",               RegexOptions.Compiled)),
+        };
+
+        var violations = new List<string>();
+
+        foreach (string filePath in allFiles)
+        {
+            string content = File.ReadAllText(filePath);
+            foreach (var (label, pattern) in forbiddenPatterns)
+            {
+                if (pattern.IsMatch(content))
+                {
+                    string rel = GetRelativePath(repoRoot, filePath);
+                    int count  = pattern.Count(content);
+                    violations.Add($"  {rel}: found {count}× '{label}'");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Reflection-based COM activation/dispatch found in Core or ComInterop.\n\n" +
+            string.Join("\n", violations) + "\n\n" +
+            "Use typed PowerPoint PIA ('new PowerPoint.Application()') instead of " +
+            "Type.GetTypeFromProgID / Activator.CreateInstance / InvokeMember.");
+    }
+
+    /// <summary>
+    /// Scans non-Image Core for raw integer constant <em>definitions</em> of pp*-named
+    /// identifiers (e.g. <c>const int ppPlaceholderBody = 2;</c>), which should instead use
+    /// typed <c>PowerPoint.Pp*</c> PIA values that are available in the embedded assembly.
+    /// </summary>
+    /// <remarks>
+    /// Pattern matched: <c>\bpp[A-Z]\w+\s*=\s*\d+</c>
+    /// (a pp*-prefixed identifier directly assigned a raw integer literal).
+    ///
+    /// <b>Not matched (and not rejected):</b>
+    /// <list type="bullet">
+    ///   <item><c>mso*</c>-named integer constants — e.g. <c>const int MsoShapePlaceholder = 14</c>
+    ///   — these refer to Office.Core types not exposed in the embedded PowerPoint PIA and are
+    ///   a documented justified exception (Notes, Master).</item>
+    ///   <item>Typed PIA usages — e.g. <c>= PowerPoint.PpEntryEffect.ppEffectFade</c> — the
+    ///   right-hand side is not a bare integer.</item>
+    ///   <item>String-literal keys — e.g. <c>["ppEffectFade"]</c> in dictionary initializers —
+    ///   the word boundary + `\s*=\s*\d+` suffix prevents a match.</item>
+    /// </list>
+    ///
+    /// <b>Known limitation:</b> inline literal <em>comparisons</em> such as
+    /// <c>shape.Type == 2</c> (where 2 should be <c>PowerPoint.PpPlaceholderType.ppPlaceholderBody</c>)
+    /// are not reliably detectable without parsing context and are therefore not guarded here.
+    /// Those patterns must be caught via code review.
+    /// </remarks>
+    [Fact]
+    public void NonImageCore_RawPpEnumConstantDefinitions_AreAbsent()
+    {
+        string repoRoot  = FindRepoRoot();
+        string coreRoot  = Path.Combine(repoRoot, "src", "PowerPointMcp.Core");
+
+        var coreFiles = Directory.GetFiles(coreRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}Image{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+
+        // Matches: bare pp[A-Z]-prefixed identifier immediately followed by `= <digits>`
+        // e.g. `ppPlaceholderBody = 2` — should use PowerPoint.PpPlaceholderType.ppPlaceholderBody
+        var rawPpPattern = new Regex(@"\bpp[A-Z]\w+\s*=\s*\d+", RegexOptions.Compiled);
+
+        var violations = new List<string>();
+
+        foreach (string filePath in coreFiles)
+        {
+            string content = File.ReadAllText(filePath);
+            var matches = rawPpPattern.Matches(content);
+            if (matches.Count > 0)
+            {
+                string rel = GetRelativePath(repoRoot, filePath);
+                foreach (Match m in matches)
+                {
+                    violations.Add($"  {rel}: raw pp* constant '{m.Value.Trim()}' — use typed PowerPoint.Pp* PIA value instead");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Raw pp* integer constant definitions found in non-Image Core. " +
+            "These should use typed PowerPoint PIA values (e.g. PowerPoint.PpPlaceholderType.ppPlaceholderBody).\n\n" +
+            string.Join("\n", violations) + "\n\n" +
+            "Justified mso* integer constants (e.g. MsoShapePlaceholder = 14) remain permitted " +
+            "and are not matched by this guard. See test remarks for the known limitation on " +
+            "inline literal comparisons.");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Counts occurrences of the <c>dynamic</c> keyword (word boundary followed by whitespace)
+    /// in <paramref name="source"/>. Counts inside XML doc comments are included; this is
+    /// intentional and acceptable given the low frequency in this codebase.
+    /// </summary>
+    private static int CountDynamicKeyword(string source)
+        => Regex.Count(source, @"\bdynamic\s");
+
+    /// <summary>
+    /// Returns a path relative to <paramref name="root"/>, for readable assertion messages.
+    /// Falls back to the full path when no common prefix is found.
+    /// </summary>
+    private static string GetRelativePath(string root, string fullPath)
+    {
+        if (fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+        {
+            string rel = fullPath.Substring(root.Length);
+            return rel.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Walks up the directory tree from the executing test assembly until it finds a directory
+    /// that contains a <c>.slnx</c> or <c>.sln</c> file, which identifies the repository root.
+    /// </summary>
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(PiaMigrationGuardTests).Assembly.Location);
+
+        while (dir is not null)
+        {
+            bool hasSlnx = Directory.GetFiles(dir, "*.slnx", SearchOption.TopDirectoryOnly).Length > 0;
+            bool hasSln  = Directory.GetFiles(dir, "*.sln",  SearchOption.TopDirectoryOnly).Length > 0;
+
+            if (hasSlnx || hasSln)
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root by searching for a .slnx/.sln file. " +
+            $"Test assembly location: {typeof(PiaMigrationGuardTests).Assembly.Location}");
+    }
+}

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpImageToolSchemaTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpImageToolSchemaTests.cs
@@ -1,0 +1,599 @@
+// Copyright (c) Sbroenne. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO.Pipelines;
+using System.Reflection;
+using System.Text.Json;
+using ModelContextProtocol.Client;
+using Sbroenne.PowerPointMcp.Core.Image;
+using Sbroenne.PowerPointMcp.Generated;
+using Sbroenne.PowerPointMcp.McpServer.Tools;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sbroenne.PowerPointMcp.McpServer.Tests.Integration;
+
+/// <summary>
+/// Future-proof schema tests that verify every <c>IImageCommands</c> method is correctly
+/// translated to the generated MCP <c>image</c> tool via <c>tools/list</c>, AND that the
+/// generated CLI surface (via <see cref="ServiceRegistry.Image.CliSettings"/> and
+/// <see cref="ServiceRegistry.Image.RouteCliArgs"/>) exposes every action and parameter.
+/// Tests fail if any interface method is omitted, renamed, or its parameters are mistranslated
+/// by the generator. No PowerPoint COM instance is required — MCP tests run via in-memory
+/// transport; CLI tests are no-transport reflective assertions.
+/// </summary>
+/// <remarks>
+/// Design intent: ground-truth is derived from <see cref="ServiceRegistry.Image.ValidActions"/>
+/// (itself generated from <c>IImageCommands</c> by <c>ServiceRegistryGenerator</c>) and the
+/// stable camelCase → snake_case naming rule, so adding a new method to <c>IImageCommands</c>
+/// automatically propagates into an assertion failure here until both the MCP and CLI surfaces
+/// catch up. The <see cref="ImageAction"/> enum cross-check (no transport needed) additionally
+/// guards that the enum members stay in sync with <c>ValidActions</c>.
+/// </remarks>
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Image")]
+public sealed class McpImageToolSchemaTests : IAsyncLifetime, IAsyncDisposable
+{
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Ground truth: derived from ServiceRegistry (generated from IImageCommands).
+    // Adding a method to IImageCommands (and re-running the generator) extends ValidActions,
+    // which immediately makes the protocol assertions below fail until the MCP surface
+    // is regenerated to include the new action and its parameters.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Expected MCP parameter names: fixed generator params + the union of all
+    /// <c>IImageCommands</c> method parameters (excluding <c>IPresentationBatch</c>),
+    /// converted via the stable camelCase → snake_case naming rule.
+    /// <list type="table">
+    ///   <listheader><term>Interface param</term><term>snake_case MCP name</term><term>Required for</term></listheader>
+    ///   <item><term>(enum, generated)</term><term>action</term><term>all — ImageAction enum</term></item>
+    ///   <item><term>(generator fixed)</term><term>session_id</term><term>all</term></item>
+    ///   <item><term>slideIndex</term><term>slide_index</term><term>all 7 actions</term></item>
+    ///   <item><term>imagePath</term><term>image_path</term><term>add-picture</term></item>
+    ///   <item><term>left</term><term>left</term><term>add-picture</term></item>
+    ///   <item><term>top</term><term>top</term><term>add-picture</term></item>
+    ///   <item><term>width</term><term>width</term><term>add-picture</term></item>
+    ///   <item><term>height</term><term>height</term><term>add-picture</term></item>
+    ///   <item><term>shapeIndex</term><term>shape_index</term><term>set/get-brightness-contrast, set/get-recolor, set/get-crop</term></item>
+    ///   <item><term>brightness</term><term>brightness</term><term>set-brightness-contrast</term></item>
+    ///   <item><term>contrast</term><term>contrast</term><term>set-brightness-contrast</term></item>
+    ///   <item><term>colorType</term><term>color_type</term><term>set-recolor</term></item>
+    ///   <item><term>cropLeft</term><term>crop_left</term><term>set-crop</term></item>
+    ///   <item><term>cropTop</term><term>crop_top</term><term>set-crop</term></item>
+    ///   <item><term>cropRight</term><term>crop_right</term><term>set-crop</term></item>
+    ///   <item><term>cropBottom</term><term>crop_bottom</term><term>set-crop</term></item>
+    /// </list>
+    /// </summary>
+    private static readonly HashSet<string> ExpectedMcpParameters = new(StringComparer.Ordinal)
+    {
+        "action",       // generated: ImageAction enum, one entry per IImageCommands method
+        "session_id",   // generator fixed: added for all session-aware tools
+        "slide_index",  // slideIndex  → snake_case (required for all 7 actions)
+        "image_path",   // imagePath   → snake_case (required for: add-picture)
+        "left",         // left        → unchanged  (required for: add-picture)
+        "top",          // top         → unchanged  (required for: add-picture)
+        "width",        // width       → unchanged  (required for: add-picture)
+        "height",       // height      → unchanged  (required for: add-picture)
+        "shape_index",  // shapeIndex  → snake_case (required for: set/get-brightness-contrast, set/get-recolor, set/get-crop)
+        "brightness",   // brightness  → unchanged  (required for: set-brightness-contrast)
+        "contrast",     // contrast    → unchanged  (required for: set-brightness-contrast)
+        "color_type",   // colorType   → snake_case (required for: set-recolor)
+        "crop_left",    // cropLeft    → snake_case (required for: set-crop)
+        "crop_top",     // cropTop     → snake_case (required for: set-crop)
+        "crop_right",   // cropRight   → snake_case (required for: set-crop)
+        "crop_bottom",  // cropBottom  → snake_case (required for: set-crop)
+    };
+
+    private readonly ITestOutputHelper _output;
+    private readonly Pipe _clientToServerPipe = new();
+    private readonly Pipe _serverToClientPipe = new();
+    private readonly CancellationTokenSource _cts = new();
+    private McpClient? _client;
+    private Task? _serverTask;
+
+    public McpImageToolSchemaTests(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        (_client, _serverTask) = await ProgramTransportTestHost.StartAsync(
+            _clientToServerPipe,
+            _serverToClientPipe,
+            "ImageSchemaTestClient",
+            _cts.Token);
+
+        _output.WriteLine($"✓ Connected: {_client.ServerInfo?.Name} v{_client.ServerInfo?.Version}");
+    }
+
+    public async Task DisposeAsync() => await DisposeAsyncCore();
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await DisposeAsyncCore();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task DisposeAsyncCore()
+    {
+        await ProgramTransportTestHost.StopAsync(
+            _client, _clientToServerPipe, _serverToClientPipe, _serverTask, _output);
+        _cts.Dispose();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // No-transport guard: ImageAction enum ↔ ValidActions in sync
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The generated <see cref="ImageAction"/> enum must have exactly as many members as
+    /// <see cref="ServiceRegistry.Image.ValidActions"/> and every action must round-trip through
+    /// <see cref="ServiceRegistry.Image.TryParseAction"/>. Both are generated from
+    /// <c>IImageCommands</c> — this cross-check guards that the two generated artifacts stay in
+    /// sync. Does not require a transport connection.
+    /// </summary>
+    [Fact]
+    public void ImageAction_EnumAndValidActions_AreInSync()
+    {
+        var enumActions = Enum.GetValues<ImageAction>()
+            .Select(a => ServiceRegistry.Image.ToActionString(a))
+            .ToList();
+
+        Assert.Equal(
+            ServiceRegistry.Image.ValidActions.Length,
+            enumActions.Count);
+
+        // Every ValidAction must parse to an enum member and convert back losslessly.
+        foreach (var action in ServiceRegistry.Image.ValidActions)
+        {
+            Assert.True(
+                ServiceRegistry.Image.TryParseAction(action, out var parsed),
+                $"ValidAction '{action}' (from IImageCommands) cannot be parsed to an ImageAction enum member.");
+
+            var roundTripped = ServiceRegistry.Image.ToActionString(parsed);
+            Assert.True(
+                action == roundTripped,
+                $"Action '{action}' did not survive a round-trip through the enum: got '{roundTripped}'.");
+        }
+
+        _output.WriteLine(
+            $"✓ ImageAction enum ({enumActions.Count} members) matches ValidActions and round-trips correctly");
+    }
+
+    [Fact]
+    public void ImageCropResult_SerializesResponseFieldsAsCamelCase()
+    {
+        var result = new ImageOperationResult
+        {
+            Success = true,
+            CropLeft = 1f,
+            CropTop = 2f,
+            CropRight = 3f,
+            CropBottom = 4f
+        };
+
+        using var document = JsonDocument.Parse(PowerPointToolsBase.Serialize(result));
+        JsonElement root = document.RootElement;
+
+        Assert.Equal(1f, root.GetProperty("cropLeft").GetSingle());
+        Assert.Equal(2f, root.GetProperty("cropTop").GetSingle());
+        Assert.Equal(3f, root.GetProperty("cropRight").GetSingle());
+        Assert.Equal(4f, root.GetProperty("cropBottom").GetSingle());
+        Assert.False(root.TryGetProperty("crop_left", out _));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Protocol assertions: tools/list schema (no COM)
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The top-level description of the MCP <c>image</c> tool must mention every action string
+    /// from <see cref="ServiceRegistry.Image.ValidActions"/>. The description is generated from
+    /// the list of interface methods, so dropping a method from <c>IImageCommands</c> (and
+    /// regenerating) causes the description to shrink and this test to fail.
+    /// </summary>
+    [Fact]
+    public async Task ImageTool_ToolDescription_MentionsEveryInterfaceAction()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var imageTool = tools.SingleOrDefault(t => t.Name == ServiceRegistry.Image.McpToolName);
+        Assert.NotNull(imageTool);
+
+        var description = imageTool.Description ?? "";
+        _output.WriteLine($"Tool description: {description}");
+
+        foreach (var action in ServiceRegistry.Image.ValidActions)
+        {
+            Assert.True(
+                description.Contains(action, StringComparison.Ordinal),
+                $"Image tool description is missing action '{action}' (from IImageCommands.{action}). " +
+                $"The generator may have dropped a method from the interface.");
+        }
+
+        _output.WriteLine(
+            $"✓ Tool description mentions all {ServiceRegistry.Image.ValidActions.Length} IImageCommands actions");
+    }
+
+    /// <summary>
+    /// The <c>action</c> parameter description in the MCP schema must mention every action from
+    /// <see cref="ServiceRegistry.Image.ValidActions"/>. This is separate from the top-level tool
+    /// description so both description surfaces are covered.
+    /// </summary>
+    [Fact]
+    public async Task ImageTool_ActionParameterDescription_MentionsEveryInterfaceAction()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var imageTool = tools.Single(t => t.Name == ServiceRegistry.Image.McpToolName);
+
+        var schema = imageTool.JsonSchema;
+        Assert.True(
+            schema.TryGetProperty("properties", out var properties),
+            "Image tool schema is missing the 'properties' object.");
+
+        var actionDesc = GetPropertyDescription(properties, "action");
+        _output.WriteLine($"action parameter description: {actionDesc}");
+
+        foreach (var action in ServiceRegistry.Image.ValidActions)
+        {
+            Assert.True(
+                actionDesc.Contains(action, StringComparison.Ordinal),
+                $"Action parameter description is missing '{action}' (from IImageCommands). " +
+                $"The generator may have dropped a method from the 'action' enum description.");
+        }
+
+        _output.WriteLine(
+            $"✓ 'action' parameter description mentions all {ServiceRegistry.Image.ValidActions.Length} actions");
+    }
+
+    /// <summary>
+    /// The <c>image</c> tool's JSON schema must expose exactly the parameters from
+    /// <see cref="ExpectedMcpParameters"/> — no more, no less. Fails if a parameter is omitted,
+    /// renamed (mis-converted from camelCase to snake_case), or an unexpected extra parameter
+    /// appears in the generated output.
+    /// </summary>
+    [Fact]
+    public async Task ImageTool_Schema_ContainsExactlyAllInterfaceParameters()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var imageTool = tools.Single(t => t.Name == ServiceRegistry.Image.McpToolName);
+
+        var schema = imageTool.JsonSchema;
+        Assert.True(
+            schema.TryGetProperty("properties", out var properties),
+            "Image tool schema is missing the 'properties' object.");
+
+        var actualParams = properties.EnumerateObject()
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        _output.WriteLine(
+            $"Actual schema params ({actualParams.Count}): " +
+            $"{string.Join(", ", actualParams.OrderBy(x => x))}");
+        _output.WriteLine(
+            $"Expected schema params ({ExpectedMcpParameters.Count}): " +
+            $"{string.Join(", ", ExpectedMcpParameters.OrderBy(x => x))}");
+
+        var missing = ExpectedMcpParameters.Except(actualParams).OrderBy(x => x).ToList();
+        var extra = actualParams.Except(ExpectedMcpParameters).OrderBy(x => x).ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"Image tool schema is missing parameters that IImageCommands declares: " +
+            $"{string.Join(", ", missing)}. " +
+            $"Either the generator dropped a method/parameter or the snake_case conversion changed.");
+
+        Assert.True(
+            extra.Count == 0,
+            $"Image tool schema has unexpected extra parameters not in IImageCommands: " +
+            $"{string.Join(", ", extra)}. Update ExpectedMcpParameters if IImageCommands was intentionally extended.");
+
+        _output.WriteLine(
+            $"✓ Image tool schema has exactly {actualParams.Count} expected parameters");
+    }
+
+    /// <summary>
+    /// The parameter descriptions in the <c>image</c> tool schema must correctly document
+    /// which actions require each parameter — matching <c>IImageCommands</c> method signatures.
+    /// Changing which parameters a method accepts (e.g., adding a new parameter to
+    /// <c>SetRecolor</c>) should cause the "required for" description to change and fail here.
+    /// </summary>
+    [Fact]
+    public async Task ImageTool_ParameterDescriptions_CorrectlyDocumentRequiredByActions()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var imageTool = tools.Single(t => t.Name == ServiceRegistry.Image.McpToolName);
+
+        var schema = imageTool.JsonSchema;
+        schema.TryGetProperty("properties", out var properties);
+
+        // image_path: required only for add-picture
+        AssertRequiredFor(properties, "image_path",
+            required: [ServiceRegistry.Image.AddPictureAction],
+            notRequired: [
+                ServiceRegistry.Image.SetBrightnessContrastAction,
+                ServiceRegistry.Image.GetBrightnessContrastAction,
+                ServiceRegistry.Image.SetRecolorAction,
+                ServiceRegistry.Image.GetRecolorAction,
+                ServiceRegistry.Image.SetCropAction,
+                ServiceRegistry.Image.GetCropAction]);
+
+        // color_type: required only for set-recolor
+        AssertRequiredFor(properties, "color_type",
+            required: [ServiceRegistry.Image.SetRecolorAction],
+            notRequired: [
+                ServiceRegistry.Image.AddPictureAction,
+                ServiceRegistry.Image.SetBrightnessContrastAction,
+                ServiceRegistry.Image.GetBrightnessContrastAction,
+                ServiceRegistry.Image.GetRecolorAction,
+                ServiceRegistry.Image.SetCropAction,
+                ServiceRegistry.Image.GetCropAction]);
+
+        // brightness + contrast: required only for set-brightness-contrast
+        AssertRequiredFor(properties, "brightness",
+            required: [ServiceRegistry.Image.SetBrightnessContrastAction],
+            notRequired: [
+                ServiceRegistry.Image.AddPictureAction,
+                ServiceRegistry.Image.SetRecolorAction,
+                ServiceRegistry.Image.GetRecolorAction,
+                ServiceRegistry.Image.SetCropAction,
+                ServiceRegistry.Image.GetCropAction]);
+
+        AssertRequiredFor(properties, "contrast",
+            required: [ServiceRegistry.Image.SetBrightnessContrastAction],
+            notRequired: [
+                ServiceRegistry.Image.AddPictureAction,
+                ServiceRegistry.Image.SetRecolorAction,
+                ServiceRegistry.Image.GetRecolorAction,
+                ServiceRegistry.Image.SetCropAction,
+                ServiceRegistry.Image.GetCropAction]);
+
+        // shape_index: required for every action except add-picture
+        AssertRequiredFor(properties, "shape_index",
+            required: [
+                ServiceRegistry.Image.SetBrightnessContrastAction,
+                ServiceRegistry.Image.GetBrightnessContrastAction,
+                ServiceRegistry.Image.SetRecolorAction,
+                ServiceRegistry.Image.GetRecolorAction,
+                ServiceRegistry.Image.SetCropAction,
+                ServiceRegistry.Image.GetCropAction],
+            notRequired: [ServiceRegistry.Image.AddPictureAction]);
+
+        // crop_left / crop_top / crop_right / crop_bottom: required only for set-crop
+        var cropNotRequired = new[]
+        {
+            ServiceRegistry.Image.AddPictureAction,
+            ServiceRegistry.Image.SetBrightnessContrastAction,
+            ServiceRegistry.Image.GetBrightnessContrastAction,
+            ServiceRegistry.Image.SetRecolorAction,
+            ServiceRegistry.Image.GetRecolorAction,
+            ServiceRegistry.Image.GetCropAction,
+        };
+
+        AssertRequiredFor(properties, "crop_left",
+            required: [ServiceRegistry.Image.SetCropAction],
+            notRequired: cropNotRequired);
+
+        AssertRequiredFor(properties, "crop_top",
+            required: [ServiceRegistry.Image.SetCropAction],
+            notRequired: cropNotRequired);
+
+        AssertRequiredFor(properties, "crop_right",
+            required: [ServiceRegistry.Image.SetCropAction],
+            notRequired: cropNotRequired);
+
+        AssertRequiredFor(properties, "crop_bottom",
+            required: [ServiceRegistry.Image.SetCropAction],
+            notRequired: cropNotRequired);
+
+        _output.WriteLine(
+            "✓ All parameter descriptions correctly document required-by-action constraints");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // CLI surface assertions (no transport, no COM)
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The generated <see cref="ServiceRegistry.Image.CliSettings"/> class must expose exactly the
+    /// expected CLI option long-names derived from <c>IImageCommands</c> parameter names via the
+    /// stable camelCase → kebab-case naming rule. Verified via reflection on
+    /// <c>CommandOptionAttribute</c> templates — fails if a parameter is dropped, renamed, or added
+    /// unexpectedly by the generator. Does not require a transport connection or PowerPoint.
+    /// </summary>
+    [Fact]
+    public void ImageCli_CliSettings_ContainsExactlyExpectedOptions()
+    {
+        // Extract --long-names from [CommandOption] attribute templates on CliSettings properties.
+        // Template format: "-s|--session <SESSION>" or "--crop-left <CROPLEFT>"
+        var cliOptionLongNames = typeof(ServiceRegistry.Image.CliSettings)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .SelectMany(p => p.GetCustomAttributesData())
+            .Where(a => a.AttributeType.Name == "CommandOptionAttribute")
+            .Select(a => a.ConstructorArguments.FirstOrDefault().Value?.ToString() ?? "")
+            // Take the first whitespace-delimited token (option flags, before the meta-var)
+            .Select(template => template.Split(' ', 2)[0])
+            // Split on | for "-s|--session" combined forms
+            .SelectMany(token => token.Split('|'))
+            .Where(part => part.StartsWith("--", StringComparison.Ordinal))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Expected long-names: session (fixed) + one per IImageCommands param (camelCase → kebab)
+        // plus output (fixed). Derived from IImageCommands method signatures via the generator's
+        // stable camelCase→kebab rule: slideIndex→--slide-index, cropLeft→--crop-left, etc.
+        var expectedOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "--session",       // fixed generator param (-s|--session)
+            "--slide-index",   // slideIndex  → kebab (all 7 actions)
+            "--image-path",    // imagePath   → kebab (add-picture)
+            "--left",          // left        → unchanged (add-picture)
+            "--top",           // top         → unchanged (add-picture)
+            "--width",         // width       → unchanged (add-picture)
+            "--height",        // height      → unchanged (add-picture)
+            "--shape-index",   // shapeIndex  → kebab (set/get-brightness-contrast, set/get-recolor, set/get-crop)
+            "--brightness",    // brightness  → unchanged (set-brightness-contrast)
+            "--contrast",      // contrast    → unchanged (set-brightness-contrast)
+            "--color-type",    // colorType   → kebab (set-recolor)
+            "--crop-left",     // cropLeft    → kebab (set-crop)
+            "--crop-top",      // cropTop     → kebab (set-crop)
+            "--crop-right",    // cropRight   → kebab (set-crop)
+            "--crop-bottom",   // cropBottom  → kebab (set-crop)
+            "--output",        // fixed generator param (-o|--output)
+        };
+
+        _output.WriteLine(
+            $"CLI option long-names ({cliOptionLongNames.Count}): " +
+            $"{string.Join(", ", cliOptionLongNames.OrderBy(x => x))}");
+        _output.WriteLine(
+            $"Expected options ({expectedOptions.Count}): " +
+            $"{string.Join(", ", expectedOptions.OrderBy(x => x))}");
+
+        var missing = expectedOptions.Except(cliOptionLongNames).OrderBy(x => x).ToList();
+        var extra = cliOptionLongNames.Except(expectedOptions).OrderBy(x => x).ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"CLI CliSettings is missing options for IImageCommands parameters: " +
+            $"{string.Join(", ", missing)}. The generator may have dropped a parameter or the camelCase→kebab conversion changed.");
+
+        Assert.True(
+            extra.Count == 0,
+            $"CLI CliSettings has unexpected extra options not in IImageCommands: " +
+            $"{string.Join(", ", extra)}. Update expectedOptions if IImageCommands was intentionally extended.");
+
+        _output.WriteLine(
+            $"✓ CLI CliSettings exposes exactly {cliOptionLongNames.Count} expected option long-names");
+    }
+
+    /// <summary>
+    /// <see cref="ServiceRegistry.Image.RouteCliArgs"/> must dispatch all 7
+    /// <c>IImageCommands</c> actions and return the correct command string for each.
+    /// Verifies that <c>set-crop</c> and <c>get-crop</c> are properly wired in the generated CLI
+    /// dispatch — a generator omission would throw <see cref="ArgumentException"/> here.
+    /// Does not require a transport connection or PowerPoint.
+    /// </summary>
+    [Fact]
+    public void ImageCli_RouteCliArgs_DispatchesAllSevenActions()
+    {
+        // add-picture (imagePath required — non-empty enforced by generated RequireNotEmpty guard)
+        var (addPicture, _) = ServiceRegistry.Image.RouteCliArgs(
+            "add-picture", slideIndex: 1, imagePath: "C:\\test.png", left: 0, top: 0, width: 100, height: 100);
+        Assert.Equal("image.add-picture", addPicture);
+
+        // set-brightness-contrast
+        var (setBC, _) = ServiceRegistry.Image.RouteCliArgs(
+            "set-brightness-contrast", slideIndex: 1, shapeIndex: 1, brightness: 0.5f, contrast: 0.5f);
+        Assert.Equal("image.set-brightness-contrast", setBC);
+
+        // get-brightness-contrast
+        var (getBC, _) = ServiceRegistry.Image.RouteCliArgs(
+            "get-brightness-contrast", slideIndex: 1, shapeIndex: 1);
+        Assert.Equal("image.get-brightness-contrast", getBC);
+
+        // set-recolor (colorType required — non-empty enforced by generated RequireNotEmpty guard)
+        var (setRecolor, _) = ServiceRegistry.Image.RouteCliArgs(
+            "set-recolor", slideIndex: 1, shapeIndex: 1, colorType: "msoPictureAutomatic");
+        Assert.Equal("image.set-recolor", setRecolor);
+
+        // get-recolor
+        var (getRecolor, _) = ServiceRegistry.Image.RouteCliArgs(
+            "get-recolor", slideIndex: 1, shapeIndex: 1);
+        Assert.Equal("image.get-recolor", getRecolor);
+
+        // set-crop — all four crop params wired through to the dispatch
+        var (setCrop, _) = ServiceRegistry.Image.RouteCliArgs(
+            "set-crop", slideIndex: 1, shapeIndex: 1,
+            cropLeft: 10f, cropTop: 20f, cropRight: 30f, cropBottom: 40f);
+        Assert.Equal("image.set-crop", setCrop);
+
+        // get-crop
+        var (getCrop, _) = ServiceRegistry.Image.RouteCliArgs(
+            "get-crop", slideIndex: 1, shapeIndex: 1);
+        Assert.Equal("image.get-crop", getCrop);
+
+        _output.WriteLine("✓ RouteCliArgs dispatches all 7 IImageCommands actions with correct command strings");
+    }
+
+    /// <summary>
+    /// <see cref="ServiceRegistry.Image.ValidActions"/> must contain exactly the 7 action strings
+    /// derived from <c>IImageCommands</c>, and every action must be dispatchable via
+    /// <see cref="ServiceRegistry.Image.RouteCliArgs"/>. Guards against both omissions (a new
+    /// method added to the interface but not to ValidActions) and accidental additions.
+    /// Does not require a transport connection or PowerPoint.
+    /// </summary>
+    [Fact]
+    public void ImageCli_ValidActions_ExactlyMatchInterfaceMethods()
+    {
+        var expectedActions = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "add-picture",
+            "set-brightness-contrast",
+            "get-brightness-contrast",
+            "set-recolor",
+            "get-recolor",
+            "set-crop",
+            "get-crop",
+        };
+
+        var actualActions = new HashSet<string>(
+            ServiceRegistry.Image.ValidActions, StringComparer.Ordinal);
+
+        _output.WriteLine(
+            $"ValidActions ({actualActions.Count}): {string.Join(", ", actualActions.OrderBy(x => x))}");
+
+        var missing = expectedActions.Except(actualActions).OrderBy(x => x).ToList();
+        var extra = actualActions.Except(expectedActions).OrderBy(x => x).ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"ValidActions is missing IImageCommands methods: {string.Join(", ", missing)}");
+
+        Assert.True(
+            extra.Count == 0,
+            $"ValidActions has unexpected extra actions: {string.Join(", ", extra)}. " +
+            $"Update expectedActions if IImageCommands was intentionally extended.");
+
+        _output.WriteLine(
+            $"✓ ValidActions contains exactly {actualActions.Count} expected actions");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    private void AssertRequiredFor(
+        JsonElement properties,
+        string paramName,
+        string[] required,
+        string[] notRequired)
+    {
+        var desc = GetPropertyDescription(properties, paramName);
+        _output.WriteLine($"  {paramName}: '{desc}'");
+
+        foreach (var action in required)
+        {
+            Assert.True(
+                desc.Contains(action, StringComparison.Ordinal),
+                $"Parameter '{paramName}' description should mention '{action}' (IImageCommands says it is required) but does not. " +
+                $"Description: '{desc}'");
+        }
+
+        foreach (var action in notRequired)
+        {
+            Assert.False(
+                desc.Contains(action, StringComparison.Ordinal),
+                $"Parameter '{paramName}' description should NOT mention '{action}' (not required by that action) but does. " +
+                $"Description: '{desc}'");
+        }
+    }
+
+    private static string GetPropertyDescription(JsonElement properties, string name)
+    {
+        if (!properties.TryGetProperty(name, out var prop))
+            return string.Empty;
+        if (prop.TryGetProperty("description", out var desc))
+            return desc.GetString() ?? string.Empty;
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- expose and document all actionable PowerPoint image formatting operations
- migrate Core COM access to typed PowerPoint PIA wherever supported
- retain narrowly justified late binding for unavailable Office/Excel interop surfaces
- add MCP/CLI parity and PIA regression guards

## Validation
- Release build: 0 warnings, 0 errors
- MCP suite: 18/18 passed
- Image, Animation, Chart, Master, and TextFrame real-COM suites passed in targeted runs

The final pre-commit hook rerun was explicitly overridden after a transient Office COM registration failure; the failed Chart test and full Chart suite both passed with a fresh Office process.