### PR TITLE
feat: add native PowerPoint delivery and accessibility tools

### DIFF
--- a/.changeset/focused-powerpoint-delivery.md
+++ b/.changeset/focused-powerpoint-delivery.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": patch
+---
+
+Add native PDF delivery, presentation page setup and footer controls, legacy slide comments and slide import, native placeholder editing, and deterministic accessibility audits with reading-order management.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,10 +130,11 @@ Unified Service Architecture.
    background daemon process** over a named pipe (`ServiceClient`/`IPowerPointDaemonRpc`,
    auto-started on first `session open`/`session create`), so sessions persist across CLI
    invocations without paying PowerPoint's ~90-150s launch cost every command.
-5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 13 tools
-   total: one hand-written `presentation` action-dispatch tool plus 12 generated action-dispatch
+5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 15 tools
+   total: one hand-written `presentation` action-dispatch tool plus 14 generated action-dispatch
    tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-   `image`, `chart`, `smartart`, `export`), covering 134 operations across 13 domains. See
+   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 158 operations
+   across 15 domains. See
    `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
    the ground-truth tool list.
 6. **CLI** (`src/PowerPointMcp.CLI`) - `pptcli`, built on the same generators as the MCP surface

--- a/README.md
+++ b/README.md
@@ -44,24 +44,25 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**13 MCP tools with 141 operations across 13 domains:**
+**15 MCP tools with 158 operations across 15 domains:**
 
 - 🗂️ **Presentation** (12 ops) — create, open, save, close, list sessions, apply a `.potx`/`.pptx`
   template's masters/theme/layouts, read the current theme name, read/write built-in and custom
   document properties
-- 📑 **Slide** (14 ops) — add, count, delete, duplicate, reorder, per-slide background color, sections
-- ▭ **Shape** (36 ops) — rectangles, text boxes, auto shapes, lines, connectors, fill/line/shadow,
-  rotation, flip, z-order, grouping, naming, alt text
+- 📑 **Slide** (19 ops) — lifecycle, backgrounds, sections, comments, and slide import
+- ▭ **Shape** (39 ops) — shapes, styling, grouping, hyperlinks, and placeholder editing
 - ✏️ **TextFrame** (20 ops) — text, font size/name/color, bold, italic, underline, alignment, bullets
 - 📊 **Table** (12 ops) — add, cell text, insert/delete rows &amp; columns, cell fill/border, merge cells
 - 🗣️ **Notes** (2 ops) — set/get speaker notes
 - 🖼️ **Layout** (4 ops) — set/get slide layout
+- 📐 **Page Setup** (5 ops) — slide size, first slide number, footer, date/time, slide numbers
+- ♿ **Accessibility** (3 ops) — deterministic audit and reading-order management
 - 🎭 **Master** (10 ops) — slide master title/body placeholder fonts, background color
 - 🎬 **Animation** (5 ops) — shape entrance/emphasis/exit effects, slide transitions
 - 🖼️ **Image** (7 ops) — insert and adjust pictures (brightness, contrast, recolor, crop)
 - 📈 **Chart** (10 ops) — add chart, multi-series data, titles, axis titles, legend
 - 🔀 **SmartArt** (7 ops) — insert and edit SmartArt diagrams
-- 🖼️ **Export** (2 ops) — export a slide, or all slides, to images for visual verification
+- 🖼️ **Export** (3 ops) — export to PDF or images for delivery and visual verification
 
 Every domain is exposed as a single **action-dispatch tool** (e.g. `shape`, `table`, `chart`,
 `presentation`) with an `action` parameter selecting the specific operation — keeping the tool

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 13 MCP tools with 141 operations across 13 domains for live PowerPoint automation through single action-dispatch tools.
+description: 15 MCP tools with 158 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
 keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **13 MCP tools with 141 operations across 13 domains**.
+PowerPoint MCP Server exposes **15 MCP tools with 158 operations across 15 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -21,18 +21,20 @@ The CLI mirrors the same domain model:
 | Tool | Ops | What it covers | MCP call shape | CLI shape |
 |------|-----|----------------|----------------|-----------|
 | `presentation` | 12 | Session lifecycle, template application, built-in/custom document properties | `presentation(action="...", ...)` | `pptcli session <action> ...` |
-| `slide` | 14 | Slide lifecycle, slide backgrounds, sections | `slide(action="...", session_id=..., ...)` | `pptcli slide <action> -s <SESSION_ID> ...` |
-| `shape` | 36 | Shapes, geometry, styling, effects, grouping, naming, hyperlinks | `shape(action="...", session_id=..., ...)` | `pptcli shape <action> -s <SESSION_ID> ...` |
+| `slide` | 19 | Slide lifecycle, backgrounds, sections, comments, import | `slide(action="...", session_id=..., ...)` | `pptcli slide <action> -s <SESSION_ID> ...` |
+| `shape` | 39 | Shapes, styling, grouping, hyperlinks, placeholders | `shape(action="...", session_id=..., ...)` | `pptcli shape <action> -s <SESSION_ID> ...` |
 | `textframe` | 20 | Text content and text formatting | `textframe(action="...", session_id=..., ...)` | `pptcli textframe <action> -s <SESSION_ID> ...` |
 | `table` | 12 | Table creation and cell editing/formatting | `table(action="...", session_id=..., ...)` | `pptcli table <action> -s <SESSION_ID> ...` |
 | `notes` | 2 | Speaker notes | `notes(action="...", session_id=..., ...)` | `pptcli notes <action> -s <SESSION_ID> ...` |
 | `layout` | 4 | Slide layouts | `layout(action="...", session_id=..., ...)` | `pptcli layout <action> -s <SESSION_ID> ...` |
+| `pagesetup` | 5 | Slide size, numbering, footer, date/time | `pagesetup(action="...", session_id=..., ...)` | `pptcli pagesetup <action> -s <SESSION_ID> ...` |
+| `accessibility` | 3 | Deterministic audit and reading order | `accessibility(action="...", session_id=..., ...)` | `pptcli accessibility <action> -s <SESSION_ID> ...` |
 | `master` | 10 | Slide master fonts and backgrounds | `master(action="...", session_id=..., ...)` | `pptcli master <action> -s <SESSION_ID> ...` |
 | `animation` | 5 | Shape effects and slide transitions | `animation(action="...", session_id=..., ...)` | `pptcli animation <action> -s <SESSION_ID> ...` |
 | `image` | 7 | Picture insertion and picture adjustments (brightness/contrast, recolor, crop) | `image(action="...", session_id=..., ...)` | `pptcli image <action> -s <SESSION_ID> ...` |
 | `chart` | 10 | Native charts, titles, axes, legend, data replacement | `chart(action="...", session_id=..., ...)` | `pptcli chart <action> -s <SESSION_ID> ...` |
 | `smartart` | 7 | SmartArt diagrams and node editing | `smartart(action="...", session_id=..., ...)` | `pptcli smartart <action> -s <SESSION_ID> ...` |
-| `export` | 2 | Export-to-verify image rendering | `export(action="...", session_id=..., ...)` | `pptcli export <action> -s <SESSION_ID> ...` |
+| `export` | 3 | PDF delivery and export-to-verify image rendering | `export(action="...", session_id=..., ...)` | `pptcli export <action> -s <SESSION_ID> ...` |
 
 ## Domain reference
 
@@ -61,7 +63,7 @@ use that `sessionId`.
 `get-theme-name`, `set-document-property`, `get-document-property`, `set-custom-property`,
 `get-custom-property`, `remove-custom-property`
 
-### `slide` tool (14 operations)
+### `slide` tool (19 operations)
 
 | Action | What it does |
 |--------|---------------|
@@ -79,13 +81,19 @@ use that `sessionId`.
 | `delete-section` | Delete a section. |
 | `get-section-count` | Return the section count. |
 | `get-section-name` | Read a section name. |
+| `list-comments` | List legacy slide comments exposed by the native PowerPoint COM API. |
+| `add-comment` | Add a legacy comment to a slide. |
+| `delete-comment` | Delete a legacy comment by 1-based index. |
+| `clear-comments` | Remove all legacy comments from a slide. |
+| `import-from-file` | Insert a 1-based source slide range after a destination slide. |
 
 **Exact action order:** `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`,
 `set-background-color`, `get-background-color`, `set-gradient-background`,
 `get-gradient-background`, `add-section`, `rename-section`, `delete-section`,
-`get-section-count`, `get-section-name`
+`get-section-count`, `get-section-name`, `list-comments`, `add-comment`, `delete-comment`,
+`clear-comments`, `import-from-file`
 
-### `shape` tool (36 operations)
+### `shape` tool (39 operations)
 
 Use `shape` for shape creation, geometry, styling, effects, grouping, naming, alt text, and
 hyperlinks.
@@ -95,7 +103,8 @@ hyperlinks.
 `set-line`, `get-line`, `set-rotation`, `get-rotation`, `flip`, `set-z-order`, `set-shadow`,
 `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`,
 `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`,
-`set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`
+`set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`,
+`list-placeholders`, `set-placeholder-text`, `set-placeholder-image`
 
 ### `textframe` tool (20 operations)
 
@@ -118,17 +127,31 @@ Use `table` for native PowerPoint tables.
 
 **Exact action order:** `set-notes-text`, `get-notes-text`
 
-### `layout` tool (2 operations)
+### `layout` tool (4 operations)
 
-**Exact action order:** `set-layout`, `get-layout`
+**Exact action order:** `set-layout`, `get-layout`, `list-layouts`, `delete-layout`
 
-### `master` tool (8 operations)
+### `pagesetup` tool (5 operations)
+
+Use `pagesetup` for presentation-wide slide dimensions, numbering, and footer settings.
+
+**Exact action order:** `get-settings`, `set-size`, `set-first-slide-number`, `get-footer`,
+`set-footer`
+
+### `accessibility` tool (3 operations)
+
+Use `accessibility` for deterministic checks and slide reading order. The audit covers missing
+alternative text on visual content and empty title placeholders; it is not an AI writing review.
+
+**Exact action order:** `audit`, `get-reading-order`, `set-reading-order`
+
+### `master` tool (10 operations)
 
 Use `master` for deck-wide master placeholder fonts and master backgrounds.
 
 **Exact action order:** `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`,
 `get-background-color`, `set-background-color`, `set-gradient-background`,
-`get-gradient-background`
+`get-gradient-background`, `list-masters`, `delete-master`
 
 ### `animation` tool (5 operations)
 
@@ -157,11 +180,12 @@ Use `smartart` for SmartArt diagrams and node editing.
 **Exact action order:** `add-smart-art`, `add-node`, `add-child-node`, `set-node-text`,
 `get-node-text`, `delete-node`, `get-node-count`
 
-### `export` tool (2 operations)
+### `export` tool (3 operations)
 
 Use `export` for the project's export-to-verify loop.
 
-**Exact action order:** `export-slide-to-image`, `export-all-slides-to-images`
+**Exact action order:** `export-to-pdf`, `export-slide-to-image`,
+`export-all-slides-to-images`
 
 !!! tip "Why export-to-verify matters"
     Because the tools drive a **real PowerPoint desktop instance**, every visual edit can be

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -101,7 +101,7 @@ hide:
 
 </div>
 
-[See all 13 tools (141 operations) across 13 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 15 tools (158 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 13 tools (141 operations) across 13 domains
+- [Complete Feature Reference](features.md) — all 15 tools (158 operations) across 15 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 13 tools with 141 operations across 13 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 158 operations across 15 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -17,8 +17,8 @@ Claude can now create and edit PowerPoint decks directly.
 ## What's inside
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
-required) plus the manifest, license, and changelog. The server exposes 13
-tools (141 operations across 13 domains) — see the
+required) plus the manifest, license, and changelog. The server exposes 15
+tools (158 operations across 15 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 
 ## Building locally

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,8 +3,8 @@
   "name": "powerpoint-mcp",
   "display_name": "PowerPoint (Windows)",
   "version": "0.1.0",
-  "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, images, notes, layouts & slide-to-image export - requires PowerPoint to be installed",
-  "long_description": "MCP server for Microsoft PowerPoint automation. 13 tools (137 operations across 13 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including slide-to-image export so an AI can visually verify its own work. Windows-only, requires Microsoft PowerPoint desktop application.",
+  "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, accessibility, PDF export, and more - requires PowerPoint to be installed",
+  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (158 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including PDF delivery and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/scripts/check-doc-counts.ps1
+++ b/scripts/check-doc-counts.ps1
@@ -29,7 +29,7 @@
     Authoritative source = the generated `_SkillManifest.g.cs` (produced by
     ServiceRegistryGenerator from the Core [ServiceCategory] interfaces). It reports every
     generator-driven domain (slide, shape, textframe, table, notes, layout, master, animation,
-    image, chart, smartart, export) - 12 tools.
+    image, chart, smartart, export, pagesetup, accessibility) - 14 tools.
 
     canonical tools      = manifest.Commands.Count + 1              (+ presentation)
     canonical operations = sum(manifest.Commands[*].Actions.Count)

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -6,9 +6,10 @@ when working with the PowerPoint MCP Server.
 ## What This Is
 
 `mcp-server-powerpoint` drives a live Microsoft PowerPoint desktop instance via COM
-(`Microsoft.Office.Interop.PowerPoint`) and exposes it as **13 MCP tools across 13 domains**.
+(`Microsoft.Office.Interop.PowerPoint`) and exposes it as **15 MCP tools across 15 domains**.
 Every domain is a single action-dispatch tool: `presentation`, `slide`, `shape`, `textframe`,
-`table`, `notes`, `layout`, `master`, `animation`, `image`, `chart`, `smartart`, and `export`.
+`table`, `notes`, `layout`, `pagesetup`, `accessibility`, `master`, `animation`, `image`, `chart`,
+`smartart`, and `export`.
 
 Windows + PowerPoint desktop required. There is no cross-platform or headless mode — everything
 goes through real COM automation of a real PowerPoint process.
@@ -36,9 +37,11 @@ exists (see `.github/copilot-instructions.md`).
 5. **Verify visually** — use `export(action: "export-slide-to-image"/"export-all-slides-to-images",
    ...)` after any visual change; this is the project's core differentiator over text-only
    PowerPoint tooling.
-6. **Never ask clarifying questions** — discover state with `presentation(action: "list")`,
+6. **Run the accessibility audit** — call `accessibility(action: "audit", ...)` before final
+   delivery and fix deterministic structure issues.
+7. **Never ask clarifying questions** — discover state with `presentation(action: "list")`,
    `slide(action: "get-count", ...)`, `shape(action: "get-count", ...)`, etc.
-7. **Always end with a text summary** — never end a turn on a bare tool call.
+8. **Always end with a text summary** — never end a turn on a bare tool call.
 
 ## When Building Decks
 

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -119,11 +119,21 @@ of one flat tool per verb.
 
 Available command groups (in addition to `session` and `service`):
 
-`animation`, `chart`, `export`, `image`, `layout`, `master`, `notes`, `shape`, `slide`, `smartart`, `table`, `textframe`
+`accessibility`, `animation`, `chart`, `export`, `image`, `layout`, `master`, `notes`, `pagesetup`, `shape`, `slide`, `smartart`, `table`, `textframe`
 
 Run `pptcli <command> --help` for the live, authoritative list of actions and flags for that
 command — the table below is a summary generated from the same Core interfaces as the MCP tool
 surface, so it can lag a `--help` run for in-flight changes.
+
+
+### `accessibility` — Deterministic presentation accessibility checks and reading-order operations.
+
+Actions: `audit`, `get-reading-order`, `set-reading-order`
+
+| Flag | Description |
+|------|-------------|
+| `--slide-index` | (required for: get-reading-order, set-reading-order) |
+| `--shape-indexes` | (required for: set-reading-order) |
 
 
 ### `animation` — Animation commands: add/delete entrance, emphasis, and exit effects on a shape's slide timeline (Slide.TimeLine.MainSequence), and read/set a slide's transition (Slide.SlideShowTransition). Operates within an already-open , targeting a specific slide (and, for shape effects, a specific shape) by 1-based index.
@@ -168,14 +178,15 @@ Actions: `add-chart`, `get-chart-data`, `add-series`, `set-chart-title`, `get-ch
 | `--series-values` | (required for: replace-chart-data) |
 
 
-### `export` — Export commands: render presentation slides to raster image files. Operates within an already-open .
+### `export` — Export commands: render presentations to PDF or slides to raster image files. Operates within an already-open .
 
-Actions: `export-slide-to-image`, `export-all-slides-to-images`
+Actions: `export-to-pdf`, `export-slide-to-image`, `export-all-slides-to-images`
 
 | Flag | Description |
 |------|-------------|
+| `--output-path` | Full path for the output .pdf file. (required for: export-to-pdf, export-slide-to-image) |
+| `--overwrite` | Whether an existing PDF may be replaced. Defaults to false. |
 | `--slide-index` | 1-based index of the slide to export. (required for: export-slide-to-image) |
-| `--output-path` | Full path for the output image file (e.g. C:\output\slide1.png). (required for: export-slide-to-image) |
 | `--format` | PowerPoint filter name for the image format (e.g. "PNG", "JPG", "GIF").     Defaults to "PNG". |
 | `--width` | Optional output width in pixels; 0 or null uses PowerPoint's default. |
 | `--height` | Optional output height in pixels; 0 or null uses PowerPoint's default. |
@@ -249,9 +260,27 @@ Actions: `set-notes-text`, `get-notes-text`
 | `--text` | (required for: set-notes-text) |
 
 
-### `shape` — Shape commands: add rectangles/text boxes, count, delete, reposition/resize. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
+### `pagesetup` — Presentation-wide slide size, numbering, and footer settings.
 
-Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`, `delete`, `set-position`, `set-size`, `set-fill`, `get-fill`, `set-line`, `get-line`, `set-rotation`, `get-rotation`, `flip`, `set-z-order`, `set-shadow`, `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`, `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`, `set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`
+Actions: `get-settings`, `set-size`, `set-first-slide-number`, `get-footer`, `set-footer`
+
+| Flag | Description |
+|------|-------------|
+| `--width` | (required for: set-size) |
+| `--height` | (required for: set-size) |
+| `--first-slide-number` | (required for: set-first-slide-number) |
+| `--footer-text` |  |
+| `--show-footer` |  |
+| `--show-slide-number` |  |
+| `--show-date-time` |  |
+| `--date-time-mode` |  |
+| `--fixed-date-time-text` |  |
+| `--show-on-title-slide` |  |
+
+
+### `shape` — Shape commands: create, inspect, format, group, link, and edit native placeholders. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
+
+Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`, `delete`, `set-position`, `set-size`, `set-fill`, `get-fill`, `set-line`, `get-line`, `set-rotation`, `get-rotation`, `flip`, `set-z-order`, `set-shadow`, `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`, `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`, `set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`, `list-placeholders`, `set-placeholder-text`, `set-placeholder-image`
 
 | Flag | Description |
 |------|-------------|
@@ -260,14 +289,14 @@ Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-con
 | `--top` | (required for: add-rectangle, add-text-box, add-auto-shape, set-position) |
 | `--width` | (required for: add-rectangle, add-text-box, add-auto-shape, set-size) |
 | `--height` | (required for: add-rectangle, add-text-box, add-auto-shape, set-size) |
-| `--text` | (required for: add-text-box) |
+| `--text` | (required for: add-text-box, set-placeholder-text) |
 | `--shape-type` | (required for: add-auto-shape) |
 | `--begin-x` | (required for: add-line, add-connector) |
 | `--begin-y` | (required for: add-line, add-connector) |
 | `--end-x` | (required for: add-line, add-connector) |
 | `--end-y` | (required for: add-line, add-connector) |
 | `--connector-type` | (required for: add-connector) |
-| `--shape-index` | (required for: delete, set-position, set-size, set-fill, get-fill, set-line, get-line, set-rotation, get-rotation, flip, set-z-order, set-shadow, get-shadow, set-glow, get-glow, set-reflection, get-reflection, set-soft-edge, get-soft-edge, set-bevel, get-bevel, ungroup, set-name, get-name, set-alt-text, get-alt-text, set-hyperlink, get-hyperlink, remove-hyperlink) |
+| `--shape-index` | (required for: delete, set-position, set-size, set-fill, get-fill, set-line, get-line, set-rotation, get-rotation, flip, set-z-order, set-shadow, get-shadow, set-glow, get-glow, set-reflection, get-reflection, set-soft-edge, get-soft-edge, set-bevel, get-bevel, ungroup, set-name, get-name, set-alt-text, get-alt-text, set-hyperlink, get-hyperlink, remove-hyperlink, set-placeholder-text, set-placeholder-image) |
 | `--red` | (required for: set-fill, set-glow) |
 | `--green` | (required for: set-fill, set-glow) |
 | `--blue` | (required for: set-fill, set-glow) |
@@ -291,15 +320,16 @@ Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-con
 | `--alt-text` | (required for: set-alt-text) |
 | `--address` | (required for: set-hyperlink) |
 | `--screen-tip` |  |
+| `--image-path` | (required for: set-placeholder-image) |
 
 
-### `slide` — Slide lifecycle commands: add, delete, count, duplicate, reorder, per-slide background color, and section management. First domain built on top of the presentation lifecycle commands, operating within an already-open IPresentationBatch.
+### `slide` — Slide lifecycle, background, section, legacy comment, and slide-import commands.
 
-Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-background-color`, `get-background-color`, `set-gradient-background`, `get-gradient-background`, `add-section`, `rename-section`, `delete-section`, `get-section-count`, `get-section-name`
+Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-background-color`, `get-background-color`, `set-gradient-background`, `get-gradient-background`, `add-section`, `rename-section`, `delete-section`, `get-section-count`, `get-section-name`, `list-comments`, `add-comment`, `delete-comment`, `clear-comments`, `import-from-file`
 
 | Flag | Description |
 |------|-------------|
-| `--slide-index` | (required for: delete, duplicate, move-to, set-background-color, get-background-color, set-gradient-background, get-gradient-background) |
+| `--slide-index` | (required for: delete, duplicate, move-to, set-background-color, get-background-color, set-gradient-background, get-gradient-background, list-comments, add-comment, delete-comment, clear-comments) |
 | `--to-position` | (required for: move-to) |
 | `--red` | (required for: set-background-color) |
 | `--green` | (required for: set-background-color) |
@@ -315,6 +345,16 @@ Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-backgr
 | `--section-index` | (required for: add-section, rename-section, delete-section, get-section-name) |
 | `--section-name` | (required for: rename-section) |
 | `--delete-slides` |  |
+| `--author` | (required for: add-comment) |
+| `--initials` | (required for: add-comment) |
+| `--text` | (required for: add-comment) |
+| `--left` |  |
+| `--top` |  |
+| `--comment-index` | (required for: delete-comment) |
+| `--source-file-path` | (required for: import-from-file) |
+| `--destination-slide-index` | (required for: import-from-file) |
+| `--source-start-slide` |  |
+| `--source-end-slide` |  |
 
 
 ### `smartart` — SmartArt commands: add a SmartArt diagram to a slide from PowerPoint's built-in layout gallery, and add/read/update/delete/count the diagram's nodes. Operates within an already-open , targeting a specific slide and shape by 1-based index.

--- a/skills/powerpoint-mcp/references/behavioral-rules.md
+++ b/skills/powerpoint-mcp/references/behavioral-rules.md
@@ -39,7 +39,7 @@ Every editing workflow starts by establishing a session:
 
 ## Tool Conventions
 
-- **All 13 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
+- **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
   `templatePath`, `propertyName`, `value`.
 - **The other 12 domain tools use `session_id` plus snake_case action parameters**, e.g.
@@ -98,6 +98,12 @@ After creating or changing visual content, export and look at the result:
 ```
 
 See `export-and-verify.md` for the full loop and when it is required.
+
+## Run the Deterministic Accessibility Audit
+
+Before final delivery, call `accessibility(action: "audit", session_id: ...)`. Fix missing
+alternative text and empty title placeholders, then rerun the audit. This is a deterministic
+PowerPoint structure check, not an AI review of writing quality.
 
 ## Report Results
 

--- a/skills/powerpoint-mcp/references/export-and-verify.md
+++ b/skills/powerpoint-mcp/references/export-and-verify.md
@@ -1,8 +1,8 @@
 # Export & Visual Verification
 
-Reference for `export(action: "export-slide-to-image", ...)` and `export(action:
-"export-all-slides-to-images", ...)` — PowerPoint's native COM rendering used as the multimodal
-"look at the result" verification loop. This is the tool surface's differentiator: text-only
+Reference for PowerPoint's native PDF delivery and image rendering actions. The image actions
+provide the multimodal "look at the result" verification loop. This is the tool surface's
+differentiator: text-only
 inspection (`textframe(action: "get-text", ...)`, `shape(action: "get-count", ...)`,
 `chart(action: "get-chart-data", ...)`) cannot catch overlapping shapes, text overflow, bad chart
 proportions, or wrong colors — only a rendered image can.
@@ -28,6 +28,7 @@ confirms the API accepted the parameters, not that the result looks correct.
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
+| `export` | `export-to-pdf` | `session_id`, `output_path`, `overwrite` (default `false`) | Creates a PDF without changing the open presentation's file path. Refuses to replace an existing file unless `overwrite` is explicitly true. |
 | `export` | `export-slide-to-image` | `session_id`, `slide_index`, `output_path`, `format` (default `"PNG"`), `width`, `height` (optional pixels) | Renders exactly one slide to a single image file. |
 | `export` | `export-all-slides-to-images` | `session_id`, `output_directory`, `format` (default `"PNG"`) | Renders every slide; PowerPoint names files `Slide1.PNG`, `Slide2.PNG`, etc. in the given directory. |
 
@@ -41,6 +42,7 @@ confirms the API accepted the parameters, not that the result looks correct.
 
 | Situation | Use |
 |-----------|-----|
+| Delivering a finished deck as a PDF | `export(action: "export-to-pdf", ...)` after saving the presentation |
 | Just added/changed one slide | `export(action: "export-slide-to-image", ...)` on that slide only |
 | Finished building a whole deck | `export(action: "export-all-slides-to-images", ...)` once, review every image |
 | Iterating on a single slide's layout | `export-slide-to-image` repeatedly on that slide during the fix loop |

--- a/skills/powerpoint-mcp/references/layouts.md
+++ b/skills/powerpoint-mcp/references/layouts.md
@@ -1,7 +1,7 @@
 # Layouts
 
-Reference for `layout(action: "set-layout", ...)` and `layout(action: "get-layout", ...)` —
-applies PowerPoint's built-in slide layouts by their native `PpSlideLayout` enum member name.
+Reference for slide layouts and presentation-wide page setup. `layout` applies PowerPoint's native
+slide layouts; `pagesetup` controls slide dimensions, numbering, and footer elements.
 
 ## Actions
 
@@ -9,6 +9,13 @@ applies PowerPoint's built-in slide layouts by their native `PpSlideLayout` enum
 |------|--------|------------|-------|
 | `layout` | `set-layout` | `session_id`, `slide_index`, `layout_name` | `layout_name` is a `PpSlideLayout` enum member name string, e.g. `"ppLayoutBlank"`. |
 | `layout` | `get-layout` | `session_id`, `slide_index` | Returns the slide's current layout name. |
+| `layout` | `list-layouts` | `session_id`, `master_index` | Lists custom layouts for a 1-based slide master. |
+| `layout` | `delete-layout` | `session_id`, `master_index`, `layout_index` | Deletes an unused custom layout; PowerPoint refuses layouts still used by slides. |
+| `pagesetup` | `get-settings` | `session_id` | Returns slide width/height in points, orientation, and first slide number. |
+| `pagesetup` | `set-size` | `session_id`, `width`, `height` | Sets custom slide dimensions in points. |
+| `pagesetup` | `set-first-slide-number` | `session_id`, `first_slide_number` | Sets the number displayed on the first slide. |
+| `pagesetup` | `get-footer` | `session_id` | Reads footer text, slide-number visibility, and date/time settings. |
+| `pagesetup` | `set-footer` | `session_id` plus optional footer fields | Changes only the supplied footer fields, including `show_footer`, slide numbers, date/time, and title-slide display. `date_time_mode` is `automatic` or `fixed`. |
 
 ## Common Layout Names
 

--- a/skills/powerpoint-mcp/references/slides-and-shapes.md
+++ b/skills/powerpoint-mcp/references/slides-and-shapes.md
@@ -1,7 +1,7 @@
 # Slides and Shapes
 
 Reference for the `slide` tool (`add-blank`, `get-count`, `delete`, `duplicate`, `move-to`,
-`set-background-color`, `get-background-color`, section management) and the `shape` tool
+`set-background-color`, `get-background-color`, sections, comments, import) and the `shape` tool
 (`add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`,
 `delete`, `set-position`, `set-size`, plus the fill/line/rotation/flip/z-order/shadow/glow/
 reflection/soft-edge/bevel/group/name/alt-text/hyperlink formatting actions below).
@@ -24,6 +24,11 @@ reflection/soft-edge/bevel/group/name/alt-text/hyperlink formatting actions belo
 | `slide` | `delete-section` | `session_id`, `section_index`, `delete_slides` (optional, default `false`) | Deletes a section. If `delete_slides` is true, its slides are deleted too; otherwise they're kept and merged into a neighboring section. **PowerPoint disallows deleting section 1 unless `delete_slides` is true** — delete/reorder other sections first if you need to remove the first one's boundary without losing its slides. |
 | `slide` | `get-section-count` | `session_id` | Returns the current number of sections (`sectionCount`, `0` if none exist). |
 | `slide` | `get-section-name` | `session_id`, `section_index` | Returns a section's name (`sectionName`). |
+| `slide` | `list-comments` | `session_id`, `slide_index` | Lists legacy comments exposed by native PowerPoint COM. Modern threaded comments are not available through this API. |
+| `slide` | `add-comment` | `session_id`, `slide_index`, `author`, `initials`, `text`, optional `left`/`top` | Adds a legacy comment. PowerPoint may replace author details with the signed-in Office identity. |
+| `slide` | `delete-comment` | `session_id`, `slide_index`, `comment_index` | Deletes one legacy comment by 1-based index. |
+| `slide` | `clear-comments` | `session_id`, `slide_index` | Deletes all legacy comments on the slide. |
+| `slide` | `import-from-file` | `session_id`, `source_file_path`, `destination_slide_index`, optional source range | Inserts an inclusive 1-based source range after the destination slide; it never replaces destination slides. |
 
 Slides always append at the end via `add-blank` — there is no "insert blank at position N" action;
 use `add-blank` then `move-to` if you need a blank slide inserted mid-deck. See `deck-builder.md`
@@ -58,6 +63,9 @@ slide(action: "rename-section", session_id: ..., section_index: 2, section_name:
 | `shape` | `delete` | `session_id`, `slide_index`, `shape_index` (1-based) | Removes one shape; later shapes on that slide shift down by one index. |
 | `shape` | `set-position` | `session_id`, `slide_index`, `shape_index`, `left`, `top` | Moves an existing shape. |
 | `shape` | `set-size` | `session_id`, `slide_index`, `shape_index`, `width`, `height` | Resizes an existing shape. |
+| `shape` | `list-placeholders` | `session_id`, `slide_index` | Returns each native placeholder's shape index, type, name, bounds, alt text, and content state. |
+| `shape` | `set-placeholder-text` | `session_id`, `slide_index`, `shape_index`, `text` | Replaces text in a native text placeholder; rejects ordinary shapes. |
+| `shape` | `set-placeholder-image` | `session_id`, `slide_index`, `shape_index`, `image_path` | Places an image in a compatible picture/content placeholder while preserving its native geometry and metadata. |
 
 All position/size values are **points** (see `deck-builder.md` for the 960×540pt 16:9 reference).
 

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save → Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 13 tools and 141 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 158 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation
@@ -57,6 +57,10 @@ to support this loop for one of two starting points: a brand-new deck or an exis
 | `shape` | `get-count` | How many shapes are on a slide before adding/deleting/positioning |
 | `textframe` | `get-text` | Current text of a shape before editing it |
 | `layout` | `get-layout` | Current layout of a slide |
+| `pagesetup` | `get-settings` / `get-footer` | Slide size, first slide number, and footer state |
+| `shape` | `list-placeholders` | Placeholder indexes, types, bounds, and content state |
+| `slide` | `list-comments` | Legacy comments exposed by native PowerPoint COM |
+| `accessibility` | `audit` / `get-reading-order` | Deterministic accessibility issues and current reading order |
 | `table` | `get-cell-text` | Current content of a table cell |
 | `chart` | `get-chart-data` | Category/series counts of an existing chart |
 | `notes` | `get-notes-text` | Current speaker notes for a slide |
@@ -92,7 +96,9 @@ table(action: "set-cell-text", session_id: sessionId, slide_index: 3, shape_inde
 
 # Verify
 export(action: "export-all-slides-to-images", session_id: sessionId, output_directory: "C:\Decks\preview")
+accessibility(action: "audit", session_id: sessionId)
 
 presentation(action: "save", sessionId: sessionId)
+export(action: "export-to-pdf", session_id: sessionId, output_path: "C:\Decks\q4.pdf")
 presentation(action: "close", sessionId: sessionId)
 ```

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -39,7 +39,7 @@ Every editing workflow starts by establishing a session:
 
 ## Tool Conventions
 
-- **All 13 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
+- **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
   `templatePath`, `propertyName`, `value`.
 - **The other 12 domain tools use `session_id` plus snake_case action parameters**, e.g.
@@ -98,6 +98,12 @@ After creating or changing visual content, export and look at the result:
 ```
 
 See `export-and-verify.md` for the full loop and when it is required.
+
+## Run the Deterministic Accessibility Audit
+
+Before final delivery, call `accessibility(action: "audit", session_id: ...)`. Fix missing
+alternative text and empty title placeholders, then rerun the audit. This is a deterministic
+PowerPoint structure check, not an AI review of writing quality.
 
 ## Report Results
 

--- a/skills/shared/export-and-verify.md
+++ b/skills/shared/export-and-verify.md
@@ -1,8 +1,8 @@
 # Export & Visual Verification
 
-Reference for `export(action: "export-slide-to-image", ...)` and `export(action:
-"export-all-slides-to-images", ...)` — PowerPoint's native COM rendering used as the multimodal
-"look at the result" verification loop. This is the tool surface's differentiator: text-only
+Reference for PowerPoint's native PDF delivery and image rendering actions. The image actions
+provide the multimodal "look at the result" verification loop. This is the tool surface's
+differentiator: text-only
 inspection (`textframe(action: "get-text", ...)`, `shape(action: "get-count", ...)`,
 `chart(action: "get-chart-data", ...)`) cannot catch overlapping shapes, text overflow, bad chart
 proportions, or wrong colors — only a rendered image can.
@@ -28,6 +28,7 @@ confirms the API accepted the parameters, not that the result looks correct.
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
+| `export` | `export-to-pdf` | `session_id`, `output_path`, `overwrite` (default `false`) | Creates a PDF without changing the open presentation's file path. Refuses to replace an existing file unless `overwrite` is explicitly true. |
 | `export` | `export-slide-to-image` | `session_id`, `slide_index`, `output_path`, `format` (default `"PNG"`), `width`, `height` (optional pixels) | Renders exactly one slide to a single image file. |
 | `export` | `export-all-slides-to-images` | `session_id`, `output_directory`, `format` (default `"PNG"`) | Renders every slide; PowerPoint names files `Slide1.PNG`, `Slide2.PNG`, etc. in the given directory. |
 
@@ -41,6 +42,7 @@ confirms the API accepted the parameters, not that the result looks correct.
 
 | Situation | Use |
 |-----------|-----|
+| Delivering a finished deck as a PDF | `export(action: "export-to-pdf", ...)` after saving the presentation |
 | Just added/changed one slide | `export(action: "export-slide-to-image", ...)` on that slide only |
 | Finished building a whole deck | `export(action: "export-all-slides-to-images", ...)` once, review every image |
 | Iterating on a single slide's layout | `export-slide-to-image` repeatedly on that slide during the fix loop |

--- a/skills/shared/layouts.md
+++ b/skills/shared/layouts.md
@@ -1,7 +1,7 @@
 # Layouts
 
-Reference for `layout(action: "set-layout", ...)` and `layout(action: "get-layout", ...)` —
-applies PowerPoint's built-in slide layouts by their native `PpSlideLayout` enum member name.
+Reference for slide layouts and presentation-wide page setup. `layout` applies PowerPoint's native
+slide layouts; `pagesetup` controls slide dimensions, numbering, and footer elements.
 
 ## Actions
 
@@ -9,6 +9,13 @@ applies PowerPoint's built-in slide layouts by their native `PpSlideLayout` enum
 |------|--------|------------|-------|
 | `layout` | `set-layout` | `session_id`, `slide_index`, `layout_name` | `layout_name` is a `PpSlideLayout` enum member name string, e.g. `"ppLayoutBlank"`. |
 | `layout` | `get-layout` | `session_id`, `slide_index` | Returns the slide's current layout name. |
+| `layout` | `list-layouts` | `session_id`, `master_index` | Lists custom layouts for a 1-based slide master. |
+| `layout` | `delete-layout` | `session_id`, `master_index`, `layout_index` | Deletes an unused custom layout; PowerPoint refuses layouts still used by slides. |
+| `pagesetup` | `get-settings` | `session_id` | Returns slide width/height in points, orientation, and first slide number. |
+| `pagesetup` | `set-size` | `session_id`, `width`, `height` | Sets custom slide dimensions in points. |
+| `pagesetup` | `set-first-slide-number` | `session_id`, `first_slide_number` | Sets the number displayed on the first slide. |
+| `pagesetup` | `get-footer` | `session_id` | Reads footer text, slide-number visibility, and date/time settings. |
+| `pagesetup` | `set-footer` | `session_id` plus optional footer fields | Changes only the supplied footer fields, including `show_footer`, slide numbers, date/time, and title-slide display. `date_time_mode` is `automatic` or `fixed`. |
 
 ## Common Layout Names
 

--- a/skills/shared/slides-and-shapes.md
+++ b/skills/shared/slides-and-shapes.md
@@ -1,7 +1,7 @@
 # Slides and Shapes
 
 Reference for the `slide` tool (`add-blank`, `get-count`, `delete`, `duplicate`, `move-to`,
-`set-background-color`, `get-background-color`, section management) and the `shape` tool
+`set-background-color`, `get-background-color`, sections, comments, import) and the `shape` tool
 (`add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`,
 `delete`, `set-position`, `set-size`, plus the fill/line/rotation/flip/z-order/shadow/glow/
 reflection/soft-edge/bevel/group/name/alt-text/hyperlink formatting actions below).
@@ -24,6 +24,11 @@ reflection/soft-edge/bevel/group/name/alt-text/hyperlink formatting actions belo
 | `slide` | `delete-section` | `session_id`, `section_index`, `delete_slides` (optional, default `false`) | Deletes a section. If `delete_slides` is true, its slides are deleted too; otherwise they're kept and merged into a neighboring section. **PowerPoint disallows deleting section 1 unless `delete_slides` is true** — delete/reorder other sections first if you need to remove the first one's boundary without losing its slides. |
 | `slide` | `get-section-count` | `session_id` | Returns the current number of sections (`sectionCount`, `0` if none exist). |
 | `slide` | `get-section-name` | `session_id`, `section_index` | Returns a section's name (`sectionName`). |
+| `slide` | `list-comments` | `session_id`, `slide_index` | Lists legacy comments exposed by native PowerPoint COM. Modern threaded comments are not available through this API. |
+| `slide` | `add-comment` | `session_id`, `slide_index`, `author`, `initials`, `text`, optional `left`/`top` | Adds a legacy comment. PowerPoint may replace author details with the signed-in Office identity. |
+| `slide` | `delete-comment` | `session_id`, `slide_index`, `comment_index` | Deletes one legacy comment by 1-based index. |
+| `slide` | `clear-comments` | `session_id`, `slide_index` | Deletes all legacy comments on the slide. |
+| `slide` | `import-from-file` | `session_id`, `source_file_path`, `destination_slide_index`, optional source range | Inserts an inclusive 1-based source range after the destination slide; it never replaces destination slides. |
 
 Slides always append at the end via `add-blank` — there is no "insert blank at position N" action;
 use `add-blank` then `move-to` if you need a blank slide inserted mid-deck. See `deck-builder.md`
@@ -58,6 +63,9 @@ slide(action: "rename-section", session_id: ..., section_index: 2, section_name:
 | `shape` | `delete` | `session_id`, `slide_index`, `shape_index` (1-based) | Removes one shape; later shapes on that slide shift down by one index. |
 | `shape` | `set-position` | `session_id`, `slide_index`, `shape_index`, `left`, `top` | Moves an existing shape. |
 | `shape` | `set-size` | `session_id`, `slide_index`, `shape_index`, `width`, `height` | Resizes an existing shape. |
+| `shape` | `list-placeholders` | `session_id`, `slide_index` | Returns each native placeholder's shape index, type, name, bounds, alt text, and content state. |
+| `shape` | `set-placeholder-text` | `session_id`, `slide_index`, `shape_index`, `text` | Replaces text in a native text placeholder; rejects ordinary shapes. |
+| `shape` | `set-placeholder-image` | `session_id`, `slide_index`, `shape_index`, `image_path` | Places an image in a compatible picture/content placeholder while preserving its native geometry and metadata. |
 
 All position/size values are **points** (see `deck-builder.md` for the 960×540pt 16:9 reference).
 

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save → Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 13 tools and 141 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 158 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation
@@ -57,6 +57,10 @@ to support this loop for one of two starting points: a brand-new deck or an exis
 | `shape` | `get-count` | How many shapes are on a slide before adding/deleting/positioning |
 | `textframe` | `get-text` | Current text of a shape before editing it |
 | `layout` | `get-layout` | Current layout of a slide |
+| `pagesetup` | `get-settings` / `get-footer` | Slide size, first slide number, and footer state |
+| `shape` | `list-placeholders` | Placeholder indexes, types, bounds, and content state |
+| `slide` | `list-comments` | Legacy comments exposed by native PowerPoint COM |
+| `accessibility` | `audit` / `get-reading-order` | Deterministic accessibility issues and current reading order |
 | `table` | `get-cell-text` | Current content of a table cell |
 | `chart` | `get-chart-data` | Category/series counts of an existing chart |
 | `notes` | `get-notes-text` | Current speaker notes for a slide |
@@ -92,7 +96,9 @@ table(action: "set-cell-text", session_id: sessionId, slide_index: 3, shape_inde
 
 # Verify
 export(action: "export-all-slides-to-images", session_id: sessionId, output_directory: "C:\Decks\preview")
+accessibility(action: "audit", session_id: sessionId)
 
 presentation(action: "save", sessionId: sessionId)
+export(action: "export-to-pdf", session_id: sessionId, output_path: "C:\Decks\q4.pdf")
 presentation(action: "close", sessionId: sessionId)
 ```

--- a/src/PowerPointMcp.Core/Accessibility/AccessibilityCommands.cs
+++ b/src/PowerPointMcp.Core/Accessibility/AccessibilityCommands.cs
@@ -1,0 +1,329 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Accessibility;
+
+/// <inheritdoc cref="IAccessibilityCommands"/>
+public sealed class AccessibilityCommands : IAccessibilityCommands
+{
+    private const int MsoTrue = -1;
+    private const int MsoPicture = 13;
+    private const int MsoLinkedPicture = 11;
+    private const int MsoPlaceholder = 14;
+    private const int MsoBringToFront = 0;
+
+    /// <inheritdoc/>
+    public AccessibilityOperationResult Audit(IPresentationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var issues = new List<AccessibilityOperationResult.AccessibilityIssue>();
+            PowerPoint.Slides? slides = null;
+            try
+            {
+                slides = ctx.Presentation.Slides;
+                int slideCount = slides.Count;
+                for (int slideIndex = 1; slideIndex <= slideCount; slideIndex++)
+                {
+                    AuditSlide(slides, slideIndex, issues);
+                }
+
+                return new AccessibilityOperationResult
+                {
+                    Success = true,
+                    Issues = issues
+                };
+            }
+            finally
+            {
+                if (slides != null) ComUtilities.Release(ref slides);
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public AccessibilityOperationResult GetReadingOrder(IPresentationBatch batch, int slideIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            int slideCount = ctx.Presentation.Slides.Count;
+            var validation = ValidateSlideIndex(slideCount, slideIndex);
+            if (validation != null) return validation;
+
+            PowerPoint.Slide? slide = null;
+            PowerPoint.Shapes? shapes = null;
+            try
+            {
+                slide = ctx.Presentation.Slides[slideIndex];
+                shapes = slide.Shapes;
+                var ownedShapes = new List<PowerPoint.Shape>(shapes.Count);
+                try
+                {
+                    for (int shapeIndex = 1; shapeIndex <= shapes.Count; shapeIndex++)
+                    {
+                        ownedShapes.Add(shapes[shapeIndex]);
+                    }
+
+                    var stableShapes = ownedShapes.OrderBy(shape => shape.Id).ToArray();
+                    return new AccessibilityOperationResult
+                    {
+                        Success = true,
+                        ReadingOrder = stableShapes
+                            .Select((shape, stableIndex) => new
+                            {
+                                ShapeIndex = stableIndex + 1,
+                                shape.ZOrderPosition
+                            })
+                            .OrderBy(item => item.ZOrderPosition)
+                            .Select(item => item.ShapeIndex)
+                            .ToArray()
+                    };
+                }
+                finally
+                {
+                    ReleaseShapes(ownedShapes);
+                }
+            }
+            finally
+            {
+                if (shapes != null) ComUtilities.Release(ref shapes);
+                if (slide != null) ComUtilities.Release(ref slide);
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public AccessibilityOperationResult SetReadingOrder(
+        IPresentationBatch batch,
+        int slideIndex,
+        IReadOnlyList<int> shapeIndexes)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(shapeIndexes);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            int slideCount = ctx.Presentation.Slides.Count;
+            var slideValidation = ValidateSlideIndex(slideCount, slideIndex);
+            if (slideValidation != null) return slideValidation;
+
+            PowerPoint.Slide? slide = null;
+            PowerPoint.Shapes? shapes = null;
+            var orderedShapes = new List<PowerPoint.Shape>();
+            try
+            {
+                slide = ctx.Presentation.Slides[slideIndex];
+                shapes = slide.Shapes;
+                int shapeCount = shapes.Count;
+
+                if (!IsCompletePermutation(shapeIndexes, shapeCount))
+                {
+                    return new AccessibilityOperationResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Reading order must contain every 1-based shape index from 1 through {shapeCount} exactly once."
+                    };
+                }
+
+                var shapesByStableIndex = new List<PowerPoint.Shape>(shapeCount);
+                for (int shapeIndex = 1; shapeIndex <= shapeCount; shapeIndex++)
+                {
+                    shapesByStableIndex.Add(shapes[shapeIndex]);
+                }
+
+                shapesByStableIndex.Sort((left, right) => left.Id.CompareTo(right.Id));
+                foreach (int shapeIndex in shapeIndexes)
+                {
+                    orderedShapes.Add(shapesByStableIndex[shapeIndex - 1]);
+                }
+
+                foreach (PowerPoint.Shape shape in orderedShapes)
+                {
+                    // PIA gap: Shape.ZOrder takes Office.MsoZOrderCmd, unavailable without office.dll.
+                    ((dynamic)shape).ZOrder(MsoBringToFront);
+                }
+
+                return new AccessibilityOperationResult
+                {
+                    Success = true,
+                    ReadingOrder = shapeIndexes.ToArray()
+                };
+            }
+            finally
+            {
+                ReleaseShapes(orderedShapes);
+                if (shapes != null) ComUtilities.Release(ref shapes);
+                if (slide != null) ComUtilities.Release(ref slide);
+            }
+        });
+    }
+
+    private static void AuditSlide(
+        PowerPoint.Slides slides,
+        int slideIndex,
+        List<AccessibilityOperationResult.AccessibilityIssue> issues)
+    {
+        PowerPoint.Slide? slide = null;
+        PowerPoint.Shapes? shapes = null;
+        try
+        {
+            slide = slides[slideIndex];
+            shapes = slide.Shapes;
+            var zOrderPositions = new HashSet<int>();
+
+            for (int shapeIndex = 1; shapeIndex <= shapes.Count; shapeIndex++)
+            {
+                PowerPoint.Shape? shape = null;
+                try
+                {
+                    shape = shapes[shapeIndex];
+                    if (IsNonDecorativeVisualShape(shape) &&
+                        string.IsNullOrWhiteSpace(shape.AlternativeText))
+                    {
+                        issues.Add(new AccessibilityOperationResult.AccessibilityIssue
+                        {
+                            Code = "missing-alt-text",
+                            Message = $"Visual shape {shapeIndex} on slide {slideIndex} is missing alternative text.",
+                            SlideIndex = slideIndex,
+                            ShapeIndex = shapeIndex
+                        });
+                    }
+
+                    if (IsEmptyTitlePlaceholder(shape))
+                    {
+                        issues.Add(new AccessibilityOperationResult.AccessibilityIssue
+                        {
+                            Code = "empty-title-placeholder",
+                            Message = $"Title placeholder {shapeIndex} on slide {slideIndex} is empty.",
+                            SlideIndex = slideIndex,
+                            ShapeIndex = shapeIndex
+                        });
+                    }
+
+                    int zOrderPosition = shape.ZOrderPosition;
+                    if (zOrderPosition < 1 || zOrderPosition > shapes.Count)
+                    {
+                        issues.Add(new AccessibilityOperationResult.AccessibilityIssue
+                        {
+                            Code = "invalid-reading-order",
+                            Message = $"Shape {shapeIndex} on slide {slideIndex} has invalid reading-order position {zOrderPosition}.",
+                            SlideIndex = slideIndex,
+                            ShapeIndex = shapeIndex
+                        });
+                    }
+                    else if (!zOrderPositions.Add(zOrderPosition))
+                    {
+                        issues.Add(new AccessibilityOperationResult.AccessibilityIssue
+                        {
+                            Code = "duplicate-reading-order",
+                            Message = $"Shape {shapeIndex} on slide {slideIndex} duplicates reading-order position {zOrderPosition}.",
+                            SlideIndex = slideIndex,
+                            ShapeIndex = shapeIndex
+                        });
+                    }
+                }
+                finally
+                {
+                    if (shape != null) ComUtilities.Release(ref shape);
+                }
+            }
+        }
+        finally
+        {
+            if (shapes != null) ComUtilities.Release(ref shapes);
+            if (slide != null) ComUtilities.Release(ref slide);
+        }
+    }
+
+    private static bool IsNonDecorativeVisualShape(PowerPoint.Shape shape)
+    {
+        // Type, HasChart, HasSmartArt, and Decorative are Office.Core-backed members, so these
+        // reads are narrowly late-bound because office.dll is intentionally not referenced.
+        dynamic dispatch = shape;
+        int shapeType = (int)dispatch.Type;
+        bool isVisual = shapeType is MsoPicture or MsoLinkedPicture ||
+                        (int)dispatch.HasChart == MsoTrue ||
+                        (int)dispatch.HasSmartArt == MsoTrue;
+        return isVisual && (int)dispatch.Decorative != MsoTrue;
+    }
+
+    private static bool IsEmptyTitlePlaceholder(PowerPoint.Shape shape)
+    {
+        // PIA gap: Shape.Type is Office.MsoShapeType, unavailable without office.dll.
+        if ((int)((dynamic)shape).Type != MsoPlaceholder)
+        {
+            return false;
+        }
+
+        PowerPoint.PlaceholderFormat? placeholderFormat = null;
+        PowerPoint.TextFrame? textFrame = null;
+        PowerPoint.TextRange? textRange = null;
+        try
+        {
+            placeholderFormat = shape.PlaceholderFormat;
+            PowerPoint.PpPlaceholderType placeholderType = placeholderFormat.Type;
+            if (placeholderType is not PowerPoint.PpPlaceholderType.ppPlaceholderTitle and
+                not PowerPoint.PpPlaceholderType.ppPlaceholderCenterTitle)
+            {
+                return false;
+            }
+
+            textFrame = shape.TextFrame;
+            textRange = textFrame.TextRange;
+            return string.IsNullOrWhiteSpace(textRange.Text);
+        }
+        finally
+        {
+            if (textRange != null) ComUtilities.Release(ref textRange);
+            if (textFrame != null) ComUtilities.Release(ref textFrame);
+            if (placeholderFormat != null) ComUtilities.Release(ref placeholderFormat);
+        }
+    }
+
+    private static bool IsCompletePermutation(IReadOnlyList<int> shapeIndexes, int shapeCount)
+    {
+        if (shapeIndexes.Count != shapeCount)
+        {
+            return false;
+        }
+
+        var seen = new HashSet<int>();
+        foreach (int shapeIndex in shapeIndexes)
+        {
+            if (shapeIndex < 1 || shapeIndex > shapeCount || !seen.Add(shapeIndex))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void ReleaseShapes(List<PowerPoint.Shape> shapes)
+    {
+        foreach (PowerPoint.Shape shape in shapes)
+        {
+            PowerPoint.Shape? ownedShape = shape;
+            ComUtilities.Release(ref ownedShape);
+        }
+    }
+
+    private static AccessibilityOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)
+    {
+        if (slideIndex < 1 || slideIndex > slideCount)
+        {
+            return new AccessibilityOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Slide index {slideIndex} is out of range. The presentation has {slideCount} slide(s) (valid range: 1-{slideCount})."
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/PowerPointMcp.Core/Accessibility/AccessibilityOperationResult.cs
+++ b/src/PowerPointMcp.Core/Accessibility/AccessibilityOperationResult.cs
@@ -1,0 +1,33 @@
+namespace Sbroenne.PowerPointMcp.Core.Accessibility;
+
+/// <summary>Result of an accessibility operation.</summary>
+public sealed class AccessibilityOperationResult
+{
+    /// <summary>Whether the operation succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Error message when <see cref="Success"/> is false.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Deterministic accessibility issues found by an audit.</summary>
+    public IReadOnlyList<AccessibilityIssue>? Issues { get; init; }
+
+    /// <summary>Shape reading order expressed as 1-based shape indexes.</summary>
+    public IReadOnlyList<int>? ReadingOrder { get; init; }
+
+    /// <summary>One deterministic accessibility issue.</summary>
+    public sealed class AccessibilityIssue
+    {
+        /// <summary>Stable machine-readable issue code.</summary>
+        public required string Code { get; init; }
+
+        /// <summary>Human-readable issue description.</summary>
+        public required string Message { get; init; }
+
+        /// <summary>1-based slide index.</summary>
+        public int SlideIndex { get; init; }
+
+        /// <summary>1-based shape index, when the issue targets a shape.</summary>
+        public int? ShapeIndex { get; init; }
+    }
+}

--- a/src/PowerPointMcp.Core/Accessibility/IAccessibilityCommands.cs
+++ b/src/PowerPointMcp.Core/Accessibility/IAccessibilityCommands.cs
@@ -1,0 +1,26 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Attributes;
+
+namespace Sbroenne.PowerPointMcp.Core.Accessibility;
+
+/// <summary>Deterministic presentation accessibility checks and reading-order operations.</summary>
+[ServiceCategory("accessibility", "Accessibility")]
+[McpTool("accessibility", Title = "Accessibility Operations", Destructive = true, Category = "content",
+    Description = "Audit presentation accessibility and read or change a slide's shape reading order.")]
+public interface IAccessibilityCommands
+{
+    /// <summary>Audits the presentation for deterministic accessibility issues.</summary>
+    AccessibilityOperationResult Audit(IPresentationBatch batch);
+
+    /// <summary>Gets a slide's shape reading order as 1-based shape indexes.</summary>
+    AccessibilityOperationResult GetReadingOrder(IPresentationBatch batch, int slideIndex);
+
+    /// <summary>
+    /// Sets a slide's reading order. <paramref name="shapeIndexes"/> must contain every 1-based
+    /// shape index on the slide exactly once.
+    /// </summary>
+    AccessibilityOperationResult SetReadingOrder(
+        IPresentationBatch batch,
+        int slideIndex,
+        IReadOnlyList<int> shapeIndexes);
+}

--- a/src/PowerPointMcp.Core/Export/ExportCommands.cs
+++ b/src/PowerPointMcp.Core/Export/ExportCommands.cs
@@ -7,6 +7,107 @@ namespace Sbroenne.PowerPointMcp.Core.Export;
 public sealed class ExportCommands : IExportCommands
 {
     /// <inheritdoc/>
+    public ExportOperationResult ExportToPdf(
+        IPresentationBatch batch,
+        string outputPath,
+        bool overwrite = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(outputPath);
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            return new ExportOperationResult
+            {
+                ErrorMessage = "Output path must not be empty."
+            };
+        }
+
+        string fullOutputPath;
+        try
+        {
+            fullOutputPath = Path.GetFullPath(outputPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new ExportOperationResult
+            {
+                ErrorMessage = $"Invalid output path: {ex.Message}"
+            };
+        }
+        if (!string.Equals(Path.GetExtension(fullOutputPath), ".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ExportOperationResult
+            {
+                ErrorMessage = "PDF output path must use the .pdf extension."
+            };
+        }
+
+        string? outputDirectory = Path.GetDirectoryName(fullOutputPath);
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            return new ExportOperationResult
+            {
+                ErrorMessage = $"Cannot determine output directory from path: {fullOutputPath}."
+            };
+        }
+
+        if (File.Exists(fullOutputPath))
+        {
+            if (!overwrite)
+            {
+                return new ExportOperationResult
+                {
+                    ErrorMessage = $"Output file already exists: {fullOutputPath}. Set overwrite=true to replace it."
+                };
+            }
+
+            try
+            {
+                File.Delete(fullOutputPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return new ExportOperationResult
+                {
+                    ErrorMessage = $"Could not replace output file '{fullOutputPath}': {ex.Message}"
+                };
+            }
+        }
+
+        try
+        {
+            Directory.CreateDirectory(outputDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new ExportOperationResult
+            {
+                ErrorMessage = $"Could not create output directory '{outputDirectory}': {ex.Message}"
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            // PIA gap: SaveCopyAs has an Office.MsoTriState parameter, unavailable without office.dll.
+            ((dynamic)ctx.Presentation).SaveCopyAs(
+                fullOutputPath,
+                (int)PowerPoint.PpSaveAsFileType.ppSaveAsPDF);
+
+            if (!File.Exists(fullOutputPath) || new FileInfo(fullOutputPath).Length == 0)
+            {
+                throw new InvalidOperationException($"PowerPoint did not produce a non-empty PDF at '{fullOutputPath}'.");
+            }
+
+            return new ExportOperationResult
+            {
+                Success = true,
+                ExportedFilePath = fullOutputPath,
+                SlideCount = ctx.Presentation.Slides.Count
+            };
+        });
+    }
+
+    /// <inheritdoc/>
     public ExportOperationResult ExportSlideToImage(
         IPresentationBatch batch,
         int slideIndex,

--- a/src/PowerPointMcp.Core/Export/IExportCommands.cs
+++ b/src/PowerPointMcp.Core/Export/IExportCommands.cs
@@ -4,20 +4,29 @@ using Sbroenne.PowerPointMcp.Core.Attributes;
 namespace Sbroenne.PowerPointMcp.Core.Export;
 
 /// <summary>
-/// Export commands: render presentation slides to raster image files.
+/// Export commands: render presentations to PDF or slides to raster image files.
 /// Operates within an already-open <see cref="IPresentationBatch"/>.
 /// </summary>
 /// <remarks>
-/// Uses the PowerPoint COM <c>Slide.Export</c> and <c>Presentation.Export</c> APIs, which
-/// are the native mechanisms for slide→image conversion and do not require any additional
-/// rendering library. This is the visual-verification ("verify visually") differentiator
-/// over competing PowerPoint MCP servers that cannot produce images from slides.
+/// Uses PowerPoint's native PDF and image export APIs without an additional rendering library.
 /// </remarks>
 [ServiceCategory("export", "Export")]
 [McpTool("export", Title = "Export Operations", Destructive = true, Category = "content",
-    Description = "Export slides in an open presentation session to raster image files.")]
+    Description = "Export an open presentation to PDF or raster image files.")]
 public interface IExportCommands
 {
+    /// <summary>
+    /// Exports the open presentation to a PDF file using PowerPoint's native fixed-format export.
+    /// Refuses to replace an existing file unless <paramref name="overwrite"/> is true.
+    /// </summary>
+    /// <param name="batch">The open presentation batch to operate on.</param>
+    /// <param name="outputPath">Full path for the output <c>.pdf</c> file.</param>
+    /// <param name="overwrite">Whether an existing PDF may be replaced. Defaults to false.</param>
+    ExportOperationResult ExportToPdf(
+        IPresentationBatch batch,
+        string outputPath,
+        bool overwrite = false);
+
     /// <summary>
     /// Exports a single slide to an image file using PowerPoint's native COM rendering
     /// (<c>Slide.Export(FileName, FilterName, ScaleWidth, ScaleHeight)</c>).

--- a/src/PowerPointMcp.Core/PageSetup/IPageSetupCommands.cs
+++ b/src/PowerPointMcp.Core/PageSetup/IPageSetupCommands.cs
@@ -1,0 +1,39 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Attributes;
+
+namespace Sbroenne.PowerPointMcp.Core.PageSetup;
+
+/// <summary>
+/// Presentation-wide slide size, numbering, and footer settings.
+/// </summary>
+[ServiceCategory("pagesetup", "PageSetup")]
+[McpTool("pagesetup", Title = "Page Setup Operations", Destructive = true, Category = "content",
+    Description = "Read or change presentation-wide slide size, numbering, and footer settings.")]
+public interface IPageSetupCommands
+{
+    /// <summary>Gets slide dimensions, orientation, and the first slide number.</summary>
+    PageSetupOperationResult GetSettings(IPresentationBatch batch);
+
+    /// <summary>Sets custom slide dimensions in points.</summary>
+    PageSetupOperationResult SetSize(IPresentationBatch batch, float width, float height);
+
+    /// <summary>Sets the number displayed on the first slide.</summary>
+    PageSetupOperationResult SetFirstSlideNumber(IPresentationBatch batch, int firstSlideNumber);
+
+    /// <summary>Gets presentation-wide footer, slide-number, and date/time settings.</summary>
+    PageSetupOperationResult GetFooter(IPresentationBatch batch);
+
+    /// <summary>
+    /// Updates presentation-wide footer settings. Null values leave the corresponding setting
+    /// unchanged. <paramref name="dateTimeMode"/> is <c>automatic</c> or <c>fixed</c>.
+    /// </summary>
+    PageSetupOperationResult SetFooter(
+        IPresentationBatch batch,
+        string? footerText = null,
+        bool? showFooter = null,
+        bool? showSlideNumber = null,
+        bool? showDateTime = null,
+        string? dateTimeMode = null,
+        string? fixedDateTimeText = null,
+        bool? showOnTitleSlide = null);
+}

--- a/src/PowerPointMcp.Core/PageSetup/PageSetupCommands.cs
+++ b/src/PowerPointMcp.Core/PageSetup/PageSetupCommands.cs
@@ -1,0 +1,306 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.PageSetup;
+
+/// <inheritdoc cref="IPageSetupCommands"/>
+public sealed class PageSetupCommands : IPageSetupCommands
+{
+    private const int MsoTrue = -1;
+    private const int MsoFalse = 0;
+
+    /// <inheritdoc/>
+    public PageSetupOperationResult GetSettings(IPresentationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) => ReadSettings(ctx.Presentation));
+    }
+
+    /// <inheritdoc/>
+    public PageSetupOperationResult SetSize(IPresentationBatch batch, float width, float height)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        if (!float.IsFinite(width) || width <= 0)
+        {
+            return new PageSetupOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Width {width} is invalid; width must be greater than zero."
+            };
+        }
+
+        if (!float.IsFinite(height) || height <= 0)
+        {
+            return new PageSetupOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Height {height} is invalid; height must be greater than zero."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.PageSetup? pageSetup = null;
+            try
+            {
+                pageSetup = ctx.Presentation.PageSetup;
+                pageSetup.SlideWidth = width;
+                pageSetup.SlideHeight = height;
+
+                return CreateSettingsResult(pageSetup);
+            }
+            finally
+            {
+                if (pageSetup != null)
+                {
+                    ComUtilities.Release(ref pageSetup);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public PageSetupOperationResult SetFirstSlideNumber(IPresentationBatch batch, int firstSlideNumber)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.PageSetup? pageSetup = null;
+            try
+            {
+                pageSetup = ctx.Presentation.PageSetup;
+                pageSetup.FirstSlideNumber = firstSlideNumber;
+
+                return CreateSettingsResult(pageSetup);
+            }
+            finally
+            {
+                if (pageSetup != null)
+                {
+                    ComUtilities.Release(ref pageSetup);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public PageSetupOperationResult GetFooter(IPresentationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) => ReadFooter(ctx.Presentation));
+    }
+
+    /// <inheritdoc/>
+    public PageSetupOperationResult SetFooter(
+        IPresentationBatch batch,
+        string? footerText = null,
+        bool? showFooter = null,
+        bool? showSlideNumber = null,
+        bool? showDateTime = null,
+        string? dateTimeMode = null,
+        string? fixedDateTimeText = null,
+        bool? showOnTitleSlide = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        string? normalizedDateTimeMode = dateTimeMode?.Trim().ToLowerInvariant();
+        if (normalizedDateTimeMode is not null and not "automatic" and not "fixed")
+        {
+            return new PageSetupOperationResult
+            {
+                Success = false,
+                ErrorMessage = $"Date/time mode '{dateTimeMode}' is invalid; it must be 'automatic' or 'fixed'."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Master? master = null;
+            PowerPoint.HeadersFooters? headersFooters = null;
+            PowerPoint.HeaderFooter? footer = null;
+            PowerPoint.HeaderFooter? slideNumber = null;
+            PowerPoint.HeaderFooter? dateAndTime = null;
+            try
+            {
+                master = GetSlideMaster(ctx.Presentation);
+                headersFooters = master.HeadersFooters;
+                footer = headersFooters.Footer;
+                slideNumber = headersFooters.SlideNumber;
+                dateAndTime = headersFooters.DateAndTime;
+
+                if (footerText != null)
+                {
+                    footer.Text = footerText;
+                    SetTriStateProperty(footer, "Visible", true);
+                }
+
+                if (showFooter.HasValue)
+                {
+                    SetTriStateProperty(footer, "Visible", showFooter.Value);
+                }
+
+                if (showSlideNumber.HasValue)
+                {
+                    SetTriStateProperty(slideNumber, "Visible", showSlideNumber.Value);
+                }
+
+                if (showDateTime.HasValue)
+                {
+                    SetTriStateProperty(dateAndTime, "Visible", showDateTime.Value);
+                }
+
+                if (normalizedDateTimeMode != null)
+                {
+                    SetTriStateProperty(dateAndTime, "UseFormat", normalizedDateTimeMode == "automatic");
+                }
+
+                if (fixedDateTimeText != null)
+                {
+                    dateAndTime.Text = fixedDateTimeText;
+                }
+
+                if (showOnTitleSlide.HasValue)
+                {
+                    SetTriStateProperty(headersFooters, "DisplayOnTitleSlide", showOnTitleSlide.Value);
+                }
+
+                return CreateFooterResult(headersFooters, footer, slideNumber, dateAndTime);
+            }
+            finally
+            {
+                if (dateAndTime != null) ComUtilities.Release(ref dateAndTime);
+                if (slideNumber != null) ComUtilities.Release(ref slideNumber);
+                if (footer != null) ComUtilities.Release(ref footer);
+                if (headersFooters != null) ComUtilities.Release(ref headersFooters);
+                if (master != null) ComUtilities.Release(ref master);
+            }
+        });
+    }
+
+    private static PageSetupOperationResult ReadSettings(PowerPoint.Presentation presentation)
+    {
+        PowerPoint.PageSetup? pageSetup = null;
+        try
+        {
+            pageSetup = presentation.PageSetup;
+            return CreateSettingsResult(pageSetup);
+        }
+        finally
+        {
+            if (pageSetup != null)
+            {
+                ComUtilities.Release(ref pageSetup);
+            }
+        }
+    }
+
+    private static PageSetupOperationResult CreateSettingsResult(PowerPoint.PageSetup pageSetup)
+    {
+        float width = pageSetup.SlideWidth;
+        float height = pageSetup.SlideHeight;
+
+        return new PageSetupOperationResult
+        {
+            Success = true,
+            Width = width,
+            Height = height,
+            Orientation = width > height ? "landscape" : width < height ? "portrait" : "square",
+            FirstSlideNumber = pageSetup.FirstSlideNumber
+        };
+    }
+
+    private static PageSetupOperationResult ReadFooter(PowerPoint.Presentation presentation)
+    {
+        PowerPoint.Master? master = null;
+        PowerPoint.HeadersFooters? headersFooters = null;
+        PowerPoint.HeaderFooter? footer = null;
+        PowerPoint.HeaderFooter? slideNumber = null;
+        PowerPoint.HeaderFooter? dateAndTime = null;
+        try
+        {
+            master = GetSlideMaster(presentation);
+            headersFooters = master.HeadersFooters;
+            footer = headersFooters.Footer;
+            slideNumber = headersFooters.SlideNumber;
+            dateAndTime = headersFooters.DateAndTime;
+
+            return CreateFooterResult(headersFooters, footer, slideNumber, dateAndTime);
+        }
+        finally
+        {
+            if (dateAndTime != null) ComUtilities.Release(ref dateAndTime);
+            if (slideNumber != null) ComUtilities.Release(ref slideNumber);
+            if (footer != null) ComUtilities.Release(ref footer);
+            if (headersFooters != null) ComUtilities.Release(ref headersFooters);
+            if (master != null) ComUtilities.Release(ref master);
+        }
+    }
+
+    private static PageSetupOperationResult CreateFooterResult(
+        PowerPoint.HeadersFooters headersFooters,
+        PowerPoint.HeaderFooter footer,
+        PowerPoint.HeaderFooter slideNumber,
+        PowerPoint.HeaderFooter dateAndTime)
+    {
+        bool useAutomaticDateTime = GetTriStateProperty(dateAndTime, "UseFormat");
+
+        return new PageSetupOperationResult
+        {
+            Success = true,
+            FooterText = footer.Text,
+            ShowFooter = GetTriStateProperty(footer, "Visible"),
+            ShowSlideNumber = GetTriStateProperty(slideNumber, "Visible"),
+            ShowDateTime = GetTriStateProperty(dateAndTime, "Visible"),
+            DateTimeMode = useAutomaticDateTime ? "automatic" : "fixed",
+            FixedDateTimeText = useAutomaticDateTime ? null : dateAndTime.Text,
+            ShowOnTitleSlide = GetTriStateProperty(headersFooters, "DisplayOnTitleSlide")
+        };
+    }
+
+    private static PowerPoint.Master GetSlideMaster(PowerPoint.Presentation presentation)
+    {
+        // The embedded NoPIA Presentation.SlideMaster getter hangs in live PowerPoint. Follow the
+        // established MasterCommands pattern and late-bind only this getter.
+        dynamic presentationDispatch = presentation;
+        return (PowerPoint.Master)presentationDispatch.SlideMaster;
+    }
+
+    private static bool GetTriStateProperty(object owner, string propertyName)
+    {
+        // These setters/getters are Office.MsoTriState-typed and office.dll is intentionally absent.
+        dynamic dispatch = owner;
+        return propertyName switch
+        {
+            "Visible" => (int)dispatch.Visible == MsoTrue,
+            "UseFormat" => (int)dispatch.UseFormat == MsoTrue,
+            "DisplayOnTitleSlide" => (int)dispatch.DisplayOnTitleSlide == MsoTrue,
+            _ => throw new ArgumentOutOfRangeException(nameof(propertyName))
+        };
+    }
+
+    private static void SetTriStateProperty(object owner, string propertyName, bool value)
+    {
+        // These setters are Office.MsoTriState-typed and office.dll is intentionally absent.
+        dynamic dispatch = owner;
+        int triState = value ? MsoTrue : MsoFalse;
+        switch (propertyName)
+        {
+            case "Visible":
+                dispatch.Visible = triState;
+                break;
+            case "UseFormat":
+                dispatch.UseFormat = triState;
+                break;
+            case "DisplayOnTitleSlide":
+                dispatch.DisplayOnTitleSlide = triState;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(propertyName));
+        }
+    }
+}

--- a/src/PowerPointMcp.Core/PageSetup/PageSetupOperationResult.cs
+++ b/src/PowerPointMcp.Core/PageSetup/PageSetupOperationResult.cs
@@ -1,0 +1,44 @@
+namespace Sbroenne.PowerPointMcp.Core.PageSetup;
+
+/// <summary>Result of a presentation page-setup operation.</summary>
+public sealed class PageSetupOperationResult
+{
+    /// <summary>Whether the operation succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Error message when <see cref="Success"/> is false.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Slide width in points.</summary>
+    public float? Width { get; init; }
+
+    /// <summary>Slide height in points.</summary>
+    public float? Height { get; init; }
+
+    /// <summary>Derived orientation: <c>landscape</c>, <c>portrait</c>, or <c>square</c>.</summary>
+    public string? Orientation { get; init; }
+
+    /// <summary>The number displayed on the first slide.</summary>
+    public int? FirstSlideNumber { get; init; }
+
+    /// <summary>Footer text.</summary>
+    public string? FooterText { get; init; }
+
+    /// <summary>Whether the footer is visible.</summary>
+    public bool? ShowFooter { get; init; }
+
+    /// <summary>Whether slide numbers are visible.</summary>
+    public bool? ShowSlideNumber { get; init; }
+
+    /// <summary>Whether date/time is visible.</summary>
+    public bool? ShowDateTime { get; init; }
+
+    /// <summary>Date/time mode: <c>automatic</c> or <c>fixed</c>.</summary>
+    public string? DateTimeMode { get; init; }
+
+    /// <summary>Fixed date/time text when fixed mode is selected.</summary>
+    public string? FixedDateTimeText { get; init; }
+
+    /// <summary>Whether footer elements are shown on title slides.</summary>
+    public bool? ShowOnTitleSlide { get; init; }
+}

--- a/src/PowerPointMcp.Core/Shape/IShapeCommands.cs
+++ b/src/PowerPointMcp.Core/Shape/IShapeCommands.cs
@@ -3,13 +3,13 @@ using Sbroenne.PowerPointMcp.Core.Attributes;
 namespace Sbroenne.PowerPointMcp.Core.Shape;
 
 /// <summary>
-/// Shape commands: add rectangles/text boxes, count, delete, reposition/resize.
+/// Shape commands: create, inspect, format, group, link, and edit native placeholders.
 /// Operates within an already-open IPresentationBatch, targeting a specific slide by
 /// its 1-based index.
 /// </summary>
 [ServiceCategory("shape", "Shape")]
 [McpTool("shape", Title = "Shape Operations", Destructive = true, Category = "content",
-    Description = "Add, count, delete, reposition, and resize shapes on a slide in an open presentation session.")]
+    Description = "Create, inspect, format, group, link, and edit native placeholders on a slide.")]
 public interface IShapeCommands
 {
     /// <summary>Adds a rectangle shape to the given slide.</summary>
@@ -176,4 +176,21 @@ public interface IShapeCommands
 
     /// <summary>Removes a shape's mouse-click hyperlink, if any (idempotent — no-op if none is set).</summary>
     ShapeOperationResult RemoveHyperlink(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex);
+
+    /// <summary>Lists native placeholders on a slide with their 1-based shape indexes and state.</summary>
+    ShapeOperationResult ListPlaceholders(ComInterop.Session.IPresentationBatch batch, int slideIndex);
+
+    /// <summary>Replaces the text in a native text placeholder.</summary>
+    ShapeOperationResult SetPlaceholderText(
+        ComInterop.Session.IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex,
+        string text);
+
+    /// <summary>Places an image into a compatible native picture or content placeholder.</summary>
+    ShapeOperationResult SetPlaceholderImage(
+        ComInterop.Session.IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex,
+        string imagePath);
 }

--- a/src/PowerPointMcp.Core/Shape/PlaceholderInfo.cs
+++ b/src/PowerPointMcp.Core/Shape/PlaceholderInfo.cs
@@ -1,0 +1,41 @@
+namespace Sbroenne.PowerPointMcp.Core.Shape;
+
+/// <summary>State and geometry of one native PowerPoint placeholder.</summary>
+public sealed class PlaceholderInfo
+{
+    /// <summary>1-based index in the slide's Shapes collection.</summary>
+    public required int ShapeIndex { get; init; }
+
+    /// <summary>Native PpPlaceholderType member name.</summary>
+    public required string PlaceholderType { get; init; }
+
+    /// <summary>Shape name shown in PowerPoint's Selection Pane.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Alternative text assigned to the placeholder.</summary>
+    public required string AltText { get; init; }
+
+    /// <summary>Horizontal position in points.</summary>
+    public required float Left { get; init; }
+
+    /// <summary>Vertical position in points.</summary>
+    public required float Top { get; init; }
+
+    /// <summary>Width in points.</summary>
+    public required float Width { get; init; }
+
+    /// <summary>Height in points.</summary>
+    public required float Height { get; init; }
+
+    /// <summary>Whether the placeholder currently contains non-empty text.</summary>
+    public required bool HasText { get; init; }
+
+    /// <summary>Current text when the placeholder contains text.</summary>
+    public string? Text { get; init; }
+
+    /// <summary>Whether the placeholder currently contains an image fill.</summary>
+    public required bool HasImage { get; init; }
+
+    /// <summary>Stable content state: empty, text, or image.</summary>
+    public required string ContentState { get; init; }
+}

--- a/src/PowerPointMcp.Core/Shape/ShapeCommands.Placeholders.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeCommands.Placeholders.cs
@@ -1,0 +1,281 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Shape;
+
+public sealed partial class ShapeCommands
+{
+    // Shape.Type and Fill.Type are Office enums unavailable without office.dll.
+    private const int MsoShapePlaceholder = 14;
+    private const int MsoFillPicture = 6;
+
+    /// <inheritdoc/>
+    public ShapeOperationResult ListPlaceholders(IPresentationBatch batch, int slideIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var validation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (validation is not null) return validation;
+
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var placeholders = new List<PlaceholderInfo>();
+            for (int shapeIndex = 1; shapeIndex <= slide.Shapes.Count; shapeIndex++)
+            {
+                PowerPoint.Shape? shape = null;
+                try
+                {
+                    shape = slide.Shapes[shapeIndex];
+                    // PIA gap: Shape.Type is Office.MsoShapeType, unavailable without office.dll.
+                    if ((int)((dynamic)shape).Type != MsoShapePlaceholder)
+                    {
+                        continue;
+                    }
+
+                    placeholders.Add(ReadPlaceholder(shape, shapeIndex));
+                }
+                finally
+                {
+                    if (shape is not null)
+                    {
+                        ComUtilities.Release(ref shape);
+                    }
+                }
+            }
+
+            return new ShapeOperationResult
+            {
+                Success = true,
+                ShapeCount = slide.Shapes.Count,
+                Placeholders = placeholders
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public ShapeOperationResult SetPlaceholderText(
+        IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex,
+        string text)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(text);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            PowerPoint.Shape? shape = null;
+            PowerPoint.TextFrame? textFrame = null;
+            PowerPoint.TextRange? textRange = null;
+            try
+            {
+                shape = slide.Shapes[shapeIndex];
+                // PIA gap: Shape.Type is Office.MsoShapeType, unavailable without office.dll.
+                if ((int)((dynamic)shape).Type != MsoShapePlaceholder)
+                {
+                    return new ShapeOperationResult
+                    {
+                        ErrorMessage = $"Shape {shapeIndex} on slide {slideIndex} is not a native placeholder.",
+                        ShapeIndex = shapeIndex
+                    };
+                }
+
+                // PIA gap: Shape.HasTextFrame returns Office.MsoTriState, unavailable without office.dll.
+                if ((int)((dynamic)shape).HasTextFrame != MsoTrue)
+                {
+                    return new ShapeOperationResult
+                    {
+                        ErrorMessage = $"Placeholder shape {shapeIndex} does not support text.",
+                        ShapeIndex = shapeIndex,
+                        PlaceholderType = shape.PlaceholderFormat.Type.ToString()
+                    };
+                }
+
+                textFrame = shape.TextFrame;
+                textRange = textFrame.TextRange;
+                textRange.Text = text;
+                return new ShapeOperationResult
+                {
+                    Success = true,
+                    ShapeIndex = shapeIndex,
+                    PlaceholderType = shape.PlaceholderFormat.Type.ToString(),
+                    PlaceholderText = text
+                };
+            }
+            finally
+            {
+                if (textRange is not null)
+                {
+                    ComUtilities.Release(ref textRange);
+                }
+                if (textFrame is not null)
+                {
+                    ComUtilities.Release(ref textFrame);
+                }
+                if (shape is not null)
+                {
+                    ComUtilities.Release(ref shape);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public ShapeOperationResult SetPlaceholderImage(
+        IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex,
+        string imagePath)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(imagePath);
+
+        string fullImagePath;
+        try
+        {
+            fullImagePath = Path.GetFullPath(imagePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new ShapeOperationResult { ErrorMessage = $"Invalid image path: {ex.Message}" };
+        }
+
+        if (!File.Exists(fullImagePath))
+        {
+            return new ShapeOperationResult { ErrorMessage = $"Image file not found: {fullImagePath}." };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null) return slideValidation;
+
+            PowerPoint.Slide slide = ctx.Presentation.Slides[slideIndex];
+            var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+            if (shapeValidation is not null) return shapeValidation;
+
+            PowerPoint.Shape? shape = null;
+            dynamic? fill = null;
+            try
+            {
+                shape = slide.Shapes[shapeIndex];
+                // PIA gap: Shape.Type is Office.MsoShapeType, unavailable without office.dll.
+                if ((int)((dynamic)shape).Type != MsoShapePlaceholder)
+                {
+                    return new ShapeOperationResult
+                    {
+                        ErrorMessage = $"Shape {shapeIndex} on slide {slideIndex} is not a native placeholder.",
+                        ShapeIndex = shapeIndex
+                    };
+                }
+
+                PowerPoint.PpPlaceholderType placeholderType = shape.PlaceholderFormat.Type;
+                if (!SupportsImage(placeholderType))
+                {
+                    return new ShapeOperationResult
+                    {
+                        ErrorMessage = $"Placeholder type {placeholderType} does not support image content.",
+                        ShapeIndex = shapeIndex,
+                        PlaceholderType = placeholderType.ToString()
+                    };
+                }
+
+                // PIA gap: FillFormat is an Office type unavailable without office.dll.
+                fill = ((dynamic)shape).Fill;
+                fill.UserPicture(fullImagePath);
+                return new ShapeOperationResult
+                {
+                    Success = true,
+                    ShapeIndex = shapeIndex,
+                    PlaceholderType = placeholderType.ToString(),
+                    HasImage = true
+                };
+            }
+            finally
+            {
+                if (fill is not null)
+                {
+                    ComUtilities.Release(ref fill);
+                }
+                if (shape is not null)
+                {
+                    ComUtilities.Release(ref shape);
+                }
+            }
+        });
+    }
+
+    private static PlaceholderInfo ReadPlaceholder(PowerPoint.Shape shape, int shapeIndex)
+    {
+        PowerPoint.TextFrame? textFrame = null;
+        PowerPoint.TextRange? textRange = null;
+        dynamic? fill = null;
+        try
+        {
+            bool hasText = false;
+            string? text = null;
+            // PIA gap: Shape.HasTextFrame returns Office.MsoTriState, unavailable without office.dll.
+            if ((int)((dynamic)shape).HasTextFrame == MsoTrue)
+            {
+                textFrame = shape.TextFrame;
+                // PIA gap: TextFrame.HasText returns Office.MsoTriState, unavailable without office.dll.
+                if ((int)((dynamic)textFrame).HasText == MsoTrue)
+                {
+                    textRange = textFrame.TextRange;
+                    text = textRange.Text;
+                    hasText = !string.IsNullOrWhiteSpace(text);
+                }
+            }
+
+            // PIA gap: FillFormat is an Office type unavailable without office.dll.
+            fill = ((dynamic)shape).Fill;
+            bool hasImage = (int)fill.Type == MsoFillPicture;
+            return new PlaceholderInfo
+            {
+                ShapeIndex = shapeIndex,
+                PlaceholderType = shape.PlaceholderFormat.Type.ToString(),
+                Name = shape.Name,
+                AltText = shape.AlternativeText,
+                Left = shape.Left,
+                Top = shape.Top,
+                Width = shape.Width,
+                Height = shape.Height,
+                HasText = hasText,
+                Text = text,
+                HasImage = hasImage,
+                ContentState = hasImage ? "image" : hasText ? "text" : "empty"
+            };
+        }
+        finally
+        {
+            if (fill is not null)
+            {
+                ComUtilities.Release(ref fill);
+            }
+            if (textRange is not null)
+            {
+                ComUtilities.Release(ref textRange);
+            }
+            if (textFrame is not null)
+            {
+                ComUtilities.Release(ref textFrame);
+            }
+        }
+    }
+
+    private static bool SupportsImage(PowerPoint.PpPlaceholderType placeholderType)
+        => placeholderType is
+            PowerPoint.PpPlaceholderType.ppPlaceholderPicture or
+            PowerPoint.PpPlaceholderType.ppPlaceholderBitmap or
+            PowerPoint.PpPlaceholderType.ppPlaceholderObject or
+            PowerPoint.PpPlaceholderType.ppPlaceholderMediaClip;
+}

--- a/src/PowerPointMcp.Core/Shape/ShapeCommands.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeCommands.cs
@@ -5,7 +5,7 @@ using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 namespace Sbroenne.PowerPointMcp.Core.Shape;
 
 /// <inheritdoc cref="IShapeCommands"/>
-public sealed class ShapeCommands : IShapeCommands
+public sealed partial class ShapeCommands : IShapeCommands
 {
     // Shapes.AddShape's Type parameter and Shapes.AddTextbox's Orientation parameter are both
     // typed as Microsoft.Office.Core enums (MsoAutoShapeType / MsoTextOrientation) — i.e. office.dll

--- a/src/PowerPointMcp.Core/Shape/ShapeOperationResult.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeOperationResult.cs
@@ -119,4 +119,16 @@ public sealed class ShapeOperationResult
 
     /// <summary>Bevel inset in points, if applicable.</summary>
     public float? BevelInset { get; init; }
+
+    /// <summary>Native placeholders found on a slide.</summary>
+    public IReadOnlyList<PlaceholderInfo>? Placeholders { get; init; }
+
+    /// <summary>Native PowerPoint placeholder type name, if applicable.</summary>
+    public string? PlaceholderType { get; init; }
+
+    /// <summary>Text assigned to a placeholder, if applicable.</summary>
+    public string? PlaceholderText { get; init; }
+
+    /// <summary>Whether a placeholder contains an image fill.</summary>
+    public bool? HasImage { get; init; }
 }

--- a/src/PowerPointMcp.Core/Slide/ISlideCommands.cs
+++ b/src/PowerPointMcp.Core/Slide/ISlideCommands.cs
@@ -4,13 +4,11 @@ using Sbroenne.PowerPointMcp.Core.Attributes;
 namespace Sbroenne.PowerPointMcp.Core.Slide;
 
 /// <summary>
-/// Slide lifecycle commands: add, delete, count, duplicate, reorder, per-slide background color,
-/// and section management. First domain built on top of the presentation lifecycle commands,
-/// operating within an already-open IPresentationBatch.
+/// Slide lifecycle, background, section, legacy comment, and slide-import commands.
 /// </summary>
 [ServiceCategory("slide", "Slide")]
 [McpTool("slide", Title = "Slide Operations", Destructive = true, Category = "content",
-    Description = "Add, count, delete, duplicate, reorder, and set section/background on slides in an open presentation session.")]
+    Description = "Manage slides, backgrounds, sections, legacy comments, and slide import in an open presentation session.")]
 public interface ISlideCommands
 {
     /// <summary>
@@ -99,4 +97,40 @@ public interface ISlideCommands
 
     /// <summary>Gets the name of the section at the given 1-based <paramref name="sectionIndex"/>.</summary>
     SlideOperationResult GetSectionName(IPresentationBatch batch, int sectionIndex);
+
+    /// <summary>
+    /// Lists the legacy comments exposed by PowerPoint for a slide. Modern Microsoft 365 threaded
+    /// comments are not exposed by the PowerPoint COM API.
+    /// </summary>
+    SlideOperationResult ListComments(IPresentationBatch batch, int slideIndex);
+
+    /// <summary>
+    /// Adds a legacy comment to a slide. PowerPoint may replace the supplied author and initials
+    /// with the signed-in Office identity.
+    /// </summary>
+    SlideOperationResult AddComment(
+        IPresentationBatch batch,
+        int slideIndex,
+        string author,
+        string initials,
+        string text,
+        float left = 0f,
+        float top = 0f);
+
+    /// <summary>Deletes a legacy comment by its 1-based index on a slide.</summary>
+    SlideOperationResult DeleteComment(IPresentationBatch batch, int slideIndex, int commentIndex);
+
+    /// <summary>Deletes every legacy comment on a slide.</summary>
+    SlideOperationResult ClearComments(IPresentationBatch batch, int slideIndex);
+
+    /// <summary>
+    /// Imports an inclusive, 1-based range of slides from another presentation after the given
+    /// 1-based destination slide.
+    /// </summary>
+    SlideOperationResult ImportFromFile(
+        IPresentationBatch batch,
+        string sourceFilePath,
+        int destinationSlideIndex,
+        int sourceStartSlide = 1,
+        int? sourceEndSlide = null);
 }

--- a/src/PowerPointMcp.Core/Slide/SlideCommands.CommentsAndImport.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideCommands.CommentsAndImport.cs
@@ -1,0 +1,336 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Slide;
+
+public sealed partial class SlideCommands
+{
+    /// <inheritdoc/>
+    public SlideOperationResult ListComments(IPresentationBatch batch, int slideIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var validation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (validation is not null) return validation;
+
+            PowerPoint.Comments? comments = null;
+            try
+            {
+                comments = ctx.Presentation.Slides[slideIndex].Comments;
+                var items = new List<SlideCommentInfo>(comments.Count);
+                for (int index = 1; index <= comments.Count; index++)
+                {
+                    PowerPoint.Comment? comment = null;
+                    try
+                    {
+                        comment = comments[index];
+                        items.Add(new SlideCommentInfo
+                        {
+                            CommentIndex = index,
+                            Author = comment.Author,
+                            Initials = comment.AuthorInitials,
+                            Text = comment.Text,
+                            Left = comment.Left,
+                            Top = comment.Top
+                        });
+                    }
+                    finally
+                    {
+                        if (comment is not null)
+                        {
+                            ComUtilities.Release(ref comment);
+                        }
+                    }
+                }
+
+                return new SlideOperationResult
+                {
+                    Success = true,
+                    SlideIndex = slideIndex,
+                    Comments = items,
+                    CommentCount = items.Count
+                };
+            }
+            finally
+            {
+                if (comments is not null)
+                {
+                    ComUtilities.Release(ref comments);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public SlideOperationResult AddComment(
+        IPresentationBatch batch,
+        int slideIndex,
+        string author,
+        string initials,
+        string text,
+        float left = 0f,
+        float top = 0f)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(author);
+        ArgumentNullException.ThrowIfNull(initials);
+        ArgumentNullException.ThrowIfNull(text);
+
+        if (string.IsNullOrWhiteSpace(author) ||
+            string.IsNullOrWhiteSpace(initials) ||
+            string.IsNullOrWhiteSpace(text))
+        {
+            return new SlideOperationResult
+            {
+                ErrorMessage = "Comment author, initials, and text must not be empty."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var validation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (validation is not null) return validation;
+
+            PowerPoint.Comments? comments = null;
+            PowerPoint.Comment? comment = null;
+            try
+            {
+                comments = ctx.Presentation.Slides[slideIndex].Comments;
+                comment = comments.Add(left, top, author, initials, text);
+                return new SlideOperationResult
+                {
+                    Success = true,
+                    SlideIndex = slideIndex,
+                    CommentCount = comments.Count
+                };
+            }
+            finally
+            {
+                if (comment is not null)
+                {
+                    ComUtilities.Release(ref comment);
+                }
+                if (comments is not null)
+                {
+                    ComUtilities.Release(ref comments);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public SlideOperationResult DeleteComment(
+        IPresentationBatch batch,
+        int slideIndex,
+        int commentIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var validation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (validation is not null) return validation;
+
+            PowerPoint.Comments? comments = null;
+            PowerPoint.Comment? comment = null;
+            try
+            {
+                comments = ctx.Presentation.Slides[slideIndex].Comments;
+                if (commentIndex < 1 || commentIndex > comments.Count)
+                {
+                    return new SlideOperationResult
+                    {
+                        ErrorMessage = $"Comment index {commentIndex} is out of range. The slide has {comments.Count} comment(s).",
+                        SlideIndex = slideIndex,
+                        CommentCount = comments.Count
+                    };
+                }
+
+                comment = comments[commentIndex];
+                comment.Delete();
+                return new SlideOperationResult
+                {
+                    Success = true,
+                    SlideIndex = slideIndex,
+                    CommentCount = comments.Count
+                };
+            }
+            finally
+            {
+                if (comment is not null)
+                {
+                    ComUtilities.Release(ref comment);
+                }
+                if (comments is not null)
+                {
+                    ComUtilities.Release(ref comments);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public SlideOperationResult ClearComments(IPresentationBatch batch, int slideIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var validation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (validation is not null) return validation;
+
+            PowerPoint.Comments? comments = null;
+            try
+            {
+                comments = ctx.Presentation.Slides[slideIndex].Comments;
+                for (int index = comments.Count; index >= 1; index--)
+                {
+                    PowerPoint.Comment? comment = null;
+                    try
+                    {
+                        comment = comments[index];
+                        comment.Delete();
+                    }
+                    finally
+                    {
+                        if (comment is not null)
+                        {
+                            ComUtilities.Release(ref comment);
+                        }
+                    }
+                }
+
+                return new SlideOperationResult
+                {
+                    Success = true,
+                    SlideIndex = slideIndex,
+                    CommentCount = 0
+                };
+            }
+            finally
+            {
+                if (comments is not null)
+                {
+                    ComUtilities.Release(ref comments);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public SlideOperationResult ImportFromFile(
+        IPresentationBatch batch,
+        string sourceFilePath,
+        int destinationSlideIndex,
+        int sourceStartSlide = 1,
+        int? sourceEndSlide = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(sourceFilePath);
+
+        if (string.IsNullOrWhiteSpace(sourceFilePath))
+        {
+            return new SlideOperationResult { ErrorMessage = "Source file path must not be empty." };
+        }
+
+        string fullSourcePath;
+        try
+        {
+            fullSourcePath = Path.GetFullPath(sourceFilePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new SlideOperationResult { ErrorMessage = $"Invalid source file path: {ex.Message}" };
+        }
+
+        if (!File.Exists(fullSourcePath))
+        {
+            return new SlideOperationResult { ErrorMessage = $"Source presentation not found: {fullSourcePath}." };
+        }
+
+        if (sourceStartSlide < 1 ||
+            (sourceEndSlide.HasValue && sourceEndSlide.Value < sourceStartSlide))
+        {
+            return new SlideOperationResult
+            {
+                ErrorMessage = "Source slide range must be 1-based and end at or after its start."
+            };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            int destinationCount = ctx.Presentation.Slides.Count;
+            var validation = ValidateSlideIndex(destinationCount, destinationSlideIndex);
+            if (validation is not null) return validation;
+
+            int sourceSlideCount;
+            PowerPoint.Presentations? presentations = null;
+            PowerPoint.Presentation? sourcePresentation = null;
+            try
+            {
+                presentations = ctx.Presentation.Application.Presentations;
+                // PIA gap: Presentations.Open uses Office.MsoTriState, unavailable without office.dll.
+                sourcePresentation = ((dynamic)presentations).Open(
+                    fullSourcePath,
+                    MsoTrue,
+                    MsoFalse,
+                    MsoFalse);
+                sourceSlideCount = sourcePresentation.Slides.Count;
+            }
+            finally
+            {
+                if (sourcePresentation is not null)
+                {
+                    sourcePresentation.Close();
+                    ComUtilities.Release(ref sourcePresentation);
+                }
+                if (presentations is not null)
+                {
+                    ComUtilities.Release(ref presentations);
+                }
+            }
+
+            int sourceEnd = sourceEndSlide ?? sourceSlideCount;
+            if (sourceStartSlide > sourceSlideCount || sourceEnd > sourceSlideCount)
+            {
+                return new SlideOperationResult
+                {
+                    ErrorMessage = $"Source slide range {sourceStartSlide}-{sourceEnd} is out of range. The source presentation has {sourceSlideCount} slide(s).",
+                    SlideCount = destinationCount
+                };
+            }
+
+            int importedCount = ctx.Presentation.Slides.InsertFromFile(
+                fullSourcePath,
+                destinationSlideIndex,
+                sourceStartSlide,
+                sourceEnd);
+            int[] importedIndexes = Enumerable.Range(destinationSlideIndex + 1, importedCount).ToArray();
+
+            return new SlideOperationResult
+            {
+                Success = true,
+                SlideCount = ctx.Presentation.Slides.Count,
+                ImportedSlideCount = importedCount,
+                ImportedSlideIndexes = importedIndexes
+            };
+        });
+    }
+
+    private static SlideOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)
+    {
+        if (slideIndex < 1 || slideIndex > slideCount)
+        {
+            return new SlideOperationResult
+            {
+                ErrorMessage = $"Slide index {slideIndex} is out of range. The presentation has {slideCount} slide(s) (valid range: 1-{slideCount}).",
+                SlideCount = slideCount
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/PowerPointMcp.Core/Slide/SlideCommands.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideCommands.cs
@@ -5,7 +5,7 @@ using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 namespace Sbroenne.PowerPointMcp.Core.Slide;
 
 /// <inheritdoc cref="ISlideCommands"/>
-public sealed class SlideCommands : ISlideCommands
+public sealed partial class SlideCommands : ISlideCommands
 {
     private const int MsoTrue = -1;
     private const int MsoFalse = 0;

--- a/src/PowerPointMcp.Core/Slide/SlideCommentInfo.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideCommentInfo.cs
@@ -1,0 +1,23 @@
+namespace Sbroenne.PowerPointMcp.Core.Slide;
+
+/// <summary>One legacy PowerPoint slide comment.</summary>
+public sealed class SlideCommentInfo
+{
+    /// <summary>1-based index within the slide's legacy comment collection.</summary>
+    public required int CommentIndex { get; init; }
+
+    /// <summary>Comment author.</summary>
+    public required string Author { get; init; }
+
+    /// <summary>Comment author initials.</summary>
+    public required string Initials { get; init; }
+
+    /// <summary>Comment text.</summary>
+    public required string Text { get; init; }
+
+    /// <summary>Horizontal comment marker position in points.</summary>
+    public required float Left { get; init; }
+
+    /// <summary>Vertical comment marker position in points.</summary>
+    public required float Top { get; init; }
+}

--- a/src/PowerPointMcp.Core/Slide/SlideOperationResult.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideOperationResult.cs
@@ -44,4 +44,16 @@ public sealed class SlideOperationResult
 
     /// <summary>Name of the section, if applicable.</summary>
     public string? SectionName { get; init; }
+
+    /// <summary>Legacy comments on a slide, in 1-based comment order.</summary>
+    public IReadOnlyList<SlideCommentInfo>? Comments { get; init; }
+
+    /// <summary>Number of legacy comments on the slide.</summary>
+    public int? CommentCount { get; init; }
+
+    /// <summary>Number of slides imported by an import operation.</summary>
+    public int? ImportedSlideCount { get; init; }
+
+    /// <summary>New 1-based indexes assigned to imported slides.</summary>
+    public IReadOnlyList<int>? ImportedSlideIndexes { get; init; }
 }

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,23 +32,25 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**13 tools with 141 operations across 13 domains:**
+**15 tools with 158 operations across 15 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
 | `presentation` | 12 | create, open, save, close, list, apply-template, get-theme-name, built-in/custom document properties |
-| `slide` | 14 | slide lifecycle, solid + gradient backgrounds, sections |
-| `shape` | 36 | shape creation, geometry, styling, effects, grouping, naming, hyperlinks |
+| `slide` | 19 | slide lifecycle, backgrounds, sections, comments, slide import |
+| `shape` | 39 | shape creation, styling, grouping, hyperlinks, placeholders |
 | `textframe` | 20 | text content, font formatting, alignment, bullets, auto-size |
 | `table` | 12 | tables, cell text, row/column edits, cell fill/border, merge |
 | `notes` | 2 | set/get speaker notes |
 | `layout` | 4 | set/get slide layout |
+| `pagesetup` | 5 | slide size, numbering, footer, date/time |
+| `accessibility` | 3 | deterministic audit and reading order |
 | `master` | 10 | title/body placeholder fonts, solid + gradient master backgrounds |
 | `animation` | 5 | shape effects, transition read/write |
 | `image` | 7 | add picture, brightness/contrast, recolor, crop |
 | `chart` | 10 | charts, series, chart/axis titles, legend visibility, data replacement |
 | `smartart` | 7 | SmartArt insertion and node editing |
-| `export` | 2 | export a slide or every slide to images |
+| `export` | 3 | export to PDF or images |
 
 Every domain is exposed as a single **action-dispatch tool** taking an `action`
 parameter — including `presentation`. Example MCP calls:

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -3,6 +3,7 @@ using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Accessibility;
 using Sbroenne.PowerPointMcp.Core.Animation;
 using Sbroenne.PowerPointMcp.Core.Chart;
 using Sbroenne.PowerPointMcp.Core.Export;
@@ -10,6 +11,7 @@ using Sbroenne.PowerPointMcp.Core.Image;
 using Sbroenne.PowerPointMcp.Core.Layout;
 using Sbroenne.PowerPointMcp.Core.Master;
 using Sbroenne.PowerPointMcp.Core.Notes;
+using Sbroenne.PowerPointMcp.Core.PageSetup;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Core.Shape;
 using Sbroenne.PowerPointMcp.Core.Slide;
@@ -60,6 +62,8 @@ public sealed class PowerPointMcpService : IDisposable
     private readonly MasterCommands _masterCommands = new();
     private readonly AnimationCommands _animationCommands = new();
     private readonly SmartArtCommands _smartArtCommands = new();
+    private readonly PageSetupCommands _pageSetupCommands = new();
+    private readonly AccessibilityCommands _accessibilityCommands = new();
 
     /// <summary>Gets the UTC time this daemon instance started.</summary>
     public DateTime StartTime => _startTime;
@@ -74,9 +78,10 @@ public sealed class PowerPointMcpService : IDisposable
     /// mirroring mcp-server-excel's architecture, where one shared Service class is consumed two
     /// ways: in-process (direct calls, no pipe) by the MCP server, and via
     /// named-pipe/StreamJsonRpc by the separate CLI daemon process. The generated domain MCP
-    /// tools (Slide, Shape, TextFrame, Table, Chart, Image, Notes, Layout, Master, Export) DO call
-    /// <see cref="ProcessAsync"/> in-process via <c>ServiceBridge.ForwardToService</c> — only the
-    /// hand-written <c>PresentationTools</c> bypass it and use <see cref="Sessions"/> directly.
+    /// tools (Slide, Shape, TextFrame, Table, Chart, Image, Notes, Layout, Master, Animation,
+    /// SmartArt, Export, PageSetup, Accessibility) DO call <see cref="ProcessAsync"/> in-process
+    /// via <c>ServiceBridge.ForwardToService</c> — only the hand-written
+    /// <c>PresentationTools</c> bypass it and use <see cref="Sessions"/> directly.
     /// </summary>
     public PresentationSessionRegistry Sessions => _sessions;
 
@@ -266,6 +271,12 @@ public sealed class PowerPointMcpService : IDisposable
                 "smartart" => DispatchSimple<SmartArtAction>(action, request,
                     ServiceRegistry.SmartArt.TryParseAction,
                     (a, batch) => ServiceRegistry.SmartArt.DispatchToCore(_smartArtCommands, a, batch, request.Args)),
+                "pagesetup" => DispatchSimple<PageSetupAction>(action, request,
+                    ServiceRegistry.PageSetup.TryParseAction,
+                    (a, batch) => ServiceRegistry.PageSetup.DispatchToCore(_pageSetupCommands, a, batch, request.Args)),
+                "accessibility" => DispatchSimple<AccessibilityAction>(action, request,
+                    ServiceRegistry.Accessibility.TryParseAction,
+                    (a, batch) => ServiceRegistry.Accessibility.DispatchToCore(_accessibilityCommands, a, batch, request.Args)),
                 _ => new ServiceResponse { Success = false, ErrorMessage = $"Unknown command category: {category}" }
             };
 

--- a/tests/PowerPointMcp.Core.Tests/AccessibilityCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/AccessibilityCommandsTests.cs
@@ -1,0 +1,95 @@
+using Sbroenne.PowerPointMcp.Core.Accessibility;
+using Sbroenne.PowerPointMcp.Core.Image;
+using Sbroenne.PowerPointMcp.Core.Presentation;
+using Sbroenne.PowerPointMcp.Core.Shape;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>Real PowerPoint integration tests for deterministic accessibility operations.</summary>
+[Trait("Category", "Integration")]
+[Trait("Feature", "Accessibility")]
+public sealed class AccessibilityCommandsTests : IClassFixture<SharedPresentationFixture>
+{
+    private readonly SharedPresentationFixture _fixture;
+    private readonly AccessibilityCommands _commands = new();
+    private readonly ImageCommands _imageCommands = new();
+    private readonly PresentationCommands _presentationCommands = new();
+    private readonly ShapeCommands _shapeCommands = new();
+
+    public AccessibilityCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Audit_FindsPictureWithoutAlternativeText()
+    {
+        _fixture.CreateFreshPresentation();
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            _imageCommands.AddPicture(_fixture.Batch, 1, imagePath, 10f, 10f, 100f, 100f);
+
+            var result = _commands.Audit(_fixture.Batch);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var issue = Assert.Single(result.Issues!, i => i.Code == "missing-alt-text");
+            Assert.Equal(1, issue.SlideIndex);
+            Assert.Equal(1, issue.ShapeIndex);
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
+    }
+
+    [Fact]
+    public void Audit_CleanBlankPresentation_ReturnsNoIssues()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var result = _commands.Audit(_fixture.Batch);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Null(result.ErrorMessage);
+        Assert.NotNull(result.Issues);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void SetReadingOrder_ThenGetReadingOrder_RoundTripsPermutation()
+    {
+        _fixture.CreateFreshPresentation();
+        _shapeCommands.AddTextBox(_fixture.Batch, 1, 10f, 10f, 100f, 30f, "First");
+        _shapeCommands.AddTextBox(_fixture.Batch, 1, 10f, 50f, 100f, 30f, "Second");
+        _shapeCommands.AddTextBox(_fixture.Batch, 1, 10f, 90f, 100f, 30f, "Third");
+
+        var setResult = _commands.SetReadingOrder(_fixture.Batch, 1, [3, 1, 2]);
+
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        Assert.Null(setResult.ErrorMessage);
+        Assert.Equal([3, 1, 2], setResult.ReadingOrder);
+
+        var saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        var getResult = _commands.GetReadingOrder(_fixture.Batch, 1);
+        Assert.True(getResult.Success, getResult.ErrorMessage);
+        Assert.Equal([3, 1, 2], getResult.ReadingOrder);
+    }
+
+    [Fact]
+    public void SetReadingOrder_WithDuplicateAndMissingShapeIndex_ReturnsFailure()
+    {
+        _fixture.CreateFreshPresentation();
+        _shapeCommands.AddTextBox(_fixture.Batch, 1, 10f, 10f, 100f, 30f, "First");
+        _shapeCommands.AddTextBox(_fixture.Batch, 1, 10f, 50f, 100f, 30f, "Second");
+        _shapeCommands.AddTextBox(_fixture.Batch, 1, 10f, 90f, 100f, 30f, "Third");
+
+        var result = _commands.SetReadingOrder(_fixture.Batch, 1, [1, 1, 3]);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/ExportCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ExportCommandsTests.cs
@@ -25,6 +25,129 @@ public class ExportCommandsTests : IClassFixture<SharedPresentationFixture>
     }
 
     [Fact]
+    public void ExportToPdf_ExportsPresentation_FileExistsAndNonEmpty()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+        string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-pdf-{Guid.NewGuid():N}");
+        string outputFile = Path.Combine(outputDir, "presentation.pdf");
+        try
+        {
+            var result = _commands.ExportToPdf(batch, outputFile);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Null(result.ErrorMessage);
+            Assert.Equal(outputFile, result.ExportedFilePath, StringComparer.OrdinalIgnoreCase);
+            Assert.True(File.Exists(outputFile), "Exported PDF must exist on disk.");
+            Assert.True(new FileInfo(outputFile).Length > 0, "Exported PDF must be non-empty.");
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+                Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExportToPdf_PreservesOpenPresentationFullName()
+    {
+        string presentationPath = _fixture.CreateFreshPresentation("pptmcp-export-pdf-fullname");
+        var batch = _fixture.Batch;
+        string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-pdf-fullname-{Guid.NewGuid():N}");
+        string outputFile = Path.Combine(outputDir, "presentation.pdf");
+        try
+        {
+            string fullNameBeforeExport = batch.Execute((ctx, ct) => ctx.Presentation.FullName);
+
+            var result = _commands.ExportToPdf(batch, outputFile);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            string fullNameAfterExport = batch.Execute((ctx, ct) => ctx.Presentation.FullName);
+            Assert.Equal(presentationPath, fullNameBeforeExport, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(fullNameBeforeExport, fullNameAfterExport, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEqual(outputFile, fullNameAfterExport, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+                Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExportToPdf_WhenFileExists_RefusesOverwriteByDefault()
+    {
+        _fixture.CreateFreshPresentation();
+        string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-pdf-existing-{Guid.NewGuid():N}");
+        string outputFile = Path.Combine(outputDir, "presentation.pdf");
+        byte[] sentinel = "existing-content"u8.ToArray();
+        try
+        {
+            Directory.CreateDirectory(outputDir);
+            File.WriteAllBytes(outputFile, sentinel);
+
+            var result = _commands.ExportToPdf(_fixture.Batch, outputFile);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
+            Assert.Equal(sentinel, File.ReadAllBytes(outputFile));
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+                Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExportToPdf_WhenOverwriteIsExplicit_ReplacesExistingFile()
+    {
+        _fixture.CreateFreshPresentation();
+        string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-pdf-overwrite-{Guid.NewGuid():N}");
+        string outputFile = Path.Combine(outputDir, "presentation.pdf");
+        byte[] sentinel = "existing-content"u8.ToArray();
+        try
+        {
+            Directory.CreateDirectory(outputDir);
+            File.WriteAllBytes(outputFile, sentinel);
+
+            var result = _commands.ExportToPdf(_fixture.Batch, outputFile, overwrite: true);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Null(result.ErrorMessage);
+            Assert.Equal(outputFile, result.ExportedFilePath, StringComparer.OrdinalIgnoreCase);
+            Assert.True(new FileInfo(outputFile).Length > sentinel.Length);
+            Assert.False(sentinel.SequenceEqual(File.ReadAllBytes(outputFile)));
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+                Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExportToPdf_WithNonPdfExtension_ReturnsFailureWithoutCreatingFile()
+    {
+        _fixture.CreateFreshPresentation();
+        string outputDir = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests", $"export-pdf-extension-{Guid.NewGuid():N}");
+        string outputFile = Path.Combine(outputDir, "presentation.pptx");
+        try
+        {
+            var result = _commands.ExportToPdf(_fixture.Batch, outputFile);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
+            Assert.False(File.Exists(outputFile));
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+                Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ExportSlideToImage_ExportsSingleSlide_FileExistsAndNonEmpty()
     {
         _fixture.CreateFreshPresentation();

--- a/tests/PowerPointMcp.Core.Tests/PageSetupCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PageSetupCommandsTests.cs
@@ -1,0 +1,93 @@
+using Sbroenne.PowerPointMcp.Core.PageSetup;
+using Sbroenne.PowerPointMcp.Core.Presentation;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>Real PowerPoint integration tests for presentation page setup.</summary>
+[Trait("Category", "Integration")]
+[Trait("Feature", "PageSetup")]
+public sealed class PageSetupCommandsTests : IClassFixture<SharedPresentationFixture>
+{
+    private readonly SharedPresentationFixture _fixture;
+    private readonly PageSetupCommands _commands = new();
+    private readonly PresentationCommands _presentationCommands = new();
+
+    public PageSetupCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void GetSettings_ReturnsSlideDimensionsAndFirstSlideNumber()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var result = _commands.GetSettings(_fixture.Batch);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(result.Width > 0);
+        Assert.True(result.Height > 0);
+        Assert.NotNull(result.Orientation);
+        Assert.NotNull(result.FirstSlideNumber);
+    }
+
+    [Fact]
+    public void SetSizeAndFirstSlideNumber_RoundTripThroughNativePageSetup()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var sizeResult = _commands.SetSize(_fixture.Batch, width: 720f, height: 405f);
+        Assert.True(sizeResult.Success, sizeResult.ErrorMessage);
+        Assert.Null(sizeResult.ErrorMessage);
+
+        var numberResult = _commands.SetFirstSlideNumber(_fixture.Batch, firstSlideNumber: 7);
+        Assert.True(numberResult.Success, numberResult.ErrorMessage);
+        Assert.Null(numberResult.ErrorMessage);
+
+        var saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        var settings = _commands.GetSettings(_fixture.Batch);
+
+        Assert.True(settings.Success, settings.ErrorMessage);
+        Assert.InRange(settings.Width!.Value, 719.9f, 720.1f);
+        Assert.InRange(settings.Height!.Value, 404.9f, 405.1f);
+        Assert.Equal("landscape", settings.Orientation);
+        Assert.Equal(7, settings.FirstSlideNumber);
+    }
+
+    [Fact]
+    public void SetFooter_RoundTripsNativeHeaderFooterSettings()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var setResult = _commands.SetFooter(
+            _fixture.Batch,
+            footerText: "Release footer",
+            showFooter: true,
+            showSlideNumber: true,
+            showDateTime: true,
+            dateTimeMode: "fixed",
+            fixedDateTimeText: "2026-08-25",
+            showOnTitleSlide: false);
+
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        Assert.Null(setResult.ErrorMessage);
+
+        var saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        var footer = _commands.GetFooter(_fixture.Batch);
+
+        Assert.True(footer.Success, footer.ErrorMessage);
+        Assert.Equal("Release footer", footer.FooterText);
+        Assert.True(footer.ShowFooter);
+        Assert.True(footer.ShowSlideNumber);
+        Assert.True(footer.ShowDateTime);
+        Assert.Equal("fixed", footer.DateTimeMode);
+        Assert.Equal("2026-08-25", footer.FixedDateTimeText);
+        Assert.False(footer.ShowOnTitleSlide);
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.Core.Presentation;
+using Sbroenne.PowerPointMcp.Core.Layout;
 using Sbroenne.PowerPointMcp.Core.Shape;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
@@ -735,5 +736,88 @@ public class ShapeCommandsTests : IClassFixture<SharedPresentationFixture>
 
         Assert.False(result.Success);
         Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void ListPlaceholders_AndSetPlaceholderText_RoundTripTitlePlaceholder()
+    {
+        _fixture.CreateFreshPresentation();
+        var layoutResult = new LayoutCommands().SetLayout(_fixture.Batch, 1, "ppLayoutTitleOnly");
+        Assert.True(layoutResult.Success, layoutResult.ErrorMessage);
+
+        var listed = _commands.ListPlaceholders(_fixture.Batch, 1);
+
+        Assert.True(listed.Success, listed.ErrorMessage);
+        var title = Assert.Single(listed.Placeholders!);
+        Assert.True(title.ShapeIndex >= 1);
+        Assert.Equal("ppPlaceholderTitle", title.PlaceholderType);
+
+        var setResult = _commands.SetPlaceholderText(
+            _fixture.Batch, 1, title.ShapeIndex, "Release title");
+
+        Assert.True(setResult.Success, setResult.ErrorMessage);
+        Assert.Null(setResult.ErrorMessage);
+
+        var saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        string nativeText = _fixture.Batch.Execute((ctx, ct) =>
+            ctx.Presentation.Slides[1].Shapes[title.ShapeIndex].TextFrame.TextRange.Text);
+        Assert.Equal("Release title", nativeText);
+    }
+
+    [Fact]
+    public void SetPlaceholderText_OnNonPlaceholder_ReturnsFailure()
+    {
+        _fixture.CreateFreshPresentation();
+        var added = _commands.AddTextBox(_fixture.Batch, 1, 10f, 10f, 200f, 40f, "Not a placeholder");
+        Assert.True(added.Success, added.ErrorMessage);
+
+        var result = _commands.SetPlaceholderText(
+            _fixture.Batch, 1, added.ShapeIndex!.Value, "Replacement text");
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void SetPlaceholderImage_ReplacesNativePicturePlaceholder()
+    {
+        _fixture.CreateFreshPresentation();
+        var layoutResult = new LayoutCommands().SetLayout(
+            _fixture.Batch, 1, "ppLayoutPictureWithCaption");
+        Assert.True(layoutResult.Success, layoutResult.ErrorMessage);
+
+        var listed = _commands.ListPlaceholders(_fixture.Batch, 1);
+        Assert.True(listed.Success, listed.ErrorMessage);
+        var picturePlaceholder = Assert.Single(
+            listed.Placeholders!,
+            placeholder => placeholder.PlaceholderType == "ppPlaceholderPicture");
+
+        string imagePath = CoreTestHelper.CreateUniqueTestImageFile();
+        try
+        {
+            var result = _commands.SetPlaceholderImage(
+                _fixture.Batch, 1, picturePlaceholder.ShapeIndex, imagePath);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Null(result.ErrorMessage);
+
+            var saveResult = _presentationCommands.Save(_fixture.Batch);
+            Assert.True(saveResult.Success, saveResult.ErrorMessage);
+            _fixture.ReopenCurrentPresentation();
+
+            var after = _commands.ListPlaceholders(_fixture.Batch, 1);
+            Assert.True(after.Success, after.ErrorMessage);
+            var replaced = Assert.Single(
+                after.Placeholders!,
+                placeholder => placeholder.PlaceholderType == "ppPlaceholderPicture");
+            Assert.True(replaced.HasImage);
+        }
+        finally
+        {
+            File.Delete(imagePath);
+        }
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/SlideCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/SlideCommandsTests.cs
@@ -1,4 +1,5 @@
 using Sbroenne.PowerPointMcp.Core.Presentation;
+using Sbroenne.PowerPointMcp.Core.Shape;
 using Sbroenne.PowerPointMcp.Core.Slide;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
@@ -341,5 +342,149 @@ public class SlideCommandsTests : IClassFixture<SharedPresentationFixture>
 
         Assert.False(result.Success);
         Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+    }
+
+    [Fact]
+    public void Comments_AddListDeleteAndClear_RoundTripAgainstNativeComments()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var firstAdd = _commands.AddComment(
+            _fixture.Batch, 1, "Release Tester", "RT", "First comment", left: 12f, top: 34f);
+        Assert.True(firstAdd.Success, firstAdd.ErrorMessage);
+        Assert.Equal(1, firstAdd.CommentCount);
+
+        var secondAdd = _commands.AddComment(
+            _fixture.Batch, 1, "Second Tester", "ST", "Second comment");
+        Assert.True(secondAdd.Success, secondAdd.ErrorMessage);
+        Assert.Equal(2, secondAdd.CommentCount);
+
+        var saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        var listed = _commands.ListComments(_fixture.Batch, 1);
+        Assert.True(listed.Success, listed.ErrorMessage);
+        Assert.Equal(2, listed.CommentCount);
+        var nativeAuthor = listed.Comments![0].Author;
+        var nativeInitials = listed.Comments[0].Initials;
+
+        // Modern PowerPoint replaces supplied comment identity with the signed-in Office identity.
+        // Assert that the native identity is populated and remains stable across comments instead.
+        Assert.False(string.IsNullOrWhiteSpace(nativeAuthor), "PowerPoint must expose a native comment author.");
+        Assert.False(string.IsNullOrWhiteSpace(nativeInitials), "PowerPoint must expose native comment initials.");
+        Assert.All(listed.Comments, comment =>
+        {
+            Assert.Equal(nativeAuthor, comment.Author);
+            Assert.Equal(nativeInitials, comment.Initials);
+        });
+
+        Assert.Collection(
+            listed.Comments,
+            comment =>
+            {
+                Assert.Equal(1, comment.CommentIndex);
+                Assert.Equal("First comment", comment.Text);
+                Assert.InRange(comment.Left, 11.9f, 12.1f);
+                // Modern comments may normalize the legacy COM Top value even when Left is preserved.
+                Assert.True(
+                    Math.Abs(comment.Top - 34f) <= 0.1f || comment.Top == 0f,
+                    $"Expected the requested or native-normalized comment Top value, but found {comment.Top}.");
+            },
+            comment =>
+            {
+                Assert.Equal(2, comment.CommentIndex);
+                Assert.Equal("Second comment", comment.Text);
+            });
+
+        var deleted = _commands.DeleteComment(_fixture.Batch, 1, 1);
+        Assert.True(deleted.Success, deleted.ErrorMessage);
+        Assert.Equal(1, deleted.CommentCount);
+
+        saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        var afterDelete = _commands.ListComments(_fixture.Batch, 1);
+        var remaining = Assert.Single(afterDelete.Comments!);
+        Assert.Equal("Second comment", remaining.Text);
+
+        var cleared = _commands.ClearComments(_fixture.Batch, 1);
+        Assert.True(cleared.Success, cleared.ErrorMessage);
+        Assert.Equal(0, cleared.CommentCount);
+
+        saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+
+        var afterClear = _commands.ListComments(_fixture.Batch, 1);
+        Assert.True(afterClear.Success, afterClear.ErrorMessage);
+        Assert.Empty(afterClear.Comments!);
+    }
+
+    [Fact]
+    public void ImportFromFile_WithSourceRange_InsertsSlidesAfterDestination()
+    {
+        string sourcePath = _fixture.CreateFreshPresentation("pptmcp-import-source");
+        _commands.AddBlank(_fixture.Batch);
+        _commands.AddBlank(_fixture.Batch);
+        var shapeCommands = new ShapeCommands();
+        shapeCommands.AddTextBox(_fixture.Batch, 2, 10f, 10f, 200f, 40f, "Imported slide two");
+        shapeCommands.AddTextBox(_fixture.Batch, 3, 10f, 10f, 200f, 40f, "Imported slide three");
+        _presentationCommands.Save(_fixture.Batch);
+
+        _fixture.CreateFreshPresentation("pptmcp-import-destination");
+
+        var result = _commands.ImportFromFile(
+            _fixture.Batch,
+            sourcePath,
+            destinationSlideIndex: 1,
+            sourceStartSlide: 2,
+            sourceEndSlide: 3);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Null(result.ErrorMessage);
+        Assert.Equal(2, result.ImportedSlideCount);
+        Assert.Equal([2, 3], result.ImportedSlideIndexes);
+        Assert.Equal(3, result.SlideCount);
+
+        var saveResult = _presentationCommands.Save(_fixture.Batch);
+        Assert.True(saveResult.Success, saveResult.ErrorMessage);
+        _fixture.ReopenCurrentPresentation();
+        Assert.Equal(3, _commands.GetCount(_fixture.Batch).SlideCount);
+
+        string[] importedText = _fixture.Batch.Execute((ctx, ct) => new[]
+        {
+            ctx.Presentation.Slides[2].Shapes[1].TextFrame.TextRange.Text,
+            ctx.Presentation.Slides[3].Shapes[1].TextFrame.TextRange.Text
+        });
+        Assert.Equal(["Imported slide two", "Imported slide three"], importedText);
+    }
+
+    [Fact]
+    public void ImportFromFile_WithInvalidSourceRangeOrDestination_ReturnsFailure()
+    {
+        string sourcePath = _fixture.CreateFreshPresentation("pptmcp-import-invalid-source");
+        _commands.AddBlank(_fixture.Batch);
+        _presentationCommands.Save(_fixture.Batch);
+        _fixture.CreateFreshPresentation("pptmcp-import-invalid-destination");
+
+        var invalidRange = _commands.ImportFromFile(
+            _fixture.Batch,
+            sourcePath,
+            destinationSlideIndex: 1,
+            sourceStartSlide: 2,
+            sourceEndSlide: 1);
+        Assert.False(invalidRange.Success);
+        Assert.False(string.IsNullOrWhiteSpace(invalidRange.ErrorMessage));
+
+        var invalidDestination = _commands.ImportFromFile(
+            _fixture.Batch,
+            sourcePath,
+            destinationSlideIndex: 99,
+            sourceStartSlide: 1,
+            sourceEndSlide: 1);
+        Assert.False(invalidDestination.Success);
+        Assert.False(string.IsNullOrWhiteSpace(invalidDestination.ErrorMessage));
     }
 }

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -35,8 +35,9 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
     /// <summary>
     /// The MCP tool surface: one hand-written action-dispatch tool (Presentation — session
     /// lifecycle + template + document properties) plus one generated action-dispatch tool per
-    /// remaining Core domain (Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation,
-    /// SmartArt, Image, Chart, Export) — enumerated directly from every <c>[McpServerTool]</c> in
+    /// remaining Core domain (Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup,
+    /// Accessibility, Master, Animation, SmartArt, Image, Chart, Export) — enumerated directly
+    /// from every <c>[McpServerTool]</c> in
     /// <c>src/PowerPointMcp.McpServer/Tools/*.cs</c> (hand-written) and the generated
     /// <c>PowerPointMcp.Generators.Mcp</c> output (one action-dispatch tool per domain, matching
     /// mcp-server-excel's architecture: a single tool per domain with an action enum, instead of
@@ -48,13 +49,15 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
         // PresentationTools.cs (1, hand-written action-dispatch tool — session lifecycle,
         // template, and document properties; 12 actions)
         "presentation",
-        // Generated action-dispatch tools (12, one per remaining Core domain)
+        // Generated action-dispatch tools (14, one per remaining Core domain)
         "slide",
         "shape",
         "textframe",
         "table",
         "notes",
         "layout",
+        "pagesetup",
+        "accessibility",
         "master",
         "animation",
         "smartart",
@@ -100,8 +103,8 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
     }
 
     /// <summary>
-    /// THE core protocol proof: exactly the 24 expected tools (12 hand-written + 12 generated
-    /// action-dispatch) are discoverable via <c>tools/list</c> — no more, no less.
+    /// THE core protocol proof: exactly the 15 expected tools (1 hand-written + 14 generated
+    /// action-dispatch tools) are discoverable via <c>tools/list</c> — no more, no less.
     /// </summary>
     [Fact]
     public async Task ListTools_ReturnsExactlyTheExpectedTools()


### PR DESCRIPTION
## Summary

Adds the focused native PowerPoint delivery release and closes the highest-value gaps identified in the comparison.

## Changes

- Adds safe native PDF export without retargeting the open presentation.
- Adds page size, slide numbering, footer, and date/time controls.
- Adds legacy comment management, slide import, and native placeholder text/image editing.
- Adds deterministic accessibility audits and reading-order management.
- Updates generated MCP/CLI surfaces and documentation to 15 tools and 158 operations.

## Testing

- Release build: 0 warnings and 0 errors
- Real-COM Core tests: Accessibility 4, Export 10, PageSetup 3, Shape 49, Slide 24
- MCP Server tests: 18 passed
- Repository safety and documentation-count audits passed

## Changelog

- [x] Added a patch changeset describing the user-facing release.
- [ ] This PR does not need a changelog entry.