### PR TITLE
docs(vscode-extension): fix stale README build/publish notes

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -26,14 +26,15 @@ server definition provider and ships the associated Agent Skills.
 ```pwsh
 cd vscode-extension
 npm install
-npm run compile        # type-check + build extension.ts
-npm run package        # produce the .vsix (runs vscode:prepublish)
+npm run compile        # quick check: compiles src/extension.ts -> out/extension.js only
+npm run package        # produce the .vsix (runs vscode:prepublish -> full bundle)
 ```
 
-`vscode:prepublish` publishes the self-contained MCP server into `bin/`, copies
-the skill pack and changelog, then compiles the TypeScript.
-
-> **Note:** a marketplace `icon.png` still needs to be added before publishing.
+`npm run compile` is just a fast TypeScript build for local iteration — it does
+**not** bundle the MCP server or skills. The `.vsix` is produced by
+`npm run package`, which triggers `vscode:prepublish`: this publishes the
+self-contained MCP server into `bin/`, copies the skill pack and changelog, and
+then compiles the TypeScript.
 
 ## Links
 


### PR DESCRIPTION
## Summary

Reviews and corrects the VS Code Marketplace README for the extension.

- Removes the obsolete note claiming `icon.png` still needs to be added before publishing — `icon.png` now exists in `vscode-extension/` and is wired up in `package.json` (`"icon": "icon.png"`).
- Clarifies the **Building locally** section: `npm run compile` is a fast local TypeScript build only (does not bundle the MCP server or skills), while `npm run package` produces the `.vsix` via `vscode:prepublish`.

Docs-only change; pre-commit checks passed.