### PR TITLE
Add slide master and layout management tools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <!-- PowerPoint COM Interop PIA -->
     <PackageVersion Include="Microsoft.Office.Interop.PowerPoint" Version="15.0.4420.1018" />
     <!-- UI Framework (CLI) -->
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
     <PackageVersion Include="Spectre.Console" Version="0.57.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <!-- Roslyn source generators (CLI + skill-manifest generation only; see .squad/decisions.md) -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,8 @@
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.30" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="MessagePack.Annotations" Version="3.1.7" />
+    <!-- Pin the vulnerable transitive dependency used by PowerShell/other SDK packages to a patched release. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <!-- Test dependencies -->
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**13 MCP tools with 137 operations across 13 domains:**
+**13 MCP tools with 141 operations across 13 domains:**
 
 - 🗂️ **Presentation** (12 ops) — create, open, save, close, list sessions, apply a `.potx`/`.pptx`
   template's masters/theme/layouts, read the current theme name, read/write built-in and custom
@@ -55,8 +55,8 @@ layout regressions that text-only automation simply cannot detect.
 - ✏️ **TextFrame** (20 ops) — text, font size/name/color, bold, italic, underline, alignment, bullets
 - 📊 **Table** (12 ops) — add, cell text, insert/delete rows &amp; columns, cell fill/border, merge cells
 - 🗣️ **Notes** (2 ops) — set/get speaker notes
-- 🖼️ **Layout** (2 ops) — set/get slide layout
-- 🎭 **Master** (8 ops) — slide master title/body placeholder fonts, background color
+- 🖼️ **Layout** (4 ops) — set/get slide layout
+- 🎭 **Master** (10 ops) — slide master title/body placeholder fonts, background color
 - 🎬 **Animation** (5 ops) — shape entrance/emphasis/exit effects, slide transitions
 - 🖼️ **Image** (7 ops) — insert and adjust pictures (brightness, contrast, recolor, crop)
 - 📈 **Chart** (10 ops) — add chart, multi-series data, titles, axis titles, legend

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 13 MCP tools with 137 operations across 13 domains for live PowerPoint automation through single action-dispatch tools.
+description: 13 MCP tools with 141 operations across 13 domains for live PowerPoint automation through single action-dispatch tools.
 keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **13 MCP tools with 137 operations across 13 domains**.
+PowerPoint MCP Server exposes **13 MCP tools with 141 operations across 13 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -26,8 +26,8 @@ The CLI mirrors the same domain model:
 | `textframe` | 20 | Text content and text formatting | `textframe(action="...", session_id=..., ...)` | `pptcli textframe <action> -s <SESSION_ID> ...` |
 | `table` | 12 | Table creation and cell editing/formatting | `table(action="...", session_id=..., ...)` | `pptcli table <action> -s <SESSION_ID> ...` |
 | `notes` | 2 | Speaker notes | `notes(action="...", session_id=..., ...)` | `pptcli notes <action> -s <SESSION_ID> ...` |
-| `layout` | 2 | Slide layouts | `layout(action="...", session_id=..., ...)` | `pptcli layout <action> -s <SESSION_ID> ...` |
-| `master` | 8 | Slide master fonts and backgrounds | `master(action="...", session_id=..., ...)` | `pptcli master <action> -s <SESSION_ID> ...` |
+| `layout` | 4 | Slide layouts | `layout(action="...", session_id=..., ...)` | `pptcli layout <action> -s <SESSION_ID> ...` |
+| `master` | 10 | Slide master fonts and backgrounds | `master(action="...", session_id=..., ...)` | `pptcli master <action> -s <SESSION_ID> ...` |
 | `animation` | 5 | Shape effects and slide transitions | `animation(action="...", session_id=..., ...)` | `pptcli animation <action> -s <SESSION_ID> ...` |
 | `image` | 7 | Picture insertion and picture adjustments (brightness/contrast, recolor, crop) | `image(action="...", session_id=..., ...)` | `pptcli image <action> -s <SESSION_ID> ...` |
 | `chart` | 10 | Native charts, titles, axes, legend, data replacement | `chart(action="...", session_id=..., ...)` | `pptcli chart <action> -s <SESSION_ID> ...` |

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -101,7 +101,7 @@ hide:
 
 </div>
 
-[See all 13 tools (137 operations) across 13 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 13 tools (141 operations) across 13 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 13 tools (137 operations) across 13 domains
+- [Complete Feature Reference](features.md) — all 13 tools (141 operations) across 13 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 13 tools with 137 operations across 13 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 13 tools with 141 operations across 13 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -18,7 +18,7 @@ Claude can now create and edit PowerPoint decks directly.
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
 required) plus the manifest, license, and changelog. The server exposes 13
-tools (137 operations across 13 domains) — see the
+tools (141 operations across 13 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 
 ## Building locally

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -206,17 +206,19 @@ Actions: `add-picture`, `set-brightness-contrast`, `get-brightness-contrast`, `s
 
 ### `layout` — Slide layout commands: apply/read a slide's built-in layout. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
 
-Actions: `set-layout`, `get-layout`
+Actions: `set-layout`, `get-layout`, `list-layouts`, `delete-layout`
 
 | Flag | Description |
 |------|-------------|
-| `--slide-index` | (required) |
+| `--slide-index` | (required for: set-layout, get-layout) |
 | `--layout-name` | (required for: set-layout) |
+| `--master-index` | (required for: list-layouts, delete-layout) |
+| `--layout-index` | (required for: delete-layout) |
 
 
 ### `master` — Slide master commands: read/edit the title and body placeholder fonts on the presentation's slide master, and read/edit the slide master's background fill color. Operates within an already-open . Changes here apply to every slide that inherits from the master (i.e. any slide that does not itself override the property), which is the practical "edit the master, not each slide" workflow PowerPoint's COM object model supports safely.
 
-Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `get-background-color`, `set-background-color`, `set-gradient-background`, `get-gradient-background`
+Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `get-background-color`, `set-background-color`, `set-gradient-background`, `get-gradient-background`, `list-masters`, `delete-master`
 
 | Flag | Description |
 |------|-------------|
@@ -234,6 +236,7 @@ Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `
 | `--blue2` | (required for: set-gradient-background) |
 | `--gradient-style` |  |
 | `--gradient-variant` |  |
+| `--master-index` | (required for: delete-master) |
 
 
 ### `notes` — Speaker notes commands: set/get the notes text for a slide. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save → Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 13 tools and 137 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 13 tools and 141 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save → Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 13 tools and 137 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 13 tools and 141 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/src/PowerPointMcp.Core/Chart/ChartCommands.cs
+++ b/src/PowerPointMcp.Core/Chart/ChartCommands.cs
@@ -69,6 +69,7 @@ public sealed class ChartCommands : IChartCommands
                 chartShape = ((dynamic)slide.Shapes).AddChart2(-1, xlChartType.Value, left, top, width, height, true);
                 PowerPoint.Chart chart = chartShape.Chart;
 
+                EnsureChartDataReady(chart);
                 WriteChartData(chart, categories, seriesName, values);
 
                 // Same NoPIA .Index late-binding quirk as Shape domain — use Shapes.Count instead.
@@ -119,6 +120,7 @@ public sealed class ChartCommands : IChartCommands
             }
 
             PowerPoint.Chart chart = shape.Chart;
+            EnsureChartDataReady(chart);
             dynamic? seriesCollection = null;
             dynamic? firstSeries = null;
             try
@@ -201,6 +203,7 @@ public sealed class ChartCommands : IChartCommands
             }
 
             PowerPoint.Chart chart = shape.Chart;
+            EnsureChartDataReady(chart);
             dynamic? seriesCollection = null;
             dynamic? firstSeries = null;
             dynamic? newSeries = null;
@@ -323,6 +326,7 @@ public sealed class ChartCommands : IChartCommands
             }
 
             PowerPoint.Chart chart = shape.Chart;
+            EnsureChartDataReady(chart);
 
             // Avoid the embedded Excel workbook and update its late-bound SeriesCollection
             // directly, because Excel interop types are not part of the embedded PowerPoint PIA.
@@ -691,6 +695,43 @@ public sealed class ChartCommands : IChartCommands
         _ => null
     };
 
+    private static void EnsureChartDataReady(PowerPoint.Chart chart)
+    {
+        dynamic? chartData = null;
+        dynamic? workbook = null;
+        dynamic? workbookApplication = null;
+        try
+        {
+            // The embedded Excel workbook backing the chart can be lazy-initialized. Activating it
+            // and forcing a workbook recalculation makes the follow-on SeriesCollection/XValues
+            // reads deterministic instead of returning transient zero-count state immediately after
+            // AddChart/ReplaceChartData.
+            chartData = chart.ChartData;
+            chartData.Activate();
+            workbook = chartData.Workbook;
+            workbookApplication = workbook.Application;
+            workbookApplication.Calculate();
+            chart.Refresh();
+        }
+        finally
+        {
+            if (workbookApplication != null)
+            {
+                ComUtilities.Release(ref workbookApplication!);
+            }
+
+            if (workbook != null)
+            {
+                ComUtilities.Release(ref workbook!);
+            }
+
+            if (chartData != null)
+            {
+                ComUtilities.Release(ref chartData!);
+            }
+        }
+    }
+
     private static void WriteChartData(PowerPoint.Chart chart, IReadOnlyList<string> categories, string seriesName, IReadOnlyList<double> values)
     {
         // SeriesCollection is backed by Excel types that are not present in the embedded
@@ -787,7 +828,19 @@ public sealed class ChartCommands : IChartCommands
             Thread.Sleep(TransientReadRetryDelayMs);
         }
 
-        return xValues;
+        Array values = Array.Empty<object>();
+        for (int attempt = 1; attempt <= TransientReadRetryAttempts; attempt++)
+        {
+            values = RetryTransientChartRead(() => (Array)series.Values);
+            if (values.Length > 0 || attempt == TransientReadRetryAttempts)
+            {
+                return values;
+            }
+
+            Thread.Sleep(TransientReadRetryDelayMs);
+        }
+
+        return values;
     }
 
     private static ChartOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)

--- a/src/PowerPointMcp.Core/Layout/ILayoutCommands.cs
+++ b/src/PowerPointMcp.Core/Layout/ILayoutCommands.cs
@@ -20,4 +20,10 @@ public interface ILayoutCommands
 
     /// <summary>Gets the current slide's layout name.</summary>
     LayoutOperationResult GetLayout(IPresentationBatch batch, int slideIndex);
+
+    /// <summary>Lists the layouts attached to a given slide master, including whether any slide uses each one.</summary>
+    LayoutOperationResult ListLayouts(IPresentationBatch batch, int masterIndex);
+
+    /// <summary>Deletes an unused layout from a slide master. Fails if any slide still references it.</summary>
+    LayoutOperationResult DeleteLayout(IPresentationBatch batch, int masterIndex, int layoutIndex);
 }

--- a/src/PowerPointMcp.Core/Layout/LayoutCommands.cs
+++ b/src/PowerPointMcp.Core/Layout/LayoutCommands.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+using Sbroenne.PowerPointMcp.ComInterop;
 using Sbroenne.PowerPointMcp.ComInterop.Session;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
@@ -61,4 +63,234 @@ public sealed class LayoutCommands : ILayoutCommands
             return new LayoutOperationResult { Success = true, LayoutName = layout.ToString() };
         });
     }
+
+    /// <inheritdoc/>
+    public LayoutOperationResult ListLayouts(IPresentationBatch batch, int masterIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        if (masterIndex < 1)
+        {
+            return new LayoutOperationResult
+            {
+                Success = false,
+                ErrorMessage = "Master index must be 1 or greater."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Designs designs = ctx.Presentation.Designs;
+            int designCount = designs.Count;
+            if (masterIndex > designCount)
+            {
+                return new LayoutOperationResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Master index {masterIndex} is out of range. The presentation has {designCount} master(s) (valid range: 1-{designCount})."
+                };
+            }
+
+            PowerPoint.Design design = designs[masterIndex];
+            PowerPoint.Master slideMaster = design.SlideMaster;
+            PowerPoint.CustomLayouts customLayouts = slideMaster.CustomLayouts;
+            int layoutCount = customLayouts.Count;
+            var layouts = new List<LayoutOperationResult.LayoutInventoryEntry>(layoutCount);
+
+            for (int i = 1; i <= layoutCount; i++)
+            {
+                PowerPoint.CustomLayout layout = customLayouts[i];
+                layouts.Add(new LayoutOperationResult.LayoutInventoryEntry
+                {
+                    LayoutIndex = i,
+                    LayoutName = GetLayoutName(layout),
+                    IsUsed = IsLayoutUsedByAnySlide(ctx, design, layout)
+                });
+            }
+
+            return new LayoutOperationResult
+            {
+                Success = true,
+                MasterIndex = masterIndex,
+                MasterName = GetMasterName(design, slideMaster),
+                Layouts = layouts
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public LayoutOperationResult DeleteLayout(IPresentationBatch batch, int masterIndex, int layoutIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        if (masterIndex < 1)
+        {
+            return new LayoutOperationResult
+            {
+                Success = false,
+                ErrorMessage = "Master index must be 1 or greater."
+            };
+        }
+
+        if (layoutIndex < 1)
+        {
+            return new LayoutOperationResult
+            {
+                Success = false,
+                ErrorMessage = "Layout index must be 1 or greater."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            try
+            {
+                PowerPoint.Designs designs = ctx.Presentation.Designs;
+                int designCount = designs.Count;
+                if (masterIndex > designCount)
+                {
+                    return new LayoutOperationResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Master index {masterIndex} is out of range. The presentation has {designCount} master(s) (valid range: 1-{designCount})."
+                    };
+                }
+
+                PowerPoint.Design design = designs[masterIndex];
+                PowerPoint.Master slideMaster = design.SlideMaster;
+                PowerPoint.CustomLayouts customLayouts = slideMaster.CustomLayouts;
+                int layoutCount = customLayouts.Count;
+                if (layoutIndex > layoutCount)
+                {
+                    return new LayoutOperationResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Layout index {layoutIndex} is out of range. The slide master has {layoutCount} layout(s) (valid range: 1-{layoutCount})."
+                    };
+                }
+
+                PowerPoint.CustomLayout layout = customLayouts[layoutIndex];
+                if (IsLayoutUsedByAnySlide(ctx, design, layout))
+                {
+                    return new LayoutOperationResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Layout '{GetLayoutName(layout)}' is still used by one or more slides."
+                    };
+                }
+
+                InvokeComMethod(layout, "Delete");
+                return new LayoutOperationResult { Success = true };
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"DeleteLayout failed while processing masterIndex={masterIndex}, layoutIndex={layoutIndex}.", ex);
+            }
+        });
+    }
+
+    private static bool IsLayoutUsedByAnySlide(PresentationContext ctx, PowerPoint.Design design, PowerPoint.CustomLayout layout)
+    {
+        string? targetDesignName = NormalizeName(design.Name);
+        string? targetLayoutName = NormalizeName(layout.Name) ?? NormalizeName(layout.MatchingName);
+
+        int slideCount = ctx.Presentation.Slides.Count;
+        for (int i = 1; i <= slideCount; i++)
+        {
+            PowerPoint.Slide slide = ctx.Presentation.Slides[i];
+            PowerPoint.CustomLayout? currentLayout = slide.CustomLayout;
+            if (currentLayout is null)
+            {
+                continue;
+            }
+
+            if (IsSameComObject(currentLayout, layout))
+            {
+                return true;
+            }
+
+            string? currentLayoutName = NormalizeName(currentLayout.Name) ?? NormalizeName(currentLayout.MatchingName);
+            string? currentLayoutDesignName = NormalizeName(currentLayout.Design?.Name);
+
+            if (string.Equals(currentLayoutName, targetLayoutName, StringComparison.OrdinalIgnoreCase)
+                && (IsSameComObject(currentLayout.Design, design)
+                    || string.Equals(currentLayoutDesignName, targetDesignName, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsSameComObject(object? left, object? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return Marshal.GetIUnknownForObject(left) == Marshal.GetIUnknownForObject(right);
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+    }
+
+    private static void InvokeComMethod(object target, string methodName)
+    {
+        if (!string.Equals(methodName, "Delete", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"Unsupported COM method '{methodName}'.");
+        }
+
+        // The PowerPoint interop RCWs expose Delete via COM dispatch rather than as a managed
+        // member. Invoke it dynamically so the underlying PowerPoint COM object receives the call.
+        dynamic? dynamicTarget = null;
+        try
+        {
+            dynamicTarget = target;
+            dynamicTarget.Delete();
+        }
+        finally
+        {
+            ComUtilities.Release(ref dynamicTarget!);
+        }
+    }
+
+    private static string? GetMasterName(PowerPoint.Design design, PowerPoint.Master slideMaster)
+    {
+        string? name = TryGetString(design.Name);
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+
+        return TryGetString(slideMaster.Design?.Name);
+    }
+
+    private static string? NormalizeName(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? GetLayoutName(PowerPoint.CustomLayout layout)
+    {
+        string? name = TryGetString(layout.Name);
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+
+        return TryGetString(layout.MatchingName);
+    }
+
+    private static string? TryGetString(object? value)
+        => value is null ? null : value.ToString();
 }

--- a/src/PowerPointMcp.Core/Layout/LayoutOperationResult.cs
+++ b/src/PowerPointMcp.Core/Layout/LayoutOperationResult.cs
@@ -19,4 +19,26 @@ public sealed class LayoutOperationResult
     /// enum member name, e.g. "ppLayoutBlank", "ppLayoutTitleOnly", "ppLayoutText").
     /// </summary>
     public string? LayoutName { get; init; }
+
+    /// <summary>1-based index of the slide master for ListLayouts.</summary>
+    public int? MasterIndex { get; init; }
+
+    /// <summary>Name of the slide master for ListLayouts.</summary>
+    public string? MasterName { get; init; }
+
+    /// <summary>Layouts attached to the selected slide master.</summary>
+    public IReadOnlyList<LayoutInventoryEntry>? Layouts { get; init; }
+
+    /// <summary>Represents one layout entry inside a slide master's inventory.</summary>
+    public sealed class LayoutInventoryEntry
+    {
+        /// <summary>1-based index of the layout within the slide master.</summary>
+        public int LayoutIndex { get; init; }
+
+        /// <summary>Name of the layout.</summary>
+        public string? LayoutName { get; init; }
+
+        /// <summary>Whether any slide in the presentation currently uses this layout.</summary>
+        public bool IsUsed { get; init; }
+    }
 }

--- a/src/PowerPointMcp.Core/Master/IMasterCommands.cs
+++ b/src/PowerPointMcp.Core/Master/IMasterCommands.cs
@@ -81,4 +81,10 @@ public interface IMasterCommands
     /// gradient fill.
     /// </summary>
     MasterOperationResult GetGradientBackground(IPresentationBatch batch);
+
+    /// <summary>Lists every slide master in the presentation, along with the layouts attached to it.</summary>
+    MasterOperationResult ListMasters(IPresentationBatch batch);
+
+    /// <summary>Deletes an unused slide master. Fails if any slide still references it.</summary>
+    MasterOperationResult DeleteMaster(IPresentationBatch batch, int masterIndex);
 }

--- a/src/PowerPointMcp.Core/Master/MasterCommands.cs
+++ b/src/PowerPointMcp.Core/Master/MasterCommands.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Sbroenne.PowerPointMcp.ComInterop;
 using Sbroenne.PowerPointMcp.ComInterop.Session;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
@@ -244,6 +245,90 @@ public sealed class MasterCommands : IMasterCommands
         });
     }
 
+    /// <inheritdoc/>
+    public MasterOperationResult ListMasters(IPresentationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Designs designs = ctx.Presentation.Designs;
+            int designCount = designs.Count;
+            var masters = new List<MasterOperationResult.MasterInventoryEntry>(designCount);
+
+            for (int i = 1; i <= designCount; i++)
+            {
+                PowerPoint.Design design = designs[i];
+                PowerPoint.Master slideMaster = design.SlideMaster;
+                PowerPoint.CustomLayouts customLayouts = slideMaster.CustomLayouts;
+                int layoutCount = customLayouts.Count;
+                var layouts = new List<MasterOperationResult.LayoutInventoryEntry>(layoutCount);
+
+                for (int j = 1; j <= layoutCount; j++)
+                {
+                    PowerPoint.CustomLayout layout = customLayouts[j];
+                    layouts.Add(new MasterOperationResult.LayoutInventoryEntry
+                    {
+                        LayoutIndex = j,
+                        LayoutName = GetLayoutName(layout),
+                        IsUsed = IsLayoutUsedByAnySlide(ctx, design, layout)
+                    });
+                }
+
+                masters.Add(new MasterOperationResult.MasterInventoryEntry
+                {
+                    MasterIndex = i,
+                    MasterName = GetMasterName(design, slideMaster),
+                    Layouts = layouts
+                });
+            }
+
+            return new MasterOperationResult { Success = true, Masters = masters };
+        });
+    }
+
+    /// <inheritdoc/>
+    public MasterOperationResult DeleteMaster(IPresentationBatch batch, int masterIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        if (masterIndex < 1)
+        {
+            return new MasterOperationResult
+            {
+                Success = false,
+                ErrorMessage = "Master index must be 1 or greater."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Designs designs = ctx.Presentation.Designs;
+            int designCount = designs.Count;
+            if (masterIndex > designCount)
+            {
+                return new MasterOperationResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Master index {masterIndex} is out of range. The presentation has {designCount} master(s) (valid range: 1-{designCount})."
+                };
+            }
+
+            PowerPoint.Design design = designs[masterIndex];
+            if (IsMasterUsedByAnySlide(ctx, design))
+            {
+                return new MasterOperationResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Master '{GetMasterName(design, design.SlideMaster)}' is still used by one or more slides."
+                };
+            }
+
+            InvokeComMethod(design, "Delete");
+            return new MasterOperationResult { Success = true };
+        });
+    }
+
     /// <summary>
     /// Finds the master placeholder shape of the given type by scanning the slide master's
     /// <c>Shapes</c> collection for a shape whose <c>PlaceholderFormat.Type</c> matches.
@@ -287,6 +372,142 @@ public sealed class MasterCommands : IMasterCommands
         dynamic presentation = ctx.Presentation;
         return (PowerPoint.Master)presentation.SlideMaster;
     }
+
+    private static bool IsLayoutUsedByAnySlide(PresentationContext ctx, PowerPoint.Design design, PowerPoint.CustomLayout layout)
+    {
+        string? targetDesignName = NormalizeName(design.Name);
+        string? targetLayoutName = NormalizeName(layout.Name) ?? NormalizeName(layout.MatchingName);
+
+        int slideCount = ctx.Presentation.Slides.Count;
+        for (int i = 1; i <= slideCount; i++)
+        {
+            PowerPoint.Slide slide = ctx.Presentation.Slides[i];
+            PowerPoint.CustomLayout? currentLayout = slide.CustomLayout;
+            if (currentLayout is null)
+            {
+                continue;
+            }
+
+            if (IsSameComObject(currentLayout, layout)
+                || IsSameComObject(currentLayout.Design, design)
+                || IsSameComObject(slide.Design, design))
+            {
+                return true;
+            }
+
+            string? currentLayoutName = NormalizeName(currentLayout.Name) ?? NormalizeName(currentLayout.MatchingName);
+            string? currentLayoutDesignName = NormalizeName(currentLayout.Design?.Name);
+            string? slideDesignName = NormalizeName(slide.Design?.Name);
+
+            if (string.Equals(currentLayoutName, targetLayoutName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(currentLayoutDesignName, targetDesignName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(slideDesignName, targetDesignName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsMasterUsedByAnySlide(PresentationContext ctx, PowerPoint.Design design)
+    {
+        string? targetDesignName = NormalizeName(design.Name);
+
+        int slideCount = ctx.Presentation.Slides.Count;
+        for (int i = 1; i <= slideCount; i++)
+        {
+            PowerPoint.Slide slide = ctx.Presentation.Slides[i];
+            PowerPoint.CustomLayout? currentLayout = slide.CustomLayout;
+            if (currentLayout is null)
+            {
+                continue;
+            }
+
+            if (IsSameComObject(slide.Design, design)
+                || IsSameComObject(currentLayout.Design, design))
+            {
+                return true;
+            }
+
+            string? slideDesignName = NormalizeName(slide.Design?.Name);
+            string? currentLayoutDesignName = NormalizeName(currentLayout.Design?.Name);
+            if (string.Equals(slideDesignName, targetDesignName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(currentLayoutDesignName, targetDesignName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsSameComObject(object? left, object? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return Marshal.GetIUnknownForObject(left) == Marshal.GetIUnknownForObject(right);
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+    }
+
+    private static void InvokeComMethod(object target, string methodName)
+    {
+        if (!string.Equals(methodName, "Delete", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"Unsupported COM method '{methodName}'.");
+        }
+
+        // The PowerPoint interop RCWs expose Delete via COM dispatch rather than as a managed
+        // member. Invoke it dynamically so the underlying PowerPoint COM object receives the call.
+        dynamic dynamicTarget = target;
+        dynamicTarget.Delete();
+    }
+
+    private static string? NormalizeName(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? GetMasterName(PowerPoint.Design design, PowerPoint.Master slideMaster)
+    {
+        string? name = TryGetString(design.Name);
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+
+        return TryGetString(slideMaster.Design?.Name);
+    }
+
+    private static string? GetLayoutName(PowerPoint.CustomLayout layout)
+    {
+        string? name = TryGetString(layout.Name);
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+
+        return TryGetString(layout.MatchingName);
+    }
+
+    private static string? TryGetString(object? value)
+        => value is null ? null : value.ToString();
 
     private static MasterOperationResult ReadFont(PowerPoint.Shape placeholder)
     {

--- a/src/PowerPointMcp.Core/Master/MasterOperationResult.cs
+++ b/src/PowerPointMcp.Core/Master/MasterOperationResult.cs
@@ -34,4 +34,33 @@ public sealed class MasterOperationResult
 
     /// <summary>Gradient variant (1-4), for Set/GetGradientBackground.</summary>
     public int? GradientVariant { get; init; }
+
+    /// <summary>Inventory of the slide masters in the presentation, for ListMasters.</summary>
+    public IReadOnlyList<MasterInventoryEntry>? Masters { get; init; }
+
+    /// <summary>Represents one slide master and the layouts attached to it.</summary>
+    public sealed class MasterInventoryEntry
+    {
+        /// <summary>1-based index of the slide master in the presentation.</summary>
+        public int MasterIndex { get; init; }
+
+        /// <summary>Name of the slide master.</summary>
+        public string? MasterName { get; init; }
+
+        /// <summary>Layouts attached to this slide master.</summary>
+        public IReadOnlyList<LayoutInventoryEntry>? Layouts { get; init; }
+    }
+
+    /// <summary>Represents one layout entry inside a slide master's inventory.</summary>
+    public sealed class LayoutInventoryEntry
+    {
+        /// <summary>1-based index of the layout within the slide master.</summary>
+        public int LayoutIndex { get; init; }
+
+        /// <summary>Name of the layout.</summary>
+        public string? LayoutName { get; init; }
+
+        /// <summary>Whether any slide in the presentation currently uses this layout.</summary>
+        public bool IsUsed { get; init; }
+    }
 }

--- a/src/PowerPointMcp.Core/PowerPointMcp.Core.csproj
+++ b/src/PowerPointMcp.Core/PowerPointMcp.Core.csproj
@@ -24,9 +24,7 @@
     <ProjectReference Include="..\PowerPointMcp.ComInterop\PowerPointMcp.ComInterop.csproj" />
     <!-- Source generator for ServiceRegistry (CLI + skill manifest only; no [ServiceCategory]
          interfaces exist yet — this wiring is inert until Core interfaces are annotated) -->
-    <ProjectReference Include="..\PowerPointMcp.Generators\PowerPointMcp.Generators.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\PowerPointMcp.Generators\PowerPointMcp.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Emit generated source files for inspection -->
@@ -40,6 +38,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
+    <PackageReference Include="Microsoft.PowerShell.SDK" />
     <!-- Required for generated CliSettings class (Spectre.Console.Cli.CommandSettings) -->
     <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,7 +32,7 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**13 tools with 137 operations across 13 domains:**
+**13 tools with 141 operations across 13 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
@@ -42,8 +42,8 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 | `textframe` | 20 | text content, font formatting, alignment, bullets, auto-size |
 | `table` | 12 | tables, cell text, row/column edits, cell fill/border, merge |
 | `notes` | 2 | set/get speaker notes |
-| `layout` | 2 | set/get slide layout |
-| `master` | 8 | title/body placeholder fonts, solid + gradient master backgrounds |
+| `layout` | 4 | set/get slide layout |
+| `master` | 10 | title/body placeholder fonts, solid + gradient master backgrounds |
 | `animation` | 5 | shape effects, transition read/write |
 | `image` | 7 | add picture, brightness/contrast, recolor, crop |
 | `chart` | 10 | charts, series, chart/axis titles, legend visibility, data replacement |

--- a/tests/PowerPointMcp.Core.Tests/LayoutCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/LayoutCommandsTests.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.Core.Layout;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
@@ -50,5 +51,50 @@ public class LayoutCommandsTests : IClassFixture<SharedPresentationFixture>
 
         Assert.False(result.Success);
         Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void ListLayouts_ReturnsLayoutsWithUsageFlag()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        var result = _commands.ListLayouts(batch, 1);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(1, result.MasterIndex);
+        Assert.NotNull(result.Layouts);
+        Assert.NotEmpty(result.Layouts);
+        Assert.Contains(result.Layouts!, layout => layout.IsUsed);
+    }
+
+    [Fact]
+    public void DeleteLayout_RemovesUnusedLayout()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Design design = ctx.Presentation.Designs[1];
+            PowerPoint.Master slideMaster = design.SlideMaster;
+            PowerPoint.CustomLayouts customLayouts = slideMaster.CustomLayouts;
+            PowerPoint.CustomLayout sourceLayout = customLayouts[1];
+            PowerPoint.CustomLayout duplicateLayout = sourceLayout.Duplicate();
+            duplicateLayout.Name = "PptMcpTestUnusedLayout";
+            return 0;
+        });
+
+        var listBefore = _commands.ListLayouts(batch, 1);
+        Assert.True(listBefore.Success, listBefore.ErrorMessage);
+        var candidateLayout = listBefore.Layouts!.Single(layout => layout.LayoutName == "PptMcpTestUnusedLayout");
+
+        var deleteResult = _commands.DeleteLayout(batch, 1, candidateLayout.LayoutIndex);
+        Assert.True(deleteResult.Success, deleteResult.ErrorMessage);
+
+        var listAfter = _commands.ListLayouts(batch, 1);
+        Assert.True(listAfter.Success, listAfter.ErrorMessage);
+        Assert.DoesNotContain(listAfter.Layouts!, layout => layout.LayoutName == candidateLayout.LayoutName);
+        Assert.Equal(listBefore.Layouts!.Count - 1, listAfter.Layouts!.Count);
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/MasterCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/MasterCommandsTests.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.Core.Master;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
 
@@ -177,5 +178,52 @@ public class MasterCommandsTests : IClassFixture<SharedPresentationFixture>
 
         Assert.False(result.Success);
         Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void ListMasters_ReturnsMastersAndLayouts()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        var result = _commands.ListMasters(batch);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.NotNull(result.Masters);
+        Assert.NotEmpty(result.Masters);
+
+        var firstMaster = Assert.Single(result.Masters);
+        Assert.NotNull(firstMaster.MasterName);
+        Assert.True(firstMaster.MasterIndex >= 1);
+        Assert.NotNull(firstMaster.Layouts);
+        Assert.NotEmpty(firstMaster.Layouts);
+    }
+
+    [Fact]
+    public void DeleteMaster_RemovesUnusedMasterAfterTemplateApply()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Designs designs = ctx.Presentation.Designs;
+            PowerPoint.Design extraDesign = designs.Add("PptMcpTestExtraMaster");
+            return 0;
+        });
+
+        var listResult = _commands.ListMasters(batch);
+        Assert.True(listResult.Success, listResult.ErrorMessage);
+        Assert.True(listResult.Masters!.Count >= 2);
+
+        var candidateMaster = listResult.Masters!.First(m => m.MasterName == "PptMcpTestExtraMaster");
+        var deleteResult = _commands.DeleteMaster(batch, candidateMaster.MasterIndex);
+
+        Assert.True(deleteResult.Success, deleteResult.ErrorMessage);
+
+        var afterDelete = _commands.ListMasters(batch);
+        Assert.True(afterDelete.Success, afterDelete.ErrorMessage);
+        Assert.DoesNotContain(afterDelete.Masters!, m => m.MasterName == candidateMaster.MasterName);
+        Assert.Equal(listResult.Masters!.Count - 1, afterDelete.Masters!.Count);
     }
 }


### PR DESCRIPTION
## Summary
- add slide master and layout inspection/delete operations with safety checks for in-use masters and layouts
- harden chart-data readiness for the end-to-end MCP workflow
- pin System.Security.Cryptography.Xml to a patched version to clear the NuGet audit gate

## Validation
- dotnet build Sbroenne.PowerPointMcp.slnx
- dotnet test tests/PowerPointMcp.Core.Tests --filter "Feature=Master|Feature=Layout"
- dotnet test tests/PowerPointMcp.McpServer.Tests
