### PR TITLE
feat: add Mark as Final presentation operations

### DIFF
--- a/.changeset/final-presentations.md
+++ b/.changeset/final-presentations.md
@@ -1,0 +1,7 @@
+---
+"powerpointmcp": minor
+---
+
+Add typed `get-final` and `set-final` presentation operations to the MCP server and CLI, with
+persistent round-trip behavior and clear guidance that Mark as Final is advisory rather than
+security.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ Unified Service Architecture.
 5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 15 tools
    total: one hand-written `presentation` action-dispatch tool plus 14 generated action-dispatch
    tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 160 operations
+   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 162 operations
    across 15 domains. See
    `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
    the ground-truth tool list.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**15 MCP tools with 160 operations across 15 domains:**
+**15 MCP tools with 162 operations across 15 domains:**
 
-- 🗂️ **Presentation** (14 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
-  `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name, read/write built-in
-  and custom document properties
+- 🗂️ **Presentation** (16 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
+  `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name, set/read
+  PowerPoint's advisory Mark as Final flag, and read/write built-in and custom document properties
 - 📑 **Slide** (19 ops) — lifecycle, backgrounds, sections, comments, and slide import
 - ▭ **Shape** (39 ops) — shapes, styling, grouping, hyperlinks, and placeholder editing
 - ✏️ **TextFrame** (20 ops) — text, font size/name/color, bold, italic, underline, alignment, bullets

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This audit compares the current 15 tools and 160 operations with the restored
+This audit compares the current 15 tools and 162 operations with the restored
 `Microsoft.Office.Interop.PowerPoint` 15.0.4420.1018 assembly. It looks for useful PowerPoint
 features that fit the existing live-session model. It does not copy Excel-only worksheet, Power
 Query, Data Model, PivotTable, or calculation APIs.

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -68,6 +68,12 @@ tool text stating clearly that it is an advisory editing flag, not access contro
 
 Tests should set, save, reopen, read, clear, save, and reopen again.
 
+Implemented with typed PIA access. PowerPoint persists the flag when it is set to `true` and then
+makes the presentation read-only, so save-on-close remains accepted as a successful no-op while
+the flag is set. Clearing the flag makes the presentation editable again and is persisted by the
+normal save-on-close workflow. The flag is advisory only; it is not authentication, encryption,
+or access control.
+
 Reference: [Presentation.Final](https://learn.microsoft.com/office/vba/api/powerpoint.presentation.final).
 
 ### 3. Presentation, slide, and shape tags

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -68,11 +68,12 @@ tool text stating clearly that it is an advisory editing flag, not access contro
 
 Tests should set, save, reopen, read, clear, save, and reopen again.
 
-Implemented with typed PIA access. PowerPoint persists the flag when it is set to `true` and then
-makes the presentation read-only, so save-on-close remains accepted as a successful no-op while
-the flag is set. Clearing the flag makes the presentation editable again and is persisted by the
-normal save-on-close workflow. The flag is advisory only; it is not authentication, encryption,
-or access control.
+Implemented with typed PIA access. Setting the flag to `true` first saves current changes, then
+PowerPoint persists the flag and makes the presentation read-only. Save-on-close remains accepted
+as a successful no-op while the flag is set without losing edits made before `set-final`.
+Clearing the flag makes the presentation editable again and is persisted by the normal
+save-on-close workflow. The flag is advisory only; it is not authentication, encryption, or
+access control.
 
 Reference: [Presentation.Final](https://learn.microsoft.com/office/vba/api/powerpoint.presentation.final).
 

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -20,7 +20,7 @@ The CLI mirrors the same domain model:
 
 | Tool | Ops | What it covers | MCP call shape | CLI shape |
 |------|-----|----------------|----------------|-----------|
-| `presentation` | 14 | Session lifecycle, Save As/copy, open testing, template application, built-in/custom document properties | `presentation(action="...", ...)` | `pptcli session <action> ...` |
+| `presentation` | 16 | Session lifecycle, Save As/copy, open testing, template application, advisory Mark as Final, built-in/custom document properties | `presentation(action="...", ...)` | `pptcli session <action> ...` |
 | `slide` | 19 | Slide lifecycle, backgrounds, sections, comments, import | `slide(action="...", session_id=..., ...)` | `pptcli slide <action> -s <SESSION_ID> ...` |
 | `shape` | 39 | Shapes, styling, grouping, hyperlinks, placeholders | `shape(action="...", session_id=..., ...)` | `pptcli shape <action> -s <SESSION_ID> ...` |
 | `textframe` | 20 | Text content and text formatting | `textframe(action="...", session_id=..., ...)` | `pptcli textframe <action> -s <SESSION_ID> ...` |

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 15 MCP tools with 160 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
+description: 15 MCP tools with 162 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
 keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **15 MCP tools with 160 operations across 15 domains**.
+PowerPoint MCP Server exposes **15 MCP tools with 162 operations across 15 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -38,7 +38,7 @@ The CLI mirrors the same domain model:
 
 ## Domain reference
 
-### `presentation` tool (14 operations)
+### `presentation` tool (16 operations)
 
 Use `presentation` for session lifecycle, Save As/copy, templates/themes, and document properties.
 `create` and `open` establish a session and return a `sessionId`; the remaining edit/read actions

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -40,9 +40,9 @@ The CLI mirrors the same domain model:
 
 ### `presentation` tool (16 operations)
 
-Use `presentation` for session lifecycle, Save As/copy, templates/themes, and document properties.
-`create` and `open` establish a session and return a `sessionId`; the remaining edit/read actions
-use that `sessionId`.
+Use `presentation` for session lifecycle, Save As/copy, templates/themes, Mark as Final, and
+document properties. `create` and `open` establish a session and return a `sessionId`; the
+remaining edit/read actions use that `sessionId`.
 
 | Action | What it does |
 |--------|---------------|
@@ -55,6 +55,8 @@ use that `sessionId`.
 | `save-copy-as` | Save a copy using the active presentation's current format without changing the active presentation or session path. Existing files require `overwrite=true`. |
 | `apply-template` | Apply a `.potx`/`.potm`/`.pot` or `.pptx`/`.pptm` template source while preserving slide content. |
 | `get-theme-name` | Read the currently applied design/theme name. |
+| `get-final` | Read PowerPoint's advisory Mark as Final editing flag. It is not authentication, encryption, or access control. |
+| `set-final` | Save current changes, then set or clear PowerPoint's advisory Mark as Final editing flag. |
 | `set-document-property` | Set a built-in document metadata property such as Title or Author. |
 | `get-document-property` | Read a built-in document metadata property. |
 | `set-custom-property` | Create or update a custom document property. |
@@ -62,8 +64,8 @@ use that `sessionId`.
 | `remove-custom-property` | Remove a custom document property. |
 
 **Exact action order:** `create`, `open`, `close`, `list`, `test`, `save-as`, `save-copy-as`,
-`apply-template`, `get-theme-name`, `set-document-property`, `get-document-property`,
-`set-custom-property`, `get-custom-property`, `remove-custom-property`
+`apply-template`, `get-theme-name`, `get-final`, `set-final`, `set-document-property`,
+`get-document-property`, `set-custom-property`, `get-custom-property`, `remove-custom-property`
 
 ### `slide` tool (19 operations)
 

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -100,7 +100,7 @@ hide:
 
 </div>
 
-[See all 15 tools (160 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 15 tools (162 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 15 tools (160 operations) across 15 domains
+- [Complete Feature Reference](features.md) — all 15 tools (162 operations) across 15 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 160 operations across 15 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 162 operations across 15 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -18,7 +18,7 @@ Claude can now create and edit PowerPoint decks directly.
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
 required) plus the manifest, license, and changelog. The server exposes 15
-tools (160 operations across 15 domains) — see the
+tools (162 operations across 15 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 
 ## Building locally

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "PowerPoint (Windows)",
   "version": "0.1.5",
   "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, accessibility, PDF export, and more - requires PowerPoint to be installed",
-  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (160 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including PDF delivery and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
+  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (162 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including PDF delivery and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "PowerPoint (Windows)",
   "version": "0.1.5",
   "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, accessibility, PDF export, and more - requires PowerPoint to be installed",
-  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (158 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including PDF delivery and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
+  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (160 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including PDF delivery and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -108,9 +108,10 @@ pptcli session set-final <session-id> false
 ```
 
 Mark as Final only communicates that editing is discouraged. It is not authentication,
-encryption, or access control. PowerPoint persists the flag when it is set to `true` and then
-makes the presentation read-only; `session close --save` remains valid. After clearing the flag,
-close with `--save` to persist the cleared state.
+encryption, or access control. Setting it to `true` first saves all current changes, then
+PowerPoint persists the flag and makes the presentation read-only; `session close --save` remains
+valid without losing edits made before `set-final`. After clearing the flag, close with `--save`
+to persist the cleared state.
 
 ### Rule 7: Report File Errors Immediately
 

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -99,11 +99,24 @@ pptcli session close $session.sessionId --save
 
 Slide content is preserved; only masters/theme/layouts change.
 
-### Rule 6: Report File Errors Immediately
+### Rule 6: Mark as Final Is Advisory, Not Security
+
+```powershell
+pptcli session get-final <session-id>
+pptcli session set-final <session-id> true
+pptcli session set-final <session-id> false
+```
+
+Mark as Final only communicates that editing is discouraged. It is not authentication,
+encryption, or access control. PowerPoint persists the flag when it is set to `true` and then
+makes the presentation read-only; `session close --save` remains valid. After clearing the flag,
+close with `--save` to persist the cleared state.
+
+### Rule 7: Report File Errors Immediately
 
 If you see "File not found" or "Path not found" - STOP and report to user. Don't retry.
 
-### Rule 7: Managing the Daemon Directly
+### Rule 8: Managing the Daemon Directly
 
 ```powershell
 pptcli service status         # Report starting/running/unresponsive/stopped state

--- a/skills/powerpoint-cli/references/behavioral-rules.md
+++ b/skills/powerpoint-cli/references/behavioral-rules.md
@@ -81,6 +81,18 @@ all changes since the last save.
   the active session path unchanged.
 - Both reject an existing destination unless `overwrite: true` is supplied.
 
+## Mark as Final Is Advisory, Not Security
+
+Use `presentation(action: "get-final", sessionId: ...)` to read PowerPoint's Mark as Final state
+and `presentation(action: "set-final", sessionId: ..., isFinal: true/false)` to set or clear it.
+This flag only communicates that editing is discouraged. It is not authentication, encryption, or
+access control, and anyone can clear it.
+
+PowerPoint persists the flag when it is set to `true` and then makes the presentation read-only.
+Calling `presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the
+session without attempting a forbidden second save. After clearing the flag with `isFinal: false`,
+close with `save: true` to persist the cleared state.
+
 ## Close Is Asynchronous (Do NOT Wait For It)
 
 `presentation(action: "close", sessionId: ...)` returns as soon as the session is removed from the

--- a/skills/powerpoint-cli/references/behavioral-rules.md
+++ b/skills/powerpoint-cli/references/behavioral-rules.md
@@ -88,10 +88,11 @@ and `presentation(action: "set-final", sessionId: ..., isFinal: true/false)` to 
 This flag only communicates that editing is discouraged. It is not authentication, encryption, or
 access control, and anyone can clear it.
 
-PowerPoint persists the flag when it is set to `true` and then makes the presentation read-only.
-Calling `presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the
-session without attempting a forbidden second save. After clearing the flag with `isFinal: false`,
-close with `save: true` to persist the cleared state.
+Setting the flag to `true` first saves all current changes, then PowerPoint persists the flag and
+makes the presentation read-only. Calling
+`presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the session
+without attempting a forbidden second save, so edits made before `set-final` are not lost. After
+clearing the flag with `isFinal: false`, close with `save: true` to persist the cleared state.
 
 ## Close Is Asynchronous (Do NOT Wait For It)
 

--- a/skills/powerpoint-cli/references/cli-commands.md
+++ b/skills/powerpoint-cli/references/cli-commands.md
@@ -495,7 +495,8 @@ OPTIONS:
 ```text
 DESCRIPTION:
 Open, create, close, test, Save As/copy, or list presentation sessions held by
-the daemon; apply templates and read/write document properties
+the daemon; apply templates, manage the advisory Mark as Final flag, and
+read/write document properties
 
 USAGE:
     pptcli session [OPTIONS] <COMMAND>
@@ -556,6 +557,26 @@ COMMANDS:
                                                                   applied to the
                                                                   open
                                                                   presentation
+    get-final <SESSION_ID>                                        Read
+                                                                  PowerPoint's
+                                                                  advisory Mark
+                                                                  as Final
+                                                                  editing flag;
+                                                                  it is not
+                                                                  authentication
+                                                                  , encryption,
+                                                                  or access
+                                                                  control
+    set-final <SESSION_ID> <IS_FINAL>                             Set or clear
+                                                                  PowerPoint's
+                                                                  advisory Mark
+                                                                  as Final
+                                                                  editing flag;
+                                                                  it is not
+                                                                  authentication
+                                                                  , encryption,
+                                                                  or access
+                                                                  control
     set-document-property <SESSION_ID> <PROPERTY_NAME> <VALUE>    Set a built-in
                                                                   document
                                                                   metadata
@@ -618,6 +639,23 @@ USAGE:
 
 ARGUMENTS:
     <FILE_PATH>    Full path to the .pptx/.pptm presentation file
+
+OPTIONS:
+    -h, --help    Prints help information
+```
+
+### `pptcli session get-final`
+
+```text
+DESCRIPTION:
+Read PowerPoint's advisory Mark as Final editing flag; it is not authentication,
+encryption, or access control
+
+USAGE:
+    pptcli session get-final <SESSION_ID> [OPTIONS]
+
+ARGUMENTS:
+    <SESSION_ID>    Session id returned by 'session open'/'session create'
 
 OPTIONS:
     -h, --help    Prints help information

--- a/skills/powerpoint-cli/references/workflows.md
+++ b/skills/powerpoint-cli/references/workflows.md
@@ -2,7 +2,7 @@
 
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 160 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 162 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/powerpoint-mcp/SKILL.md
+++ b/skills/powerpoint-mcp/SKILL.md
@@ -17,8 +17,9 @@ via the Model Context Protocol, driving a live PowerPoint desktop instance throu
 skill documents session lifecycle, indexing conventions, workflows, and gotchas that aren't
 obvious from tool schemas alone.
 
-Session lifecycle, templates, and document properties use the `presentation` action-dispatch tool
-with camelCase arguments. Domain tools (`slide`, `shape`, `textframe`, `table`, `chart`, `image`,
+Session lifecycle, templates, the advisory Mark as Final flag, and document properties use the
+`presentation` action-dispatch tool with camelCase arguments. Domain tools (`slide`, `shape`,
+`textframe`, `table`, `chart`, `image`,
 `notes`, `layout`, `master`, `smartart`, `animation`, `export`, `pagesetup`, `accessibility`) are
 action-dispatch: one tool per domain, called as `tool(action:
 "kebab-action", session_id: ..., snake_case_param: ...)`.
@@ -94,6 +95,7 @@ saved.
 |------|---------|
 | Create/open/test/close/list sessions | `presentation(action: "create"/"open"/"test"/"close"/"list")` |
 | Apply template, read theme name | `presentation(action: "apply-template"/"get-theme-name")` |
+| Read/set advisory Mark as Final state | `presentation(action: "get-final"/"set-final")` |
 | Document metadata (built-in and custom properties) | `presentation` property actions |
 | Add/count/delete/duplicate/reorder slides | `slide(action: "add-blank"/"get-count"/"delete"/"duplicate"/"move-to")` |
 | Per-slide background color, sections | `slide(action: "set-background-color"/"get-background-color"/"add-section"/"rename-section"/"delete-section"/"get-section-count"/"get-section-name")` |

--- a/skills/powerpoint-mcp/references/behavioral-rules.md
+++ b/skills/powerpoint-mcp/references/behavioral-rules.md
@@ -86,10 +86,11 @@ and `presentation(action: "set-final", sessionId: ..., isFinal: true/false)` to 
 This flag only communicates that editing is discouraged. It is not authentication, encryption, or
 access control, and anyone can clear it.
 
-PowerPoint persists the flag when it is set to `true` and then makes the presentation read-only.
-Calling `presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the
-session without attempting a forbidden second save. After clearing the flag with `isFinal: false`,
-close with `save: true` to persist the cleared state.
+Setting the flag to `true` first saves all current changes, then PowerPoint persists the flag and
+makes the presentation read-only. Calling
+`presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the session
+without attempting a forbidden second save, so edits made before `set-final` are not lost. After
+clearing the flag with `isFinal: false`, close with `save: true` to persist the cleared state.
 
 ## Close Is Asynchronous (Do NOT Wait For It)
 

--- a/skills/powerpoint-mcp/references/behavioral-rules.md
+++ b/skills/powerpoint-mcp/references/behavioral-rules.md
@@ -79,6 +79,18 @@ all changes since the last save.
   the active session path unchanged.
 - Both reject an existing destination unless `overwrite: true` is supplied.
 
+## Mark as Final Is Advisory, Not Security
+
+Use `presentation(action: "get-final", sessionId: ...)` to read PowerPoint's Mark as Final state
+and `presentation(action: "set-final", sessionId: ..., isFinal: true/false)` to set or clear it.
+This flag only communicates that editing is discouraged. It is not authentication, encryption, or
+access control, and anyone can clear it.
+
+PowerPoint persists the flag when it is set to `true` and then makes the presentation read-only.
+Calling `presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the
+session without attempting a forbidden second save. After clearing the flag with `isFinal: false`,
+close with `save: true` to persist the cleared state.
+
 ## Close Is Asynchronous (Do NOT Wait For It)
 
 `presentation(action: "close", sessionId: ...)` returns as soon as the session is removed from the

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 160 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 162 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -86,10 +86,11 @@ and `presentation(action: "set-final", sessionId: ..., isFinal: true/false)` to 
 This flag only communicates that editing is discouraged. It is not authentication, encryption, or
 access control, and anyone can clear it.
 
-PowerPoint persists the flag when it is set to `true` and then makes the presentation read-only.
-Calling `presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the
-session without attempting a forbidden second save. After clearing the flag with `isFinal: false`,
-close with `save: true` to persist the cleared state.
+Setting the flag to `true` first saves all current changes, then PowerPoint persists the flag and
+makes the presentation read-only. Calling
+`presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the session
+without attempting a forbidden second save, so edits made before `set-final` are not lost. After
+clearing the flag with `isFinal: false`, close with `save: true` to persist the cleared state.
 
 ## Close Is Asynchronous (Do NOT Wait For It)
 

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -79,6 +79,18 @@ all changes since the last save.
   the active session path unchanged.
 - Both reject an existing destination unless `overwrite: true` is supplied.
 
+## Mark as Final Is Advisory, Not Security
+
+Use `presentation(action: "get-final", sessionId: ...)` to read PowerPoint's Mark as Final state
+and `presentation(action: "set-final", sessionId: ..., isFinal: true/false)` to set or clear it.
+This flag only communicates that editing is discouraged. It is not authentication, encryption, or
+access control, and anyone can clear it.
+
+PowerPoint persists the flag when it is set to `true` and then makes the presentation read-only.
+Calling `presentation(action: "close", sessionId: ..., save: true)` remains valid and closes the
+session without attempting a forbidden second save. After clearing the flag with `isFinal: false`,
+close with `save: true` to persist the cleared state.
+
 ## Close Is Asynchronous (Do NOT Wait For It)
 
 `presentation(action: "close", sessionId: ...)` returns as soon as the session is removed from the

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 160 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 162 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -108,9 +108,10 @@ pptcli session set-final <session-id> false
 ```
 
 Mark as Final only communicates that editing is discouraged. It is not authentication,
-encryption, or access control. PowerPoint persists the flag when it is set to `true` and then
-makes the presentation read-only; `session close --save` remains valid. After clearing the flag,
-close with `--save` to persist the cleared state.
+encryption, or access control. Setting it to `true` first saves all current changes, then
+PowerPoint persists the flag and makes the presentation read-only; `session close --save` remains
+valid without losing edits made before `set-final`. After clearing the flag, close with `--save`
+to persist the cleared state.
 
 ### Rule 7: Report File Errors Immediately
 

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -99,11 +99,24 @@ pptcli session close $session.sessionId --save
 
 Slide content is preserved; only masters/theme/layouts change.
 
-### Rule 6: Report File Errors Immediately
+### Rule 6: Mark as Final Is Advisory, Not Security
+
+```powershell
+pptcli session get-final <session-id>
+pptcli session set-final <session-id> true
+pptcli session set-final <session-id> false
+```
+
+Mark as Final only communicates that editing is discouraged. It is not authentication,
+encryption, or access control. PowerPoint persists the flag when it is set to `true` and then
+makes the presentation read-only; `session close --save` remains valid. After clearing the flag,
+close with `--save` to persist the cleared state.
+
+### Rule 7: Report File Errors Immediately
 
 If you see "File not found" or "Path not found" - STOP and report to user. Don't retry.
 
-### Rule 7: Managing the Daemon Directly
+### Rule 8: Managing the Daemon Directly
 
 ```powershell
 pptcli service status         # Report starting/running/unresponsive/stopped state

--- a/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
+++ b/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
@@ -263,6 +263,42 @@ internal sealed class SessionGetThemeNameCommand : AsyncCommand<SessionIdSetting
     }
 }
 
+/// <summary>Reads PowerPoint's advisory Mark as Final editing flag.</summary>
+internal sealed class SessionGetFinalCommand : AsyncCommand<SessionIdSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionIdSettings settings, CancellationToken cancellationToken)
+        => await SessionCommandHelpers.SendFinalCommandAsync(
+            "session.get-final",
+            settings.SessionId,
+            isFinal: null,
+            cancellationToken);
+}
+
+/// <summary>Settings for the "session set-final" command.</summary>
+internal sealed class SessionSetFinalSettings : CommandSettings
+{
+    [CommandArgument(0, "<SESSION_ID>")]
+    [Description("Session id returned by 'session open'/'session create'.")]
+    public string SessionId { get; init; } = string.Empty;
+
+    [CommandArgument(1, "<IS_FINAL>")]
+    [Description("True to mark the presentation as final; false to clear it. This is an advisory editing flag, not authentication, encryption, or access control.")]
+    public bool IsFinal { get; init; }
+}
+
+/// <summary>Sets or clears PowerPoint's advisory Mark as Final editing flag.</summary>
+internal sealed class SessionSetFinalCommand : AsyncCommand<SessionSetFinalSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionSetFinalSettings settings, CancellationToken cancellationToken)
+        => await SessionCommandHelpers.SendFinalCommandAsync(
+            "session.set-final",
+            settings.SessionId,
+            settings.IsFinal,
+            cancellationToken);
+}
+
 /// <summary>Settings shared by the document/custom property "get" commands.</summary>
 internal sealed class SessionPropertyGetSettings : CommandSettings
 {
@@ -350,6 +386,28 @@ internal static class SessionCommandHelpers
             Args = JsonSerializer.Serialize(
                 new { targetPath, format, overwrite },
                 ServiceProtocol.JsonOptions),
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+
+    public static async Task<int> SendFinalCommandAsync(string command, string sessionId, bool? isFinal, CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = command,
+            SessionId = sessionId,
+            Args = isFinal.HasValue
+                ? JsonSerializer.Serialize(new { isFinal = isFinal.Value }, ServiceProtocol.JsonOptions)
+                : null,
             Source = "cli"
         }, cancellationToken);
 

--- a/src/PowerPointMcp.CLI/Program.cs
+++ b/src/PowerPointMcp.CLI/Program.cs
@@ -29,7 +29,7 @@ public static class Program
 
             config.AddBranch("session", session =>
             {
-                session.SetDescription("Open, create, close, test, Save As/copy, or list presentation sessions held by the daemon; apply templates and read/write document properties.");
+                session.SetDescription("Open, create, close, test, Save As/copy, or list presentation sessions held by the daemon; apply templates, manage the advisory Mark as Final flag, and read/write document properties.");
                 session.AddCommand<SessionOpenCommand>("open").WithDescription("Open an existing presentation and return a session id.");
                 session.AddCommand<SessionCreateCommand>("create").WithDescription("Create a new presentation and return a session id.");
                 session.AddCommand<SessionCloseCommand>("close").WithDescription("Close a session, optionally saving first.");
@@ -39,6 +39,8 @@ public static class Program
                 session.AddCommand<SessionSaveCopyAsCommand>("save-copy-as").WithDescription("Save a copy without changing the active presentation or session path.");
                 session.AddCommand<SessionApplyTemplateCommand>("apply-template").WithDescription("Apply a template's masters/theme/layouts to the open presentation, preserving slide content.");
                 session.AddCommand<SessionGetThemeNameCommand>("get-theme-name").WithDescription("Read the design/theme name currently applied to the open presentation.");
+                session.AddCommand<SessionGetFinalCommand>("get-final").WithDescription("Read PowerPoint's advisory Mark as Final editing flag; it is not authentication, encryption, or access control.");
+                session.AddCommand<SessionSetFinalCommand>("set-final").WithDescription("Set or clear PowerPoint's advisory Mark as Final editing flag; it is not authentication, encryption, or access control.");
                 session.AddCommand<SessionSetDocumentPropertyCommand>("set-document-property").WithDescription("Set a built-in document metadata property (Title, Subject, Author, Keywords, Comments, Category, Manager, Company).");
                 session.AddCommand<SessionGetDocumentPropertyCommand>("get-document-property").WithDescription("Read a built-in document metadata property.");
                 session.AddCommand<SessionSetCustomPropertyCommand>("set-custom-property").WithDescription("Create or update a custom (user-defined) document property.");

--- a/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
@@ -3,7 +3,7 @@ using Sbroenne.PowerPointMcp.ComInterop.Session;
 namespace Sbroenne.PowerPointMcp.Core.Presentation;
 
 /// <summary>
-/// Presentation lifecycle commands: create, open, save, Save As, and Save Copy As.
+/// Presentation lifecycle, Save As/copy, template, metadata, and Mark as Final commands.
 /// </summary>
 /// <remarks>
 /// First Core command domain implemented, proving the ComInterop batch pattern end-to-end.
@@ -87,6 +87,22 @@ public interface IPresentationCommands
     /// presentation's styling.
     /// </summary>
     PresentationOperationResult GetThemeName(IPresentationBatch batch);
+
+    /// <summary>
+    /// Reads PowerPoint's Mark as Final state for the open presentation. This is an advisory
+    /// editing flag only; it is not authentication, encryption, or access control.
+    /// </summary>
+    /// <param name="batch">The open batch whose Mark as Final state will be read.</param>
+    PresentationOperationResult GetFinal(IPresentationBatch batch);
+
+    /// <summary>
+    /// Sets or clears PowerPoint's Mark as Final state for the open presentation. This is an
+    /// advisory editing flag only; it is not authentication, encryption, or access control.
+    /// Save the presentation to persist the change.
+    /// </summary>
+    /// <param name="batch">The open batch whose Mark as Final state will be updated.</param>
+    /// <param name="isFinal"><c>true</c> to mark the presentation as final; <c>false</c> to clear the flag.</param>
+    PresentationOperationResult SetFinal(IPresentationBatch batch, bool isFinal);
 
     /// <summary>
     /// Sets a built-in document metadata property (Title, Subject, Author, Keywords, Comments,

--- a/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
@@ -98,7 +98,8 @@ public interface IPresentationCommands
     /// <summary>
     /// Sets or clears PowerPoint's Mark as Final state for the open presentation. This is an
     /// advisory editing flag only; it is not authentication, encryption, or access control.
-    /// Save the presentation to persist the change.
+    /// Setting it saves current changes before PowerPoint makes the presentation read-only.
+    /// Clearing it must be followed by a save to persist the cleared state.
     /// </summary>
     /// <param name="batch">The open batch whose Mark as Final state will be updated.</param>
     /// <param name="isFinal"><c>true</c> to mark the presentation as final; <c>false</c> to clear the flag.</param>

--- a/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
@@ -66,13 +66,23 @@ public sealed class PresentationCommands : IPresentationCommands
     public PresentationOperationResult Save(IPresentationBatch batch)
     {
         ArgumentNullException.ThrowIfNull(batch);
-        batch.Save();
 
-        return new PresentationOperationResult
+        return batch.Execute((ctx, ct) =>
         {
-            Success = true,
-            PresentationPath = batch.PresentationPath
-        };
+            // PowerPoint persists Mark as Final when Final is set to true, then makes the
+            // presentation read-only. Calling Save afterward fails with "Presentation cannot be
+            // modified", so save-on-close is a successful no-op while that native flag is set.
+            if (!ctx.Presentation.Final)
+            {
+                ctx.Presentation.Save();
+            }
+
+            return new PresentationOperationResult
+            {
+                Success = true,
+                PresentationPath = batch.PresentationPath
+            };
+        });
     }
 
     /// <inheritdoc/>
@@ -402,6 +412,37 @@ public sealed class PresentationCommands : IPresentationCommands
                 Success = true,
                 PresentationPath = batch.PresentationPath,
                 ThemeName = themeName
+            };
+        });
+    }
+
+    /// <inheritdoc/>
+    public PresentationOperationResult GetFinal(IPresentationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) => new PresentationOperationResult
+        {
+            Success = true,
+            PresentationPath = batch.PresentationPath,
+            IsFinal = ctx.Presentation.Final
+        });
+    }
+
+    /// <inheritdoc/>
+    public PresentationOperationResult SetFinal(IPresentationBatch batch, bool isFinal)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            ctx.Presentation.Final = isFinal;
+
+            return new PresentationOperationResult
+            {
+                Success = true,
+                PresentationPath = batch.PresentationPath,
+                IsFinal = ctx.Presentation.Final
             };
         });
     }

--- a/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
@@ -69,9 +69,9 @@ public sealed class PresentationCommands : IPresentationCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            // PowerPoint persists Mark as Final when Final is set to true, then makes the
-            // presentation read-only. Calling Save afterward fails with "Presentation cannot be
-            // modified", so save-on-close is a successful no-op while that native flag is set.
+            // SetFinal saves pending edits before enabling Final. PowerPoint then persists the
+            // flag and makes the presentation read-only, so a second Save would fail with
+            // "Presentation cannot be modified". Save-on-close is therefore a successful no-op.
             if (!ctx.Presentation.Final)
             {
                 ctx.Presentation.Save();
@@ -436,6 +436,11 @@ public sealed class PresentationCommands : IPresentationCommands
 
         return batch.Execute((ctx, ct) =>
         {
+            if (isFinal && !ctx.Presentation.Final)
+            {
+                ctx.Presentation.Save();
+            }
+
             ctx.Presentation.Final = isFinal;
 
             return new PresentationOperationResult

--- a/src/PowerPointMcp.Core/Presentation/PresentationOperationResult.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationOperationResult.cs
@@ -1,7 +1,7 @@
 namespace Sbroenne.PowerPointMcp.Core.Presentation;
 
 /// <summary>
-/// Result of a presentation lifecycle operation (open, create, close, save).
+/// Result of a presentation lifecycle, template, metadata, or Mark as Final operation.
 /// </summary>
 /// <remarks>
 /// Follows the same Success/ErrorMessage invariant used throughout mcp-server-excel
@@ -25,6 +25,12 @@ public sealed class PresentationOperationResult
     /// Null for operations that don't touch theming.
     /// </summary>
     public string? ThemeName { get; init; }
+
+    /// <summary>
+    /// PowerPoint's Mark as Final state. This advisory editing flag is not authentication,
+    /// encryption, or access control. Null for operations that do not read or update the flag.
+    /// </summary>
+    public bool? IsFinal { get; init; }
 
     /// <summary>
     /// The document property name acted on by the document-property/custom-property commands.

--- a/src/PowerPointMcp.Core/Presentation/PresentationToolAction.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationToolAction.cs
@@ -55,6 +55,14 @@ public enum PresentationToolAction
     [JsonStringEnumMemberName("get-theme-name")]
     GetThemeName,
 
+    /// <summary>Read the advisory Mark as Final editing flag.</summary>
+    [JsonStringEnumMemberName("get-final")]
+    GetFinal,
+
+    /// <summary>Set or clear the advisory Mark as Final editing flag.</summary>
+    [JsonStringEnumMemberName("set-final")]
+    SetFinal,
+
     /// <summary>Set a built-in document metadata property (Title, Author, etc.).</summary>
     [JsonStringEnumMemberName("set-document-property")]
     SetDocumentProperty,
@@ -94,6 +102,8 @@ public static class PresentationToolActionExtensions
         PresentationToolAction.SaveCopyAs => "save-copy-as",
         PresentationToolAction.ApplyTemplate => "apply-template",
         PresentationToolAction.GetThemeName => "get-theme-name",
+        PresentationToolAction.GetFinal => "get-final",
+        PresentationToolAction.SetFinal => "set-final",
         PresentationToolAction.SetDocumentProperty => "set-document-property",
         PresentationToolAction.GetDocumentProperty => "get-document-property",
         PresentationToolAction.SetCustomProperty => "set-custom-property",

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,11 +32,11 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**15 tools with 160 operations across 15 domains:**
+**15 tools with 162 operations across 15 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
-| `presentation` | 14 | create, open, Save As, Save Copy As, close, list, apply-template, get-theme-name, built-in/custom document properties |
+| `presentation` | 16 | create, open, Save As, Save Copy As, close, list, apply-template, get-theme-name, get-final, set-final, built-in/custom document properties |
 | `slide` | 19 | slide lifecycle, backgrounds, sections, comments, slide import |
 | `shape` | 39 | shape creation, styling, grouping, hyperlinks, placeholders |
 | `textframe` | 20 | text content, font formatting, alignment, bullets, auto-size |

--- a/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
@@ -8,7 +8,8 @@ namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 /// <summary>
 /// Single action-dispatch MCP tool for presentation lifecycle, template application, and
 /// document-property operations: create a file, open/close/test a session, list open
-/// sessions, apply a template, and read/write document properties.
+/// sessions, apply a template, read/write document properties, and manage the advisory Mark as
+/// Final editing flag.
 /// </summary>
 /// <remarks>
 /// Mirrors mcp-server-excel's <c>ExcelFileTool</c> shape (one hand-written tool named
@@ -29,27 +30,28 @@ public static class PresentationTools
     private static readonly PresentationCommands Commands = new();
 
     /// <summary>
-    /// Presentation lifecycle, template, and document-property operations for an already-open
-    /// or about-to-be-opened presentation.
+    /// Presentation lifecycle, template, document-property, and advisory Mark as Final operations
+    /// for an already-open or about-to-be-opened presentation.
     /// </summary>
     [McpServerTool(Name = "presentation")]
-    [Description("Presentation lifecycle (create, open, close, list sessions, test), Save As/copy, template restyling (apply-template, get-theme-name), and document-property (built-in and custom) operations. Actions: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")]
+    [Description("Presentation lifecycle (create, open, close, list sessions, test), Save As/copy, template restyling, document-property operations, and PowerPoint's advisory Mark as Final editing flag. Mark as Final is not authentication, encryption, or access control. Actions: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")]
     public static string Presentation(
-        [Description("The action to perform. One of: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] PresentationToolAction action,
+        [Description("The action to perform. One of: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] PresentationToolAction action,
         [Description("Full Windows path to the presentation file. Required for: create (new .pptx/.pptm file; containing directory must already exist), open or test (existing .pptx/.pptm/.ppt file).")] string? filePath = null,
-        [Description("The sessionId returned by create or open. Required for: close, save-as, save-copy-as, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? sessionId = null,
+        [Description("The sessionId returned by create or open. Required for: close, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? sessionId = null,
         [Description("Save the presentation before closing. Used for: close. Default: false.")] bool? save = null,
         [Description("Set true only when creating a macro-enabled .pptm file. Default: false. Used for: create.")] bool? isMacroEnabled = null,
         [Description("Full Windows destination path. Required for: save-as, save-copy-as. The containing directory must already exist.")] string? targetPath = null,
         [Description("Output format for save-as: auto, pptx, pptm, or ppt. Default: auto infers from targetPath.")] PresentationSaveFormat? format = null,
         [Description("Whether an existing destination file may be replaced. Used for: save-as, save-copy-as. Default: false.")] bool? overwrite = null,
         [Description("Full Windows path to a .potx/.potm/.pot template file (a .pptx/.pptm presentation may also be used as a template source). Required for: apply-template.")] string? templatePath = null,
+        [Description("Set true to mark the presentation as final or false to clear it. Required for: set-final. Mark as Final is an advisory editing flag only; it is not authentication, encryption, or access control.")] bool? isFinal = null,
         [Description("Document property name. For set/get-document-property, one of: Title, Subject, Author, Keywords, Comments, Category, Manager, Company (case-insensitive). For custom-property actions, any user-defined name. Required for: set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? propertyName = null,
         [Description("The new property value. Required for: set-document-property, set-custom-property.")] string? value = null,
         PresentationSessionRegistry? registry = null)
         => PowerPointToolsBase.ExecuteToolAction("presentation", action.ToActionString(), () =>
         {
-            ValidateActionParameters(action, filePath, sessionId, save, isMacroEnabled, targetPath, format, overwrite, templatePath, propertyName, value);
+            ValidateActionParameters(action, filePath, sessionId, save, isMacroEnabled, targetPath, format, overwrite, templatePath, isFinal, propertyName, value);
             var reg = registry!;
             return action switch
             {
@@ -62,6 +64,8 @@ public static class PresentationTools
                 PresentationToolAction.SaveCopyAs => HandleSaveCopyAs(sessionId, targetPath, overwrite == true, reg),
                 PresentationToolAction.ApplyTemplate => HandleApplyTemplate(sessionId, templatePath, reg),
                 PresentationToolAction.GetThemeName => HandleGetThemeName(sessionId, reg),
+                PresentationToolAction.GetFinal => HandleGetFinal(sessionId, reg),
+                PresentationToolAction.SetFinal => HandleSetFinal(sessionId, isFinal, reg),
                 PresentationToolAction.SetDocumentProperty => HandleSetDocumentProperty(sessionId, propertyName, value, reg),
                 PresentationToolAction.GetDocumentProperty => HandleGetDocumentProperty(sessionId, propertyName, reg),
                 PresentationToolAction.SetCustomProperty => HandleSetCustomProperty(sessionId, propertyName, value, reg),
@@ -81,6 +85,7 @@ public static class PresentationTools
         PresentationSaveFormat? format,
         bool? overwrite,
         string? templatePath,
+        bool? isFinal,
         string? propertyName,
         string? value)
     {
@@ -93,6 +98,7 @@ public static class PresentationTools
         if (format != null) supplied.Add("format");
         if (overwrite != null) supplied.Add("overwrite");
         if (templatePath != null) supplied.Add("templatePath");
+        if (isFinal != null) supplied.Add("isFinal");
         if (propertyName != null) supplied.Add("propertyName");
         if (value != null) supplied.Add("value");
 
@@ -104,7 +110,8 @@ public static class PresentationTools
             PresentationToolAction.SaveAs => ["sessionId", "targetPath", "format", "overwrite"],
             PresentationToolAction.SaveCopyAs => ["sessionId", "targetPath", "overwrite"],
             PresentationToolAction.ApplyTemplate => ["sessionId", "templatePath"],
-            PresentationToolAction.GetThemeName => ["sessionId"],
+            PresentationToolAction.GetThemeName or PresentationToolAction.GetFinal => ["sessionId"],
+            PresentationToolAction.SetFinal => ["sessionId", "isFinal"],
             PresentationToolAction.SetDocumentProperty or PresentationToolAction.SetCustomProperty => ["sessionId", "propertyName", "value"],
             PresentationToolAction.GetDocumentProperty or PresentationToolAction.GetCustomProperty or PresentationToolAction.RemoveCustomProperty => ["sessionId", "propertyName"],
             _ => []
@@ -338,6 +345,31 @@ public static class PresentationTools
         return SerializeResult(Commands.GetThemeName(batch));
     }
 
+    private static string HandleGetFinal(string? sessionId, PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        return SerializeResult(Commands.GetFinal(batch));
+    }
+
+    private static string HandleSetFinal(string? sessionId, bool? isFinal, PresentationSessionRegistry registry)
+    {
+        if (!isFinal.HasValue)
+        {
+            return PowerPointToolsBase.ValidationError("isFinal is required for action=set-final.");
+        }
+
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        return SerializeResult(Commands.SetFinal(batch, isFinal.Value));
+    }
+
     /// <summary>
     /// Sets a built-in document metadata property (Title, Subject, Author, Keywords, Comments,
     /// Category, Manager, or Company) on the open presentation.
@@ -439,6 +471,7 @@ public static class PresentationTools
                 success = true,
                 presentationPath = result.PresentationPath,
                 themeName = result.ThemeName,
+                isFinal = result.IsFinal,
                 propertyName = result.PropertyName,
                 propertyValue = result.PropertyValue
             });
@@ -450,6 +483,7 @@ public static class PresentationTools
             errorMessage = result.ErrorMessage,
             presentationPath = result.PresentationPath,
             themeName = result.ThemeName,
+            isFinal = result.IsFinal,
             propertyName = result.PropertyName,
             propertyValue = result.PropertyValue,
             isError = true

--- a/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
@@ -45,7 +45,7 @@ public static class PresentationTools
         [Description("Output format for save-as: auto, pptx, pptm, or ppt. Default: auto infers from targetPath.")] PresentationSaveFormat? format = null,
         [Description("Whether an existing destination file may be replaced. Used for: save-as, save-copy-as. Default: false.")] bool? overwrite = null,
         [Description("Full Windows path to a .potx/.potm/.pot template file (a .pptx/.pptm presentation may also be used as a template source). Required for: apply-template.")] string? templatePath = null,
-        [Description("Set true to mark the presentation as final or false to clear it. Required for: set-final. Mark as Final is an advisory editing flag only; it is not authentication, encryption, or access control.")] bool? isFinal = null,
+        [Description("Set true to save current changes and mark the presentation as final, or false to clear the flag. Required for: set-final. Mark as Final is an advisory editing flag only; it is not authentication, encryption, or access control.")] bool? isFinal = null,
         [Description("Document property name. For set/get-document-property, one of: Title, Subject, Author, Keywords, Comments, Category, Manager, Company (case-insensitive). For custom-property actions, any user-defined name. Required for: set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? propertyName = null,
         [Description("The new property value. Required for: set-document-property, set-custom-property.")] string? value = null,
         PresentationSessionRegistry? registry = null)

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -326,7 +326,8 @@ public sealed class PowerPointMcpService : IDisposable
     {
         if (action is not ("create" or "open" or "close" or "list" or "test" or
             "save-as" or "save-copy-as" or
-            "apply-template" or "get-theme-name" or "set-document-property" or
+            "apply-template" or "get-theme-name" or "get-final" or "set-final" or
+            "set-document-property" or
             "get-document-property" or "set-custom-property" or "get-custom-property" or
             "remove-custom-property"))
         {
@@ -345,6 +346,8 @@ public sealed class PowerPointMcpService : IDisposable
             "save-copy-as" => HandleSessionSaveCopyAs(request),
             "apply-template" => HandleSessionApplyTemplate(request),
             "get-theme-name" => HandleSessionGetThemeName(request),
+            "get-final" => HandleSessionGetFinal(request),
+            "set-final" => HandleSessionSetFinal(request),
             "set-document-property" => HandleSessionSetDocumentProperty(request),
             "get-document-property" => HandleSessionGetDocumentProperty(request),
             "set-custom-property" => HandleSessionSetCustomProperty(request),
@@ -363,6 +366,7 @@ public sealed class PowerPointMcpService : IDisposable
             "save-as" => ["targetPath", "format", "overwrite"],
             "save-copy-as" => ["targetPath", "overwrite"],
             "apply-template" => ["templatePath"],
+            "set-final" => ["isFinal"],
             "set-document-property" or "set-custom-property" => ["propertyName", "value"],
             "get-document-property" or "get-custom-property" or "remove-custom-property" => ["propertyName"],
             _ => []
@@ -458,7 +462,11 @@ public sealed class PowerPointMcpService : IDisposable
         {
             try
             {
-                batchToSave.Save();
+                var saveResult = _presentationCommands.Save(batchToSave);
+                if (!saveResult.Success)
+                {
+                    return new ServiceResponse { Success = false, ErrorMessage = saveResult.ErrorMessage };
+                }
             }
             catch (Exception ex)
             {
@@ -576,6 +584,32 @@ public sealed class PowerPointMcpService : IDisposable
         }
 
         return WrapPresentationResult(() => _presentationCommands.GetThemeName(batch!), request);
+    }
+
+    private ServiceResponse HandleSessionGetFinal(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        return WrapPresentationResult(() => _presentationCommands.GetFinal(batch!), request);
+    }
+
+    private ServiceResponse HandleSessionSetFinal(ServiceRequest request)
+    {
+        var args = ServiceRegistry.DeserializeArgs<SessionFinalArgs>(request.Args);
+        if (!args.IsFinal.HasValue)
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "isFinal is required" };
+        }
+
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        return WrapPresentationResult(() => _presentationCommands.SetFinal(batch!, args.IsFinal.Value), request);
     }
 
     private ServiceResponse HandleSessionSetDocumentProperty(ServiceRequest request)
@@ -699,6 +733,7 @@ public sealed class PowerPointMcpService : IDisposable
                 errorMessage = result.ErrorMessage,
                 presentationPath = result.PresentationPath,
                 themeName = result.ThemeName,
+                isFinal = result.IsFinal,
                 propertyName = result.PropertyName,
                 propertyValue = result.PropertyValue
             }, ServiceProtocol.JsonOptions);
@@ -865,6 +900,16 @@ public sealed class SessionApplyTemplateArgs
 {
     /// <summary>Full path to a .potx/.potm/.pot template file (or a .pptx/.pptm presentation used as a template source).</summary>
     public string? TemplatePath { get; set; }
+}
+
+/// <summary>Args for "session.set-final".</summary>
+public sealed class SessionFinalArgs
+{
+    /// <summary>
+    /// Whether to set or clear PowerPoint's advisory Mark as Final editing flag. This is not
+    /// authentication, encryption, or access control.
+    /// </summary>
+    public bool? IsFinal { get; set; }
 }
 
 /// <summary>Args for "session.set/get-document-property" and "session.set/get/remove-custom-property".</summary>

--- a/tests/PowerPointMcp.CLI.Tests/SessionFinalCommandTests.cs
+++ b/tests/PowerPointMcp.CLI.Tests/SessionFinalCommandTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.CLI.Tests;
+
+public sealed class SessionFinalCommandTests
+{
+    [Theory]
+    [InlineData("get-final")]
+    [InlineData("set-final")]
+    public async Task SessionFinalCommand_IsRegistered(string action)
+    {
+        var exitCode = await Program.Main(["session", action, "--help"]);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task SessionFinalCommands_RejectMissingOrInapplicableArguments()
+    {
+        var getExitCode = await Program.Main(
+            ["session", "get-final", "missing-session", "--is-final", "true"]);
+        Assert.NotEqual(0, getExitCode);
+
+        var setExitCode = await Program.Main(
+            ["session", "set-final", "missing-session"]);
+        Assert.NotEqual(0, setExitCode);
+    }
+
+    [Fact]
+    public async Task FinalServiceActions_RejectUnknownSessionsWithoutStartingPowerPoint()
+    {
+        using var service = new PowerPointMcpService();
+
+        var getResponse = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.get-final",
+            SessionId = "missing-session",
+            Source = "cli"
+        });
+        Assert.False(getResponse.Success);
+        Assert.Contains("not found", getResponse.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+
+        var setResponse = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.set-final",
+            SessionId = "missing-session",
+            Args = JsonSerializer.Serialize(new { isFinal = true }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        });
+        Assert.False(setResponse.Success);
+        Assert.Contains("not found", setResponse.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FinalServiceActions_RejectUnknownParameters()
+    {
+        using var service = new PowerPointMcpService();
+
+        var getResponse = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.get-final",
+            SessionId = "missing-session",
+            Args = JsonSerializer.Serialize(new { isFinal = true }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        });
+        Assert.False(getResponse.Success);
+        Assert.Contains("Unknown parameter", getResponse.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+
+        var setResponse = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.set-final",
+            SessionId = "missing-session",
+            Args = JsonSerializer.Serialize(new { isFinal = true, value = "unexpected" }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        });
+        Assert.False(setResponse.Success);
+        Assert.Contains("Unknown parameter", setResponse.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
@@ -273,6 +273,50 @@ public class PresentationCommandsTests
     }
 
     [Fact]
+    public void Final_SetSaveReopenClearSaveReopen_RoundTrips()
+    {
+        string path = CoreTestHelper.CreateUniqueTestFilePath();
+        try
+        {
+            using (var batch = PresentationSession.CreateNew(path))
+            {
+                var setResult = _commands.SetFinal(batch, true);
+                Assert.True(setResult.Success);
+                Assert.Null(setResult.ErrorMessage);
+                Assert.True(setResult.IsFinal);
+
+                var saveResult = _commands.Save(batch);
+                Assert.True(saveResult.Success);
+            }
+
+            using (var reopened = PresentationSession.BeginBatch(path))
+            {
+                var getResult = _commands.GetFinal(reopened);
+                Assert.True(getResult.Success);
+                Assert.Null(getResult.ErrorMessage);
+                Assert.True(getResult.IsFinal);
+
+                var clearResult = _commands.SetFinal(reopened, false);
+                Assert.True(clearResult.Success);
+                Assert.Null(clearResult.ErrorMessage);
+                Assert.False(clearResult.IsFinal);
+
+                var saveResult = _commands.Save(reopened);
+                Assert.True(saveResult.Success);
+            }
+            using var reopenedAgain = PresentationSession.BeginBatch(path);
+            var finalResult = _commands.GetFinal(reopenedAgain);
+            Assert.True(finalResult.Success);
+            Assert.Null(finalResult.ErrorMessage);
+            Assert.False(finalResult.IsFinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Open_ExistingFile_ReturnsSuccess_WithPresentationPath()
     {
         string path = CoreTestHelper.CreateUniqueTestFilePath();

--- a/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
@@ -280,6 +280,9 @@ public class PresentationCommandsTests
         {
             using (var batch = PresentationSession.CreateNew(path))
             {
+                var propertyResult = _commands.SetDocumentProperty(batch, "Title", "Saved before final");
+                Assert.True(propertyResult.Success);
+
                 var setResult = _commands.SetFinal(batch, true);
                 Assert.True(setResult.Success);
                 Assert.Null(setResult.ErrorMessage);
@@ -295,6 +298,10 @@ public class PresentationCommandsTests
                 Assert.True(getResult.Success);
                 Assert.Null(getResult.ErrorMessage);
                 Assert.True(getResult.IsFinal);
+
+                var propertyResult = _commands.GetDocumentProperty(reopened, "Title");
+                Assert.True(propertyResult.Success);
+                Assert.Equal("Saved before final", propertyResult.PropertyValue);
 
                 var clearResult = _commands.SetFinal(reopened, false);
                 Assert.True(clearResult.Success);

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -48,7 +48,7 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
     private static readonly HashSet<string> ExpectedToolNames =
     [
         // PresentationTools.cs (1, hand-written action-dispatch tool — session lifecycle,
-        // template, Mark as Final, and document properties; 14 actions)
+        // Save As/copy, template, Mark as Final, and document properties; 16 actions)
         "presentation",
         // Generated action-dispatch tools (14, one per remaining Core domain)
         "slide",

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System.IO.Pipelines;
+using System.Text.Json;
 using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 using Xunit.Abstractions;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tests.Integration;
@@ -46,7 +48,7 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
     private static readonly HashSet<string> ExpectedToolNames =
     [
         // PresentationTools.cs (1, hand-written action-dispatch tool — session lifecycle,
-        // template, and document properties; 12 actions)
+        // template, Mark as Final, and document properties; 14 actions)
         "presentation",
         // Generated action-dispatch tools (14, one per remaining Core domain)
         "slide",
@@ -215,6 +217,84 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
         Assert.Equal(
             new HashSet<string?> { "auto", "pptx", "pptm", "ppt" },
             formatValues);
+    }
+
+    [Fact]
+    public async Task PresentationSchema_ExposesFinalActionsAndAdvisoryContract()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var presentation = Assert.Single(tools, tool => tool.Name == "presentation");
+        var properties = presentation.JsonSchema.GetProperty("properties");
+        var actions = properties
+            .GetProperty("action")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(value => value.GetString())
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Contains("get-final", actions);
+        Assert.Contains("set-final", actions);
+
+        var isFinalSchema = properties.GetProperty("isFinal");
+        var isFinalTypes = isFinalSchema
+            .GetProperty("type")
+            .EnumerateArray()
+            .Select(value => value.GetString())
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("boolean", isFinalTypes);
+        Assert.Contains("null", isFinalTypes);
+
+        var contractText = $"{presentation.Description} {isFinalSchema.GetProperty("description").GetString()}";
+        Assert.Contains("advisory", contractText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not authentication", contractText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("encryption", contractText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("access control", contractText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PresentationFinalActions_RejectUnknownSessionsAndInapplicableParameters()
+    {
+        var unknownGet = await CallPresentationAsync(new()
+        {
+            ["action"] = "get-final",
+            ["sessionId"] = "missing-session"
+        });
+        Assert.False(unknownGet.GetProperty("success").GetBoolean());
+        Assert.Contains("Unknown sessionId", unknownGet.GetProperty("errorMessage").GetString());
+
+        var unknownSet = await CallPresentationAsync(new()
+        {
+            ["action"] = "set-final",
+            ["sessionId"] = "missing-session",
+            ["isFinal"] = true
+        });
+        Assert.False(unknownSet.GetProperty("success").GetBoolean());
+        Assert.Contains("Unknown sessionId", unknownSet.GetProperty("errorMessage").GetString());
+
+        var missingValue = await CallPresentationAsync(new()
+        {
+            ["action"] = "set-final",
+            ["sessionId"] = "missing-session"
+        });
+        Assert.False(missingValue.GetProperty("success").GetBoolean());
+        Assert.Contains("isFinal is required", missingValue.GetProperty("errorMessage").GetString());
+
+        var inapplicableValue = await CallPresentationAsync(new()
+        {
+            ["action"] = "get-final",
+            ["sessionId"] = "missing-session",
+            ["isFinal"] = false
+        });
+        Assert.False(inapplicableValue.GetProperty("success").GetBoolean());
+        Assert.Contains("not valid for action 'get-final'", inapplicableValue.GetProperty("errorMessage").GetString());
+    }
+
+    private async Task<JsonElement> CallPresentationAsync(Dictionary<string, object?> arguments)
+    {
+        var result = await _client!.CallToolAsync("presentation", arguments, cancellationToken: _cts.Token);
+        var text = Assert.Single(result.Content.OfType<TextContentBlock>()).Text;
+        using var json = JsonDocument.Parse(text);
+        return json.RootElement.Clone();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds PowerPoint's native Mark as Final support across Core, MCP, and CLI with strict parameter validation and persisted state round trips. Mark as Final is documented as an advisory editing flag, not authentication, encryption, or access control.

## Changes

- Add `presentation` actions `get-final` and `set-final` plus `pptcli session get-final` / `set-final` parity.
- Use the typed `_Presentation.Final` property and expose `isFinal` in operation results.
- Save pending edits before enabling Final; once PowerPoint makes the deck read-only, save-on-close succeeds as a no-op rather than calling the forbidden second `Save()`.
- Cover MCP/CLI schemas, routing, strict arguments, unknown sessions, and real-PowerPoint set/save/reopen/clear persistence.
- Preserve the merged Save As/Copy surface and reconcile documentation to 15 tools, 162 operations, and 16 presentation actions.
- Update skills, generated CLI guidance, docs, operation counts, and the native-feature audit.

## Testing

- Focused real-PowerPoint Final persistence round trip: 1/1 passed in 22s, including edits made before `set-final`, reopen/read `true`, clear/save, and reopen/read `false`.
- Full staged `scripts/pre-commit.ps1` gate: passed.
  - Release build: 0 warnings/errors.
  - Presentation real-COM tests: 36/36 passed.
  - MCP Server tests: 28/28 passed.
  - Release metadata and Agent Skills packaging tests: 65/65 passed.
  - COM cleanup, dynamic-cast, interface completeness, documentation-count, Success invariant, and TODO/FIXME/HACK checks passed.
- `npx changeset status --since=origin/main`: `powerpointmcp` minor bump validated.

## Changelog

- [x] I added a changeset (`npx changeset` from the repo root) describing this change for end users — see [`.changeset/README.md`](../.changeset/README.md).
- [ ] This PR doesn't need a changelog entry (docs-only, test-only, CI-only, or dependency-bump) — I added the `skip-changelog` label instead.