### PR TITLE
Trim release exes and stabilize real-COM chart tests

### DIFF
--- a/.changeset/trim-release-exes.md
+++ b/.changeset/trim-release-exes.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": patch
+---
+
+The MCP Server and CLI standalone `.exe` release downloads are now trimmed, reducing their download size by roughly 29% (CLI: ~185MB → ~131MB). Also fixed an intermittent failure in chart creation/data operations that could occur immediately after adding or replacing chart data.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,6 @@ jobs:
           --self-contained true `
           -p:PublishSingleFile=true `
           -p:IncludeNativeLibrariesForSelfExtract=true `
-          -p:PublishTrimmed=false `
           -p:PublishReadyToRun=false `
           -p:Version=${{ env.VERSION }} `
           -p:AssemblyVersion=${{ env.VERSION }}.0 `
@@ -235,7 +234,6 @@ jobs:
           --self-contained true `
           -p:PublishSingleFile=true `
           -p:IncludeNativeLibrariesForSelfExtract=true `
-          -p:PublishTrimmed=false `
           -p:PublishReadyToRun=false `
           -p:Version=${{ env.VERSION }} `
           -p:AssemblyVersion=${{ env.VERSION }}.0 `

--- a/src/PowerPointMcp.CLI/Infrastructure/ServiceCommandBase.cs
+++ b/src/PowerPointMcp.CLI/Infrastructure/ServiceCommandBase.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Sbroenne.PowerPointMcp.Core.Cli;
 using Sbroenne.PowerPointMcp.Service;
 using Spectre.Console.Cli;
 
@@ -83,7 +84,7 @@ internal abstract class ServiceCommandBase<TSettings> : AsyncCommand<TSettings>
             Source = "cli"
         }, cancellationToken);
 
-        var outputPath = settings.GetType().GetProperty("OutputPath")?.GetValue(settings) as string;
+        var outputPath = (settings as IHasOutputPath)?.OutputPath;
 
         if (response.Success)
         {

--- a/src/PowerPointMcp.CLI/PowerPointMcp.CLI.csproj
+++ b/src/PowerPointMcp.CLI/PowerPointMcp.CLI.csproj
@@ -21,7 +21,25 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pptcli</ToolCommandName>
     <PublishSelfContained>false</PublishSelfContained>
-    <PublishTrimmed>false</PublishTrimmed>
+    <!-- Trimming is enabled only for the standalone self-contained exe publish (win-x64, CI release
+         job). Setting it here (not via -p: on the publish command line) keeps it from propagating
+         as a global MSBuild property to the netstandard2.0 analyzer/generator project references,
+         which don't support trimming and would fail with NETSDK1124. -->
+    <PublishTrimmed Condition="'$(SelfContained)' == 'true'">true</PublishTrimmed>
+    <TrimMode Condition="'$(SelfContained)' == 'true'">partial</TrimMode>
+    <!-- IL2104 ("assembly not verified trim-safe") is expected noise from third-party
+         dependencies (Humanizer, PowerShell SDK, WPF, System.Management, etc. — pulled in
+         transitively via Roslyn/Spectre.Console.Cli/COM interop) under TrimMode=partial, where
+         only explicitly opted-in assemblies get trimmed and everything else is preserved as-is.
+         It is informational, not an actionable bug in this project's own code, so it must not be
+         promoted to a build error by the repo-wide TreatWarningsAsErrors=true. -->
+    <NoWarn Condition="'$(SelfContained)' == 'true'">$(NoWarn);IL2104</NoWarn>
+    <!-- Trimming disables System.Text.Json's reflection-based serializer by default (it expects
+         source-generated JsonSerializerContext usage). ServiceProtocol.JsonOptions (the CLI<->
+         daemon RPC wire format) and the daemon's own request/response types still rely on runtime
+         reflection, so re-enable it explicitly for the trimmed publish to avoid breaking the
+         daemon at runtime ("Reflection-based serialization has been disabled..."). -->
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(SelfContained)' == 'true'">true</JsonSerializerIsReflectionEnabledByDefault>
     <!-- IMPORTANT: Do NOT declare <RuntimeIdentifiers> here — combined with PackAsTool it forces
          the pack flow to look for RID-qualified build output (bin/Release/net10.0-windows/win-x64/),
          but `dotnet build` without a RID produces plain bin/Release/net10.0-windows/, breaking

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -184,6 +185,12 @@ internal sealed class PresentationBatch : IPresentationBatch
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "The `new PowerPoint.Application()` coclass constructor lowers to a " +
+            "runtime-activation call keyed off Marshal.GetTypeFromCLSID(...) for the embedded " +
+            "interop type. The created object is a COM proxy accessed exclusively via " +
+            "IDispatch/`dynamic` (see the PIA-first COM access rule) — no .NET reflection over " +
+            "its members occurs, so trimming member metadata on this type is irrelevant.")]
     private void RunStaThread(TaskCompletionSource started)
     {
         PowerPoint.Application? startupApp = null;

--- a/src/PowerPointMcp.Core/Chart/ChartCommands.cs
+++ b/src/PowerPointMcp.Core/Chart/ChartCommands.cs
@@ -707,11 +707,33 @@ public sealed class ChartCommands : IChartCommands
             // reads deterministic instead of returning transient zero-count state immediately after
             // AddChart/ReplaceChartData.
             chartData = chart.ChartData;
-            chartData.Activate();
-            workbook = chartData.Workbook;
-            workbookApplication = workbook.Application;
-            workbookApplication.Calculate();
-            chart.Refresh();
+
+            // Any step below (Activate, Workbook, Application, Calculate, Refresh) can throw a
+            // transient COMException immediately after AddChart/ReplaceChartData while the
+            // embedded Excel workbook is still spinning up — same class of flakiness
+            // RetryTransientChartRead already handles for series reads. Retry the whole sequence
+            // as a unit, releasing any partially-acquired COM refs before each retry attempt.
+            RetryTransientChartRead(() =>
+            {
+                if (workbookApplication != null)
+                {
+                    ComUtilities.Release(ref workbookApplication!);
+                    workbookApplication = null;
+                }
+
+                if (workbook != null)
+                {
+                    ComUtilities.Release(ref workbook!);
+                    workbook = null;
+                }
+
+                chartData.Activate();
+                workbook = chartData.Workbook;
+                workbookApplication = workbook.Application;
+                workbookApplication.Calculate();
+                chart.Refresh();
+                return true;
+            });
         }
         finally
         {

--- a/src/PowerPointMcp.Core/Cli/IHasOutputPath.cs
+++ b/src/PowerPointMcp.Core/Cli/IHasOutputPath.cs
@@ -1,0 +1,14 @@
+namespace Sbroenne.PowerPointMcp.Core.Cli;
+
+/// <summary>
+/// Implemented by generated CLI settings classes that expose the shared <c>-o|--output</c>
+/// option. Lets <c>ServiceCommandBase&lt;TSettings&gt;</c> read <c>OutputPath</c> without
+/// reflection (<see cref="System.Type.GetProperty(string)"/>), which is required for the
+/// standalone-exe release build to be trim-safe (see the release workflow's
+/// <c>PublishTrimmed</c> exe publish).
+/// </summary>
+public interface IHasOutputPath
+{
+    /// <summary>Gets the file path to write command output to, or <see langword="null"/> to write to stdout.</summary>
+    string? OutputPath { get; }
+}

--- a/src/PowerPointMcp.Generators/ServiceRegistryGenerator.cs
+++ b/src/PowerPointMcp.Generators/ServiceRegistryGenerator.cs
@@ -463,12 +463,20 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
 
     private static void GenerateCliSettings(StringBuilder sb, ServiceInfo info, List<ExposedParameter> allParams)
     {
+        // Output path option (available on all commands), unless a domain parameter already uses
+        // the "OutputPath" PascalCase name (e.g. Export's own outputPath parameter) — in that case
+        // skip the reserved option/interface to avoid a duplicate-member compile error.
+        var hasConflictingOutputPathParam = allParams.Any(p => StringHelper.ToPascalCase(p.Name) == "OutputPath");
+
         // Note: These types require Spectre.Console reference in consuming project
         sb.AppendLine("        /// <summary>");
         sb.AppendLine($"        /// Generated CLI settings for {info.CategoryPascal} commands.");
         sb.AppendLine("        /// Requires Spectre.Console package reference.");
         sb.AppendLine("        /// </summary>");
-        sb.AppendLine("        public sealed class CliSettings : Spectre.Console.Cli.CommandSettings");
+        var settingsBaseTypes = hasConflictingOutputPathParam
+            ? "Spectre.Console.Cli.CommandSettings"
+            : "Spectre.Console.Cli.CommandSettings, Sbroenne.PowerPointMcp.Core.Cli.IHasOutputPath";
+        sb.AppendLine($"        public sealed class CliSettings : {settingsBaseTypes}");
         sb.AppendLine("        {");
 
         // Action argument (always first)
@@ -518,7 +526,6 @@ public class ServiceRegistryGenerator : IIncrementalGenerator
         // Output path option (available on all commands), unless a domain parameter already
         // uses the "OutputPath" PascalCase name (e.g. Export's own outputPath parameter) —
         // skip the reserved option in that case to avoid a duplicate-member compile error.
-        var hasConflictingOutputPathParam = allParams.Any(p => StringHelper.ToPascalCase(p.Name) == "OutputPath");
         if (!hasConflictingOutputPathParam)
         {
             sb.AppendLine("            [Spectre.Console.Cli.CommandOption(\"-o|--output <PATH>\")]");

--- a/src/PowerPointMcp.McpServer/PowerPointMcp.McpServer.csproj
+++ b/src/PowerPointMcp.McpServer/PowerPointMcp.McpServer.csproj
@@ -31,7 +31,25 @@
          combined with PackAsTool it forces the pack flow to look for RID-qualified output,
          breaking `dotnet pack` (no-build) in CI. Standalone-exe CI builds pass the RID flag. -->
     <PublishSelfContained>false</PublishSelfContained>
-    <PublishTrimmed>false</PublishTrimmed>
+    <!-- Trimming is enabled only for the standalone self-contained exe publish (win-x64, CI release
+         job). Setting it here (not via -p: on the publish command line) keeps it from propagating
+         as a global MSBuild property to the netstandard2.0 analyzer/generator project references,
+         which don't support trimming and would fail with NETSDK1124. -->
+    <PublishTrimmed Condition="'$(SelfContained)' == 'true'">true</PublishTrimmed>
+    <TrimMode Condition="'$(SelfContained)' == 'true'">partial</TrimMode>
+    <!-- IL2104 ("assembly not verified trim-safe") is expected noise from third-party
+         dependencies (Humanizer, PowerShell SDK, WPF, System.Management, etc. — pulled in
+         transitively via Roslyn/Spectre.Console.Cli/COM interop) under TrimMode=partial, where
+         only explicitly opted-in assemblies get trimmed and everything else is preserved as-is.
+         It is informational, not an actionable bug in this project's own code, so it must not be
+         promoted to a build error by the repo-wide TreatWarningsAsErrors=true. -->
+    <NoWarn Condition="'$(SelfContained)' == 'true'">$(NoWarn);IL2104</NoWarn>
+    <!-- Trimming disables System.Text.Json's reflection-based serializer by default (it expects
+         source-generated JsonSerializerContext usage). The MCP SDK (ModelContextProtocol) and
+         this project's own JSON usage still rely on runtime reflection, so re-enable it
+         explicitly for the trimmed publish to avoid breaking tool serialization at runtime
+         ("Reflection-based serialization has been disabled..."). -->
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(SelfContained)' == 'true'">true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <!-- Emit generated source files for inspection -->


### PR DESCRIPTION
## Summary

**1. Trim the release .exe assets**
Enables .NET trimming (`PublishTrimmed`, scoped to `SelfContained=='true'` builds only) for the CLI and MCP Server standalone-exe release publishes, reducing the shipped exe size by ~29% (CLI: 185MB -> 131MB; MCP Server similarly reduced).

Fixes required to make trimming safe:
- Replaced a reflection-based `OutputPath` lookup in `ServiceCommandBase` with a generated `IHasOutputPath` interface (avoids an `IL2075` trim warning).
- Added a documented `[UnconditionalSuppressMessage]` for the one legitimate `IL2072` warning in `PresentationBatch` (COM coclass activation via `new PowerPoint.Application()`, accessed only through `dynamic`/IDispatch - no reflection over its members).
- Re-enabled reflection-based `System.Text.Json` serialization for trimmed builds (`JsonSerializerIsReflectionEnabledByDefault=true`), since trimming silently disables it by default and it is required by the CLI/daemon RPC protocol.
- Suppressed the informational `IL2104` ("assembly not trim-verified") noise for third-party dependencies, scoped to self-contained builds only.

**2. Fix the sandbox / stabilize tests**
- Fixed a flaky real-COM chart test: `ChartCommands.EnsureChartDataReady` now retries the whole chart-data readiness sequence (`Activate`/`Workbook`/`Application`/`Calculate`/`Refresh`) using the existing `RetryTransientChartRead` pattern already used for series reads elsewhere in the file - any step can transiently throw a `COMException` immediately after `AddChart`/`ReplaceChartData` while the embedded Excel workbook is still spinning up.
- Reworded a trim-suppression justification comment that unintentionally contained the literal text `Activator.CreateInstance(`, which tripped `PiaMigrationGuardTests` source-text scanner (false positive - the actual code correctly uses the typed PIA constructor).

## Verification
- Full Core real-COM integration suite: 226/226 passed (two full runs).
- Chart feature tests specifically re-run twice in isolation: 14/14 both times (previously-flaky tests now pass reliably via retry).
- MCP protocol test suite: 18/18 passed.
- Full solution build: 0 warnings, 0 errors.
- Pre-commit hook (build + Success-flag/COM-leak/dynamic-cast/interface audits + targeted real-COM tests) passed clean.
