### PR TITLE
Add presentation Save As and Save Copy As

### DIFF
--- a/.changeset/bright-slides-save.md
+++ b/.changeset/bright-slides-save.md
@@ -1,10 +1,5 @@
 ---
-"Sbroenne.PowerPointMcp.Core": minor
-"Sbroenne.PowerPointMcp.ComInterop": minor
-"Sbroenne.PowerPointMcp.Service": minor
-"Sbroenne.PowerPointMcp.McpServer": minor
-"Sbroenne.PowerPointMcp.CLI": minor
-"Sbroenne.PowerPointMcp.Skill": minor
+"powerpointmcp": minor
 ---
 
 Add `save-as` and `save-copy-as` presentation operations to the MCP server and CLI. Save As moves

--- a/.changeset/bright-slides-save.md
+++ b/.changeset/bright-slides-save.md
@@ -1,0 +1,12 @@
+---
+"Sbroenne.PowerPointMcp.Core": minor
+"Sbroenne.PowerPointMcp.ComInterop": minor
+"Sbroenne.PowerPointMcp.Service": minor
+"Sbroenne.PowerPointMcp.McpServer": minor
+"Sbroenne.PowerPointMcp.CLI": minor
+"Sbroenne.PowerPointMcp.Skill": minor
+---
+
+Add `save-as` and `save-copy-as` presentation operations to the MCP server and CLI. Save As moves
+the active session to the new file only after PowerPoint succeeds, while Save Copy As preserves the
+active file and session path. Both operations validate formats, paths, and explicit overwrite intent.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ Unified Service Architecture.
 5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 15 tools
    total: one hand-written `presentation` action-dispatch tool plus 14 generated action-dispatch
    tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 158 operations
+   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 160 operations
    across 15 domains. See
    `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
    the ground-truth tool list.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**15 MCP tools with 158 operations across 15 domains:**
+**15 MCP tools with 160 operations across 15 domains:**
 
-- 🗂️ **Presentation** (12 ops) — create, open, save, close, list sessions, apply a `.potx`/`.pptx`
-  template's masters/theme/layouts, read the current theme name, read/write built-in and custom
-  document properties
+- 🗂️ **Presentation** (14 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
+  `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name, read/write built-in
+  and custom document properties
 - 📑 **Slide** (19 ops) — lifecycle, backgrounds, sections, comments, and slide import
 - ▭ **Shape** (39 ops) — shapes, styling, grouping, hyperlinks, and placeholder editing
 - ✏️ **TextFrame** (20 ops) — text, font size/name/color, bold, italic, underline, alignment, bullets

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This audit compares the current 15 tools and 158 operations with the restored
+This audit compares the current 15 tools and 160 operations with the restored
 `Microsoft.Office.Interop.PowerPoint` 15.0.4420.1018 assembly. It looks for useful PowerPoint
 features that fit the existing live-session model. It does not copy Excel-only worksheet, Power
 Query, Data Model, PivotTable, or calculation APIs.
@@ -35,25 +35,23 @@ The existing legacy comment operations are therefore correctly scoped.
 | 5 | Linked pictures | optional `link_to_file` on `image: add-picture`; `shape: get-link-info`, `update-link`, `break-link`, `set-link-auto-update` | Enables linked-asset workflows and repair | `LinkFormat` is valid only for linked shapes |
 | 6 | Audio and video | new `media` domain with `add-media`, `get-media-info` | Large PowerPoint-specific capability gap | Needs small licensed test fixtures and narrowly scoped Office enum handling |
 
-### 1. Save As and Save Copy As
+### 1. Save As and Save Copy As — implemented
 
 The restored PIA exposes:
 
 - `_Presentation.SaveAs(string, PpSaveAsFileType, MsoTriState)`
 - `_Presentation.SaveCopyAs(string, PpSaveAsFileType, MsoTriState)`
 
-All parameters after the file name are optional in the restored metadata. Use the typed
-`PpSaveAsFileType` enum and omit the Office enum unless font embedding is explicitly added later.
-If the compiler cannot bind `SaveCopyAs` without the Office assembly, keep any late-bound call
-limited to that one invocation and document the PIA limitation.
+The restored signatures include an optional `Office.MsoTriState` parameter, but this project does
+not reference `office.dll`, so the compiler cannot bind either method. The implementation keeps
+late binding limited to these two invocations, passes typed `PpSaveAsFileType` values, and leaves
+font embedding at PowerPoint's default.
 
-`save-as` changes the active file identity. Add an internal
-`IPresentationBatch.UpdatePresentationPath` operation, update it only after COM succeeds, and make
-the session registry report the new path. `save-copy-as` must leave the active session and original
-path unchanged. Both operations need extension/format validation and an overwrite guard before COM
-is called.
+`save-as` updates the batch and session registry path only after COM succeeds. `save-copy-as`
+preserves the active session and original path. Both operations validate supported extensions,
+format matches, destination directories, and overwrite intent before COM.
 
-Tests:
+Real-PowerPoint tests cover:
 
 - save as to `.pptx`, reopen the new path, and verify content
 - save copy, verify both files exist, and verify the session still points to the original

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 15 MCP tools with 158 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
+description: 15 MCP tools with 160 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
 keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **15 MCP tools with 158 operations across 15 domains**.
+PowerPoint MCP Server exposes **15 MCP tools with 160 operations across 15 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -20,7 +20,7 @@ The CLI mirrors the same domain model:
 
 | Tool | Ops | What it covers | MCP call shape | CLI shape |
 |------|-----|----------------|----------------|-----------|
-| `presentation` | 12 | Session lifecycle, open testing, template application, built-in/custom document properties | `presentation(action="...", ...)` | `pptcli session <action> ...` |
+| `presentation` | 14 | Session lifecycle, Save As/copy, open testing, template application, built-in/custom document properties | `presentation(action="...", ...)` | `pptcli session <action> ...` |
 | `slide` | 19 | Slide lifecycle, backgrounds, sections, comments, import | `slide(action="...", session_id=..., ...)` | `pptcli slide <action> -s <SESSION_ID> ...` |
 | `shape` | 39 | Shapes, styling, grouping, hyperlinks, placeholders | `shape(action="...", session_id=..., ...)` | `pptcli shape <action> -s <SESSION_ID> ...` |
 | `textframe` | 20 | Text content and text formatting | `textframe(action="...", session_id=..., ...)` | `pptcli textframe <action> -s <SESSION_ID> ...` |
@@ -38,9 +38,9 @@ The CLI mirrors the same domain model:
 
 ## Domain reference
 
-### `presentation` tool (12 operations)
+### `presentation` tool (14 operations)
 
-Use `presentation` for session lifecycle, templates/themes, and document properties.
+Use `presentation` for session lifecycle, Save As/copy, templates/themes, and document properties.
 `create` and `open` establish a session and return a `sessionId`; the remaining edit/read actions
 use that `sessionId`.
 
@@ -51,6 +51,8 @@ use that `sessionId`.
 | `close` | Close an open session, optionally saving first; PowerPoint shutdown continues in the background. |
 | `list` | List all currently open sessions. |
 | `test` | Check whether PowerPoint can open a file without retaining a live session. |
+| `save-as` | Save the active presentation under a new `.pptx`, `.pptm`, or `.ppt` path and update the session to that path. Existing files require `overwrite=true`. |
+| `save-copy-as` | Save a copy using the active presentation's current format without changing the active presentation or session path. Existing files require `overwrite=true`. |
 | `apply-template` | Apply a `.potx`/`.potm`/`.pot` or `.pptx`/`.pptm` template source while preserving slide content. |
 | `get-theme-name` | Read the currently applied design/theme name. |
 | `set-document-property` | Set a built-in document metadata property such as Title or Author. |
@@ -59,9 +61,9 @@ use that `sessionId`.
 | `get-custom-property` | Read a custom document property. |
 | `remove-custom-property` | Remove a custom document property. |
 
-**Exact action order:** `create`, `open`, `close`, `list`, `test`, `apply-template`,
-`get-theme-name`, `set-document-property`, `get-document-property`, `set-custom-property`,
-`get-custom-property`, `remove-custom-property`
+**Exact action order:** `create`, `open`, `close`, `list`, `test`, `save-as`, `save-copy-as`,
+`apply-template`, `get-theme-name`, `set-document-property`, `get-document-property`,
+`set-custom-property`, `get-custom-property`, `remove-custom-property`
 
 ### `slide` tool (19 operations)
 

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -100,7 +100,7 @@ hide:
 
 </div>
 
-[See all 15 tools (158 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 15 tools (160 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 15 tools (158 operations) across 15 domains
+- [Complete Feature Reference](features.md) — all 15 tools (160 operations) across 15 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 158 operations across 15 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 160 operations across 15 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -18,7 +18,7 @@ Claude can now create and edit PowerPoint decks directly.
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
 required) plus the manifest, license, and changelog. The server exposes 15
-tools (158 operations across 15 domains) — see the
+tools (160 operations across 15 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 
 ## Building locally

--- a/skills/powerpoint-cli/references/behavioral-rules.md
+++ b/skills/powerpoint-cli/references/behavioral-rules.md
@@ -42,7 +42,7 @@ Every editing workflow starts by establishing a session:
 
 - **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
-  `templatePath`, `propertyName`, `value`.
+  `targetPath`, `format`, `overwrite`, `templatePath`, `propertyName`, `value`.
 - **The other 14 domain tools use `session_id` plus snake_case action parameters**, e.g.
   `shape(action: "add-rectangle", session_id: ..., slide_index: 1, left: 50, top: 80, width: 100,
   height: 60)`.
@@ -72,6 +72,14 @@ all changes since the last save.
 2. textframe(action: "set-text", session_id: ..., slide_index: ..., shape_index: ...) → text set in memory
 3. presentation(action: "close", sessionId: ..., save: true)                         → persisted and closed
 ```
+
+`save-as` and `save-copy-as` are explicit delivery operations, not a generic save action:
+
+- `save-as` writes `.pptx`, `.pptm`, or `.ppt`, then changes the active session path only after
+  PowerPoint succeeds.
+- `save-copy-as` requires the destination extension to match the active presentation and leaves
+  the active session path unchanged.
+- Both reject an existing destination unless `overwrite: true` is supplied.
 
 ## Close Is Asynchronous (Do NOT Wait For It)
 

--- a/skills/powerpoint-cli/references/cli-commands.md
+++ b/skills/powerpoint-cli/references/cli-commands.md
@@ -494,8 +494,8 @@ OPTIONS:
 
 ```text
 DESCRIPTION:
-Open, create, close, test, or list presentation sessions held by the daemon;
-apply templates and read/write document properties
+Open, create, close, test, Save As/copy, or list presentation sessions held by
+the daemon; apply templates and read/write document properties
 
 USAGE:
     pptcli session [OPTIONS] <COMMAND>
@@ -528,6 +528,20 @@ COMMANDS:
                                                                   without
                                                                   retaining a
                                                                   session
+    save-as <SESSION_ID> <TARGET_PATH>                            Save the
+                                                                  active
+                                                                  presentation
+                                                                  under a new
+                                                                  path and move
+                                                                  the session to
+                                                                  it
+    save-copy-as <SESSION_ID> <TARGET_PATH>                       Save a copy
+                                                                  without
+                                                                  changing the
+                                                                  active
+                                                                  presentation
+                                                                  or session
+                                                                  path
     apply-template <SESSION_ID> <TEMPLATE_PATH>                   Apply a
                                                                   template's
                                                                   masters/theme/

--- a/skills/powerpoint-cli/references/workflows.md
+++ b/skills/powerpoint-cli/references/workflows.md
@@ -2,7 +2,7 @@
 
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 158 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 160 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation
@@ -46,8 +46,12 @@ to support this loop for one of two starting points: a brand-new deck or an exis
   writes.
 - **Batch text + formatting per shape.** For a given shape, call `textframe(action: "set-text",
   ...)`, then `set-font-size`/`set-bold`/`set-font-color` as needed.
-- **Choose save behavior at close.** There is no standalone save action; render and inspect the
-  finished work, then close once with `save: true` or discard with `save: false`.
+- **Choose the right persistence action.** There is no standalone generic save action. Use
+  `presentation(action: "save-as", sessionId: ..., targetPath: ..., format: "auto",
+  overwrite: false)` when the active presentation should move to a new path. Use
+  `presentation(action: "save-copy-as", sessionId: ..., targetPath: ..., overwrite: false)` when
+  the active presentation and session path must remain unchanged. Otherwise, render and inspect
+  the finished work, then close once with `save: true` or discard with `save: false`.
 
 ## The Discovery Actions
 

--- a/skills/powerpoint-mcp/references/behavioral-rules.md
+++ b/skills/powerpoint-mcp/references/behavioral-rules.md
@@ -40,7 +40,7 @@ Every editing workflow starts by establishing a session:
 
 - **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
-  `templatePath`, `propertyName`, `value`.
+  `targetPath`, `format`, `overwrite`, `templatePath`, `propertyName`, `value`.
 - **The other 14 domain tools use `session_id` plus snake_case action parameters**, e.g.
   `shape(action: "add-rectangle", session_id: ..., slide_index: 1, left: 50, top: 80, width: 100,
   height: 60)`.
@@ -70,6 +70,14 @@ all changes since the last save.
 2. textframe(action: "set-text", session_id: ..., slide_index: ..., shape_index: ...) → text set in memory
 3. presentation(action: "close", sessionId: ..., save: true)                         → persisted and closed
 ```
+
+`save-as` and `save-copy-as` are explicit delivery operations, not a generic save action:
+
+- `save-as` writes `.pptx`, `.pptm`, or `.ppt`, then changes the active session path only after
+  PowerPoint succeeds.
+- `save-copy-as` requires the destination extension to match the active presentation and leaves
+  the active session path unchanged.
+- Both reject an existing destination unless `overwrite: true` is supplied.
 
 ## Close Is Asynchronous (Do NOT Wait For It)
 

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 158 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 160 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation
@@ -44,8 +44,12 @@ to support this loop for one of two starting points: a brand-new deck or an exis
   writes.
 - **Batch text + formatting per shape.** For a given shape, call `textframe(action: "set-text",
   ...)`, then `set-font-size`/`set-bold`/`set-font-color` as needed.
-- **Choose save behavior at close.** There is no standalone save action; render and inspect the
-  finished work, then close once with `save: true` or discard with `save: false`.
+- **Choose the right persistence action.** There is no standalone generic save action. Use
+  `presentation(action: "save-as", sessionId: ..., targetPath: ..., format: "auto",
+  overwrite: false)` when the active presentation should move to a new path. Use
+  `presentation(action: "save-copy-as", sessionId: ..., targetPath: ..., overwrite: false)` when
+  the active presentation and session path must remain unchanged. Otherwise, render and inspect
+  the finished work, then close once with `save: true` or discard with `save: false`.
 
 ## The Discovery Actions
 

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -40,7 +40,7 @@ Every editing workflow starts by establishing a session:
 
 - **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
-  `templatePath`, `propertyName`, `value`.
+  `targetPath`, `format`, `overwrite`, `templatePath`, `propertyName`, `value`.
 - **The other 14 domain tools use `session_id` plus snake_case action parameters**, e.g.
   `shape(action: "add-rectangle", session_id: ..., slide_index: 1, left: 50, top: 80, width: 100,
   height: 60)`.
@@ -70,6 +70,14 @@ all changes since the last save.
 2. textframe(action: "set-text", session_id: ..., slide_index: ..., shape_index: ...) → text set in memory
 3. presentation(action: "close", sessionId: ..., save: true)                         → persisted and closed
 ```
+
+`save-as` and `save-copy-as` are explicit delivery operations, not a generic save action:
+
+- `save-as` writes `.pptx`, `.pptm`, or `.ppt`, then changes the active session path only after
+  PowerPoint succeeds.
+- `save-copy-as` requires the destination extension to match the active presentation and leaves
+  the active session path unchanged.
+- Both reject an existing destination unless `overwrite: true` is supplied.
 
 ## Close Is Asynchronous (Do NOT Wait For It)
 

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 158 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 160 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation
@@ -44,8 +44,12 @@ to support this loop for one of two starting points: a brand-new deck or an exis
   writes.
 - **Batch text + formatting per shape.** For a given shape, call `textframe(action: "set-text",
   ...)`, then `set-font-size`/`set-bold`/`set-font-color` as needed.
-- **Choose save behavior at close.** There is no standalone save action; render and inspect the
-  finished work, then close once with `save: true` or discard with `save: false`.
+- **Choose the right persistence action.** There is no standalone generic save action. Use
+  `presentation(action: "save-as", sessionId: ..., targetPath: ..., format: "auto",
+  overwrite: false)` when the active presentation should move to a new path. Use
+  `presentation(action: "save-copy-as", sessionId: ..., targetPath: ..., overwrite: false)` when
+  the active presentation and session path must remain unchanged. Otherwise, render and inspect
+  the finished work, then close once with `save: true` or discard with `save: false`.
 
 ## The Discovery Actions
 

--- a/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
+++ b/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using Sbroenne.PowerPointMcp.CLI.Infrastructure;
+using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Service;
 using Spectre.Console.Cli;
 
@@ -129,6 +130,76 @@ internal sealed class SessionTestCommand : AsyncCommand<SessionOpenSettings>
         Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
         return 0;
     }
+}
+
+/// <summary>Settings for the "session save-as" command.</summary>
+internal sealed class SessionSaveAsSettings : CommandSettings
+{
+    [CommandArgument(0, "<SESSION_ID>")]
+    [Description("Session id returned by 'session open'/'session create'.")]
+    public string SessionId { get; init; } = string.Empty;
+
+    [CommandArgument(1, "<TARGET_PATH>")]
+    [Description("Full destination path in an existing directory.")]
+    public string TargetPath { get; init; } = string.Empty;
+
+    [CommandOption("--format")]
+    [Description("Output format: auto, pptx, pptm, or ppt. Default: auto.")]
+    public PresentationSaveFormat Format { get; init; } = PresentationSaveFormat.Auto;
+
+    [CommandOption("--overwrite")]
+    [Description("Replace an existing destination file.")]
+    public bool Overwrite { get; init; }
+}
+
+/// <summary>Settings for the "session save-copy-as" command.</summary>
+internal sealed class SessionSaveCopyAsSettings : CommandSettings
+{
+    [CommandArgument(0, "<SESSION_ID>")]
+    [Description("Session id returned by 'session open'/'session create'.")]
+    public string SessionId { get; init; } = string.Empty;
+
+    [CommandArgument(1, "<TARGET_PATH>")]
+    [Description("Full destination path in an existing directory.")]
+    public string TargetPath { get; init; } = string.Empty;
+
+    [CommandOption("--overwrite")]
+    [Description("Replace an existing destination file.")]
+    public bool Overwrite { get; init; }
+}
+
+/// <summary>Saves the active presentation under a new path and moves the session to it.</summary>
+internal sealed class SessionSaveAsCommand : AsyncCommand<SessionSaveAsSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(
+        CommandContext context,
+        SessionSaveAsSettings settings,
+        CancellationToken cancellationToken)
+        => await SessionCommandHelpers.SendSaveCommandAsync(
+            "session.save-as",
+            settings.SessionId,
+            settings.TargetPath,
+            settings.Format,
+            settings.Overwrite,
+            cancellationToken);
+}
+
+/// <summary>Saves a copy without changing the active presentation or session path.</summary>
+internal sealed class SessionSaveCopyAsCommand : AsyncCommand<SessionSaveCopyAsSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(
+        CommandContext context,
+        SessionSaveCopyAsSettings settings,
+        CancellationToken cancellationToken)
+        => await SessionCommandHelpers.SendSaveCommandAsync(
+            "session.save-copy-as",
+            settings.SessionId,
+            settings.TargetPath,
+            format: null,
+            settings.Overwrite,
+            cancellationToken);
 }
 
 /// <summary>Settings for the "session apply-template" command.</summary>
@@ -263,6 +334,34 @@ internal sealed class SessionRemoveCustomPropertyCommand : AsyncCommand<SessionP
 /// <summary>Shared daemon round-trip logic for the document/custom-property session commands.</summary>
 internal static class SessionCommandHelpers
 {
+    public static async Task<int> SendSaveCommandAsync(
+        string command,
+        string sessionId,
+        string targetPath,
+        PresentationSaveFormat? format,
+        bool overwrite,
+        CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = command,
+            SessionId = sessionId,
+            Args = JsonSerializer.Serialize(
+                new { targetPath, format, overwrite },
+                ServiceProtocol.JsonOptions),
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+
     public static async Task<int> SendPropertyCommandAsync(string command, string sessionId, string propertyName, string? value, CancellationToken cancellationToken)
     {
         using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);

--- a/src/PowerPointMcp.CLI/Program.cs
+++ b/src/PowerPointMcp.CLI/Program.cs
@@ -29,12 +29,14 @@ public static class Program
 
             config.AddBranch("session", session =>
             {
-                session.SetDescription("Open, create, close, test, or list presentation sessions held by the daemon; apply templates and read/write document properties.");
+                session.SetDescription("Open, create, close, test, Save As/copy, or list presentation sessions held by the daemon; apply templates and read/write document properties.");
                 session.AddCommand<SessionOpenCommand>("open").WithDescription("Open an existing presentation and return a session id.");
                 session.AddCommand<SessionCreateCommand>("create").WithDescription("Create a new presentation and return a session id.");
                 session.AddCommand<SessionCloseCommand>("close").WithDescription("Close a session, optionally saving first.");
                 session.AddCommand<SessionListCommand>("list").WithDescription("List every session currently open in the daemon.");
                 session.AddCommand<SessionTestCommand>("test").WithDescription("Validate that PowerPoint can open a presentation without retaining a session.");
+                session.AddCommand<SessionSaveAsCommand>("save-as").WithDescription("Save the active presentation under a new path and move the session to it.");
+                session.AddCommand<SessionSaveCopyAsCommand>("save-copy-as").WithDescription("Save a copy without changing the active presentation or session path.");
                 session.AddCommand<SessionApplyTemplateCommand>("apply-template").WithDescription("Apply a template's masters/theme/layouts to the open presentation, preserving slide content.");
                 session.AddCommand<SessionGetThemeNameCommand>("get-theme-name").WithDescription("Read the design/theme name currently applied to the open presentation.");
                 session.AddCommand<SessionSetDocumentPropertyCommand>("set-document-property").WithDescription("Set a built-in document metadata property (Title, Subject, Author, Keywords, Comments, Category, Manager, Company).");

--- a/src/PowerPointMcp.ComInterop/Session/IPresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/IPresentationBatch.cs
@@ -41,6 +41,13 @@ public interface IPresentationBatch : IDisposable
     /// </summary>
     void Save(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Updates the tracked presentation path after PowerPoint Save As changes the active file
+    /// identity.
+    /// </summary>
+    /// <param name="presentationPath">New absolute presentation path.</param>
+    void UpdatePresentationPath(string presentationPath);
+
     /// <summary>Checks if the underlying PowerPoint process is still alive.</summary>
     bool IsPowerPointProcessAlive();
 

--- a/src/PowerPointMcp.ComInterop/Session/IPresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/IPresentationBatch.cs
@@ -43,7 +43,9 @@ public interface IPresentationBatch : IDisposable
 
     /// <summary>
     /// Updates the tracked presentation path after PowerPoint Save As changes the active file
-    /// identity.
+    /// identity. Must be called from inside this batch's serialized <see cref="Execute(Action{PresentationContext, CancellationToken}, CancellationToken)"/>
+    /// or <see cref="Execute{T}(Func{PresentationContext, CancellationToken, T}, CancellationToken)"/>
+    /// callback immediately after the COM operation succeeds.
     /// </summary>
     /// <param name="presentationPath">New absolute presentation path.</param>
     void UpdatePresentationPath(string presentationPath);

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -544,6 +544,11 @@ internal sealed class PresentationBatch : IPresentationBatch
     {
         ObjectDisposedException.ThrowIf(_disposed != 0, nameof(PresentationBatch));
         ArgumentException.ThrowIfNullOrWhiteSpace(presentationPath);
+        if (Thread.CurrentThread != _staThread)
+        {
+            throw new InvalidOperationException(
+                "Presentation path updates must run inside this batch's serialized Execute callback.");
+        }
 
         string normalizedPath = Path.GetFullPath(presentationPath);
         var context = _context;

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -434,7 +434,7 @@ internal sealed class PresentationBatch : IPresentationBatch
         }
     }
 
-    public string PresentationPath => _presentationPath;
+    public string PresentationPath => Volatile.Read(ref _presentationPath);
 
     public bool HasTimedOutOperation => _operationTimedOut;
 
@@ -538,6 +538,23 @@ internal sealed class PresentationBatch : IPresentationBatch
             ctx.Presentation.Save();
             return 0;
         }, cancellationToken);
+    }
+
+    public void UpdatePresentationPath(string presentationPath)
+    {
+        ObjectDisposedException.ThrowIf(_disposed != 0, nameof(PresentationBatch));
+        ArgumentException.ThrowIfNullOrWhiteSpace(presentationPath);
+
+        string normalizedPath = Path.GetFullPath(presentationPath);
+        var context = _context;
+        if (context != null)
+        {
+            Volatile.Write(
+                ref _context,
+                new PresentationContext(normalizedPath, context.App, context.Presentation));
+        }
+
+        Volatile.Write(ref _presentationPath, normalizedPath);
     }
 
     /// <summary>

--- a/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
@@ -3,7 +3,7 @@ using Sbroenne.PowerPointMcp.ComInterop.Session;
 namespace Sbroenne.PowerPointMcp.Core.Presentation;
 
 /// <summary>
-/// Presentation lifecycle commands: create, close, save.
+/// Presentation lifecycle commands: create, open, save, Save As, and Save Copy As.
 /// </summary>
 /// <remarks>
 /// First Core command domain implemented, proving the ComInterop batch pattern end-to-end.
@@ -52,6 +52,25 @@ public interface IPresentationCommands
     /// Saves the presentation currently open in the given batch.
     /// </summary>
     PresentationOperationResult Save(IPresentationBatch batch);
+
+    /// <summary>
+    /// Saves the active presentation under a new path and format, then moves the active session
+    /// to that path.
+    /// </summary>
+    PresentationOperationResult SaveAs(
+        IPresentationBatch batch,
+        string targetPath,
+        PresentationSaveFormat format = PresentationSaveFormat.Auto,
+        bool overwrite = false);
+
+    /// <summary>
+    /// Saves a copy without changing the active presentation or session path. The output extension
+    /// must match the active presentation.
+    /// </summary>
+    PresentationOperationResult SaveCopyAs(
+        IPresentationBatch batch,
+        string targetPath,
+        bool overwrite = false);
 
     /// <summary>
     /// Applies a PowerPoint template's masters/theme/layouts to the presentation currently open

--- a/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
@@ -75,6 +75,263 @@ public sealed class PresentationCommands : IPresentationCommands
         };
     }
 
+    /// <inheritdoc/>
+    public PresentationOperationResult SaveAs(
+        IPresentationBatch batch,
+        string targetPath,
+        PresentationSaveFormat format = PresentationSaveFormat.Auto,
+        bool overwrite = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        var pathValidation = ValidateOutputPath(batch, targetPath, overwrite);
+        if (pathValidation.Error != null)
+        {
+            return pathValidation.Error;
+        }
+
+        string normalizedPath = pathValidation.Path!;
+        PresentationSaveFormat? resolvedFormat = ResolveSaveFormat(normalizedPath, format);
+        if (resolvedFormat == null)
+        {
+            return ValidationError(
+                batch,
+                $"Cannot infer a supported presentation format from extension '{Path.GetExtension(normalizedPath)}'. Supported extensions: .pptx, .pptm, .ppt.");
+        }
+
+        var extensionError = ValidateSaveExtension(batch, normalizedPath, resolvedFormat);
+        if (extensionError != null)
+        {
+            return extensionError;
+        }
+
+        var result = batch.Execute((ctx, ct) =>
+        {
+            // PIA gap: the restored typed SaveAs method exposes an optional Office.MsoTriState
+            // parameter, but this project intentionally does not reference office.dll. Keep late
+            // binding limited to this invocation while still passing typed PpSaveAsFileType.
+            ((dynamic)ctx.Presentation).SaveAs(
+                normalizedPath,
+                ToPowerPointFileType(resolvedFormat.Value));
+
+            batch.UpdatePresentationPath(normalizedPath);
+            return new PresentationOperationResult
+            {
+                Success = true,
+                PresentationPath = normalizedPath
+            };
+        });
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public PresentationOperationResult SaveCopyAs(
+        IPresentationBatch batch,
+        string targetPath,
+        bool overwrite = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        var pathValidation = ValidateOutputPath(batch, targetPath, overwrite);
+        if (pathValidation.Error != null)
+        {
+            return pathValidation.Error;
+        }
+
+        string normalizedPath = pathValidation.Path!;
+        string outputExtension = Path.GetExtension(normalizedPath);
+        PresentationSaveFormat? format = ResolveSaveFormat(
+            normalizedPath,
+            PresentationSaveFormat.Auto);
+        if (format == null)
+        {
+            return ValidationError(
+                batch,
+                $"Save Copy As does not support presentation extension '{outputExtension}'. Supported extensions: .pptx, .pptm, .ppt.");
+        }
+
+        string writePath = GetWritePath(normalizedPath, overwrite);
+        try
+        {
+            var result = batch.Execute((ctx, ct) =>
+            {
+                string currentExtension = Path.GetExtension(batch.PresentationPath);
+                if (!string.Equals(currentExtension, outputExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return ValidationError(
+                        batch,
+                        $"Save Copy As preserves the current presentation format. Output extension must be '{currentExtension}'.");
+                }
+
+                // PIA gap: the restored typed SaveCopyAs method exposes an optional
+                // Office.MsoTriState parameter, but this project intentionally does not reference
+                // office.dll. Keep late binding limited to this invocation while still passing
+                // typed PpSaveAsFileType.
+                ((dynamic)ctx.Presentation).SaveCopyAs(
+                    writePath,
+                    ToPowerPointFileType(format.Value));
+
+                return new PresentationOperationResult
+                {
+                    Success = true,
+                    PresentationPath = normalizedPath
+                };
+            });
+
+            if (!result.Success)
+            {
+                return result;
+            }
+
+            CommitOutput(writePath, normalizedPath);
+            return result;
+        }
+        finally
+        {
+            DeleteTemporaryOutput(writePath, normalizedPath);
+        }
+    }
+
+    private static (string? Path, PresentationOperationResult? Error) ValidateOutputPath(
+        IPresentationBatch batch,
+        string targetPath,
+        bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            return (null, ValidationError(batch, "A destination path is required."));
+        }
+
+        string normalizedPath;
+        try
+        {
+            normalizedPath = Path.GetFullPath(targetPath);
+        }
+        catch (ArgumentException)
+        {
+            return (null, ValidationError(batch, $"Invalid destination path: '{targetPath}'."));
+        }
+        catch (NotSupportedException)
+        {
+            return (null, ValidationError(batch, $"Invalid destination path: '{targetPath}'."));
+        }
+        catch (PathTooLongException)
+        {
+            return (null, ValidationError(batch, $"Destination path is too long: '{targetPath}'."));
+        }
+
+        string? directory = Path.GetDirectoryName(normalizedPath);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            return (null, ValidationError(batch, $"Destination directory does not exist: '{directory}'."));
+        }
+
+        if (Directory.Exists(normalizedPath))
+        {
+            return (null, ValidationError(batch, $"Destination path is a directory: '{normalizedPath}'."));
+        }
+
+        if (File.Exists(normalizedPath) && !overwrite)
+        {
+            return (null, ValidationError(batch, $"Destination file already exists: '{normalizedPath}'. Set overwrite=true to replace it."));
+        }
+
+        return (normalizedPath, null);
+    }
+
+    private static PresentationSaveFormat? ResolveSaveFormat(
+        string outputPath,
+        PresentationSaveFormat format)
+    {
+        if (format != PresentationSaveFormat.Auto)
+        {
+            return Enum.IsDefined(format) ? format : null;
+        }
+
+        return Path.GetExtension(outputPath).ToLowerInvariant() switch
+        {
+            ".pptx" => PresentationSaveFormat.Pptx,
+            ".pptm" => PresentationSaveFormat.Pptm,
+            ".ppt" => PresentationSaveFormat.Ppt,
+            _ => null
+        };
+    }
+
+    private static PresentationOperationResult? ValidateSaveExtension(
+        IPresentationBatch batch,
+        string outputPath,
+        PresentationSaveFormat? format)
+    {
+        string expectedExtension = format switch
+        {
+            PresentationSaveFormat.Pptx => ".pptx",
+            PresentationSaveFormat.Pptm => ".pptm",
+            PresentationSaveFormat.Ppt => ".ppt",
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported Save As format.")
+        };
+
+        return string.Equals(
+            Path.GetExtension(outputPath),
+            expectedExtension,
+            StringComparison.OrdinalIgnoreCase)
+            ? null
+            : ValidationError(
+                batch,
+                $"Save As format '{format}' requires the '{expectedExtension}' file extension.");
+    }
+
+    private static PowerPoint.PpSaveAsFileType ToPowerPointFileType(PresentationSaveFormat format)
+    {
+        return format switch
+        {
+            PresentationSaveFormat.Pptx => PowerPoint.PpSaveAsFileType.ppSaveAsOpenXMLPresentation,
+            PresentationSaveFormat.Pptm => PowerPoint.PpSaveAsFileType.ppSaveAsOpenXMLPresentationMacroEnabled,
+            PresentationSaveFormat.Ppt => PowerPoint.PpSaveAsFileType.ppSaveAsPresentation,
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported Save As format.")
+        };
+    }
+
+    private static string GetWritePath(string normalizedPath, bool overwrite)
+    {
+        if (!overwrite || !File.Exists(normalizedPath))
+        {
+            return normalizedPath;
+        }
+
+        string directory = Path.GetDirectoryName(normalizedPath)!;
+        string fileName = Path.GetFileNameWithoutExtension(normalizedPath);
+        string extension = Path.GetExtension(normalizedPath);
+        return Path.Combine(directory, $".{fileName}.{Guid.NewGuid():N}.tmp{extension}");
+    }
+
+    private static void CommitOutput(string writePath, string normalizedPath)
+    {
+        if (!string.Equals(writePath, normalizedPath, StringComparison.OrdinalIgnoreCase))
+        {
+            File.Move(writePath, normalizedPath, overwrite: true);
+        }
+    }
+
+    private static void DeleteTemporaryOutput(string writePath, string normalizedPath)
+    {
+        if (!string.Equals(writePath, normalizedPath, StringComparison.OrdinalIgnoreCase) &&
+            File.Exists(writePath))
+        {
+            File.Delete(writePath);
+        }
+    }
+
+    private static PresentationOperationResult ValidationError(
+        IPresentationBatch batch,
+        string message)
+        => new()
+        {
+            Success = false,
+            ErrorMessage = message,
+            PresentationPath = batch.PresentationPath
+        };
+
     private static readonly string[] AcceptedTemplateExtensions = [".potx", ".potm", ".pot", ".pptx", ".pptm", ".ppt"];
 
     /// <inheritdoc/>

--- a/src/PowerPointMcp.Core/Presentation/PresentationSaveFormat.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationSaveFormat.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Sbroenne.PowerPointMcp.Core.Presentation;
+
+/// <summary>Supported presentation formats for Save As.</summary>
+public enum PresentationSaveFormat
+{
+    /// <summary>Infer the format from the destination extension.</summary>
+    [JsonStringEnumMemberName("auto")]
+    Auto,
+
+    /// <summary>Open XML presentation (.pptx).</summary>
+    [JsonStringEnumMemberName("pptx")]
+    Pptx,
+
+    /// <summary>Macro-enabled Open XML presentation (.pptm).</summary>
+    [JsonStringEnumMemberName("pptm")]
+    Pptm,
+
+    /// <summary>Legacy binary presentation (.ppt).</summary>
+    [JsonStringEnumMemberName("ppt")]
+    Ppt
+}

--- a/src/PowerPointMcp.Core/Presentation/PresentationToolAction.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationToolAction.cs
@@ -39,6 +39,14 @@ public enum PresentationToolAction
     [JsonStringEnumMemberName("test")]
     Test,
 
+    /// <summary>Save the active presentation under a new path and move the session to it.</summary>
+    [JsonStringEnumMemberName("save-as")]
+    SaveAs,
+
+    /// <summary>Save a copy without changing the active presentation or session path.</summary>
+    [JsonStringEnumMemberName("save-copy-as")]
+    SaveCopyAs,
+
     /// <summary>Apply a template's masters/theme/layouts to the open presentation.</summary>
     [JsonStringEnumMemberName("apply-template")]
     ApplyTemplate,
@@ -82,6 +90,8 @@ public static class PresentationToolActionExtensions
         PresentationToolAction.Close => "close",
         PresentationToolAction.List => "list",
         PresentationToolAction.Test => "test",
+        PresentationToolAction.SaveAs => "save-as",
+        PresentationToolAction.SaveCopyAs => "save-copy-as",
         PresentationToolAction.ApplyTemplate => "apply-template",
         PresentationToolAction.GetThemeName => "get-theme-name",
         PresentationToolAction.SetDocumentProperty => "set-document-property",

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,11 +32,11 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**15 tools with 158 operations across 15 domains:**
+**15 tools with 160 operations across 15 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
-| `presentation` | 12 | create, open, save, close, list, apply-template, get-theme-name, built-in/custom document properties |
+| `presentation` | 14 | create, open, Save As, Save Copy As, close, list, apply-template, get-theme-name, built-in/custom document properties |
 | `slide` | 19 | slide lifecycle, backgrounds, sections, comments, slide import |
 | `shape` | 39 | shape creation, styling, grouping, hyperlinks, placeholders |
 | `textframe` | 20 | text content, font formatting, alignment, bullets, auto-size |

--- a/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
@@ -33,20 +33,23 @@ public static class PresentationTools
     /// or about-to-be-opened presentation.
     /// </summary>
     [McpServerTool(Name = "presentation")]
-    [Description("Presentation lifecycle (create, open, close, list sessions, test), template restyling (apply-template, get-theme-name), and document-property (built-in and custom) operations. Actions: create, open, close, list, test, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")]
+    [Description("Presentation lifecycle (create, open, close, list sessions, test), Save As/copy, template restyling (apply-template, get-theme-name), and document-property (built-in and custom) operations. Actions: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")]
     public static string Presentation(
-        [Description("The action to perform. One of: create, open, close, list, test, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] PresentationToolAction action,
+        [Description("The action to perform. One of: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] PresentationToolAction action,
         [Description("Full Windows path to the presentation file. Required for: create (new .pptx/.pptm file; containing directory must already exist), open or test (existing .pptx/.pptm/.ppt file).")] string? filePath = null,
-        [Description("The sessionId returned by create or open. Required for: close, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? sessionId = null,
+        [Description("The sessionId returned by create or open. Required for: close, save-as, save-copy-as, apply-template, get-theme-name, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? sessionId = null,
         [Description("Save the presentation before closing. Used for: close. Default: false.")] bool? save = null,
         [Description("Set true only when creating a macro-enabled .pptm file. Default: false. Used for: create.")] bool? isMacroEnabled = null,
+        [Description("Full Windows destination path. Required for: save-as, save-copy-as. The containing directory must already exist.")] string? targetPath = null,
+        [Description("Output format for save-as: auto, pptx, pptm, or ppt. Default: auto infers from targetPath.")] PresentationSaveFormat? format = null,
+        [Description("Whether an existing destination file may be replaced. Used for: save-as, save-copy-as. Default: false.")] bool? overwrite = null,
         [Description("Full Windows path to a .potx/.potm/.pot template file (a .pptx/.pptm presentation may also be used as a template source). Required for: apply-template.")] string? templatePath = null,
         [Description("Document property name. For set/get-document-property, one of: Title, Subject, Author, Keywords, Comments, Category, Manager, Company (case-insensitive). For custom-property actions, any user-defined name. Required for: set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? propertyName = null,
         [Description("The new property value. Required for: set-document-property, set-custom-property.")] string? value = null,
         PresentationSessionRegistry? registry = null)
         => PowerPointToolsBase.ExecuteToolAction("presentation", action.ToActionString(), () =>
         {
-            ValidateActionParameters(action, filePath, sessionId, save, isMacroEnabled, templatePath, propertyName, value);
+            ValidateActionParameters(action, filePath, sessionId, save, isMacroEnabled, targetPath, format, overwrite, templatePath, propertyName, value);
             var reg = registry!;
             return action switch
             {
@@ -55,6 +58,8 @@ public static class PresentationTools
                 PresentationToolAction.Close => HandleClose(sessionId, save == true, reg),
                 PresentationToolAction.List => HandleList(reg),
                 PresentationToolAction.Test => HandleTest(filePath),
+                PresentationToolAction.SaveAs => HandleSaveAs(sessionId, targetPath, format, overwrite == true, reg),
+                PresentationToolAction.SaveCopyAs => HandleSaveCopyAs(sessionId, targetPath, overwrite == true, reg),
                 PresentationToolAction.ApplyTemplate => HandleApplyTemplate(sessionId, templatePath, reg),
                 PresentationToolAction.GetThemeName => HandleGetThemeName(sessionId, reg),
                 PresentationToolAction.SetDocumentProperty => HandleSetDocumentProperty(sessionId, propertyName, value, reg),
@@ -72,6 +77,9 @@ public static class PresentationTools
         string? sessionId,
         bool? save,
         bool? isMacroEnabled,
+        string? targetPath,
+        PresentationSaveFormat? format,
+        bool? overwrite,
         string? templatePath,
         string? propertyName,
         string? value)
@@ -81,6 +89,9 @@ public static class PresentationTools
         if (sessionId != null) supplied.Add("sessionId");
         if (save != null) supplied.Add("save");
         if (isMacroEnabled != null) supplied.Add("isMacroEnabled");
+        if (targetPath != null) supplied.Add("targetPath");
+        if (format != null) supplied.Add("format");
+        if (overwrite != null) supplied.Add("overwrite");
         if (templatePath != null) supplied.Add("templatePath");
         if (propertyName != null) supplied.Add("propertyName");
         if (value != null) supplied.Add("value");
@@ -90,6 +101,8 @@ public static class PresentationTools
             PresentationToolAction.Create => ["filePath", "isMacroEnabled"],
             PresentationToolAction.Open or PresentationToolAction.Test => ["filePath"],
             PresentationToolAction.Close => ["sessionId", "save"],
+            PresentationToolAction.SaveAs => ["sessionId", "targetPath", "format", "overwrite"],
+            PresentationToolAction.SaveCopyAs => ["sessionId", "targetPath", "overwrite"],
             PresentationToolAction.ApplyTemplate => ["sessionId", "templatePath"],
             PresentationToolAction.GetThemeName => ["sessionId"],
             PresentationToolAction.SetDocumentProperty or PresentationToolAction.SetCustomProperty => ["sessionId", "propertyName", "value"],
@@ -226,6 +239,49 @@ public static class PresentationTools
         }
 
         return SerializeResult(Commands.Open(filePath));
+    }
+
+    private static string HandleSaveAs(
+        string? sessionId,
+        string? targetPath,
+        PresentationSaveFormat? format,
+        bool overwrite,
+        PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            return PowerPointToolsBase.ValidationError("targetPath is required for action=save-as.");
+        }
+
+        return SerializeResult(Commands.SaveAs(
+            batch,
+            targetPath,
+            format ?? PresentationSaveFormat.Auto,
+            overwrite));
+    }
+
+    private static string HandleSaveCopyAs(
+        string? sessionId,
+        string? targetPath,
+        bool overwrite,
+        PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            return PowerPointToolsBase.ValidationError("targetPath is required for action=save-copy-as.");
+        }
+
+        return SerializeResult(Commands.SaveCopyAs(batch, targetPath, overwrite));
     }
 
     /// <summary>

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -325,6 +325,7 @@ public sealed class PowerPointMcpService : IDisposable
     private ServiceResponse HandleSessionCommand(string action, ServiceRequest request)
     {
         if (action is not ("create" or "open" or "close" or "list" or "test" or
+            "save-as" or "save-copy-as" or
             "apply-template" or "get-theme-name" or "set-document-property" or
             "get-document-property" or "set-custom-property" or "get-custom-property" or
             "remove-custom-property"))
@@ -340,6 +341,8 @@ public sealed class PowerPointMcpService : IDisposable
             "close" => HandleSessionClose(request),
             "list" => HandleSessionList(),
             "test" => HandleSessionTest(request),
+            "save-as" => HandleSessionSaveAs(request),
+            "save-copy-as" => HandleSessionSaveCopyAs(request),
             "apply-template" => HandleSessionApplyTemplate(request),
             "get-theme-name" => HandleSessionGetThemeName(request),
             "set-document-property" => HandleSessionSetDocumentProperty(request),
@@ -357,6 +360,8 @@ public sealed class PowerPointMcpService : IDisposable
         {
             "create" or "open" or "test" => ["filePath"],
             "close" => ["save"],
+            "save-as" => ["targetPath", "format", "overwrite"],
+            "save-copy-as" => ["targetPath", "overwrite"],
             "apply-template" => ["templatePath"],
             "set-document-property" or "set-custom-property" => ["propertyName", "value"],
             "get-document-property" or "get-custom-property" or "remove-custom-property" => ["propertyName"],
@@ -502,6 +507,49 @@ public sealed class PowerPointMcpService : IDisposable
             Success = true,
             Result = JsonSerializer.Serialize(new { success = true, sessions, count = sessions.Count }, ServiceProtocol.JsonOptions)
         };
+    }
+
+    private ServiceResponse HandleSessionSaveAs(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionSaveAsArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.TargetPath))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "targetPath is required" };
+        }
+
+        return WrapPresentationResult(
+            () => _presentationCommands.SaveAs(
+                batch!,
+                args.TargetPath,
+                args.Format,
+                args.Overwrite),
+            request);
+    }
+
+    private ServiceResponse HandleSessionSaveCopyAs(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionSaveCopyAsArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.TargetPath))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "targetPath is required" };
+        }
+
+        return WrapPresentationResult(
+            () => _presentationCommands.SaveCopyAs(
+                batch!,
+                args.TargetPath,
+                args.Overwrite),
+            request);
     }
 
     private ServiceResponse HandleSessionApplyTemplate(ServiceRequest request)
@@ -787,6 +835,29 @@ public sealed class SessionCloseArgs
 {
     /// <summary>Whether to save the presentation before closing it.</summary>
     public bool Save { get; set; }
+}
+
+/// <summary>Args for "session.save-as".</summary>
+public sealed class SessionSaveAsArgs
+{
+    /// <summary>Full destination path in an existing directory.</summary>
+    public string? TargetPath { get; set; }
+
+    /// <summary>Output format inferred from the extension by default.</summary>
+    public PresentationSaveFormat Format { get; set; } = PresentationSaveFormat.Auto;
+
+    /// <summary>Whether an existing destination may be replaced.</summary>
+    public bool Overwrite { get; set; }
+}
+
+/// <summary>Args for "session.save-copy-as".</summary>
+public sealed class SessionSaveCopyAsArgs
+{
+    /// <summary>Full destination path in an existing directory.</summary>
+    public string? TargetPath { get; set; }
+
+    /// <summary>Whether an existing destination may be replaced.</summary>
+    public bool Overwrite { get; set; }
 }
 
 /// <summary>Args for "session.apply-template".</summary>

--- a/tests/PowerPointMcp.CLI.Tests/SessionCommandContractTests.cs
+++ b/tests/PowerPointMcp.CLI.Tests/SessionCommandContractTests.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.Core.Presentation;
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.CLI.Tests;
+
+public sealed class SessionCommandContractTests
+{
+    [Fact]
+    public async Task SessionHelp_ListsSaveAsAndSaveCopyAs()
+    {
+        var originalOut = Console.Out;
+        using var output = new StringWriter();
+        Console.SetOut(output);
+        try
+        {
+            int exitCode = await Program.Main(["session", "--help"]);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("save-as", output.ToString(), StringComparison.Ordinal);
+            Assert.Contains("save-copy-as", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public async Task Service_SaveAsContract_DeserializesFormatAndRoutesToSessionLookup()
+    {
+        using var service = new PowerPointMcpService();
+        var response = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.save-as",
+            SessionId = "missing-session",
+            Args = JsonSerializer.Serialize(
+                new
+                {
+                    targetPath = @"C:\Temp\saved.pptx",
+                    format = PresentationSaveFormat.Pptx,
+                    overwrite = true
+                },
+                ServiceProtocol.JsonOptions),
+            Source = "cli"
+        });
+
+        Assert.False(response.Success);
+        Assert.Contains("not found", response.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unknown session action", response.ErrorMessage, StringComparison.Ordinal);
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
@@ -1,5 +1,8 @@
+using System.Runtime.InteropServices;
+using Sbroenne.PowerPointMcp.ComInterop;
 using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Presentation;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
 
@@ -25,9 +28,7 @@ public class PresentationCommandsTests
             {
                 batch.Execute((ctx, ct) =>
                 {
-                    ctx.Presentation.Slides.Add(
-                        2,
-                        Microsoft.Office.Interop.PowerPoint.PpSlideLayout.ppLayoutBlank);
+                    AddBlankSlide(ctx);
                 });
 
                 var result = _commands.SaveAs(
@@ -44,13 +45,148 @@ public class PresentationCommandsTests
             }
 
             using var reopened = PresentationSession.BeginBatch(targetPath);
-            int slideCount = reopened.Execute((ctx, ct) => ctx.Presentation.Slides.Count);
+            int slideCount = reopened.Execute((ctx, ct) => GetSlideCount(ctx));
             Assert.Equal(2, slideCount);
         }
         finally
         {
             File.Delete(originalPath);
             File.Delete(targetPath);
+        }
+    }
+
+    [Fact]
+    public void SaveAs_ComFailureAfterValidation_PreservesBatchAndRegistryPath()
+    {
+        string originalPath = CoreTestHelper.CreateUniqueTestFilePath();
+        string outputDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "PowerPointMcpTests",
+            $"save-as-failure-{Guid.NewGuid():N}");
+        string targetPath = Path.Combine(outputDirectory, "failed-save.pptx");
+        Directory.CreateDirectory(outputDirectory);
+        var registry = new PresentationSessionRegistry();
+
+        try
+        {
+            string sessionId = registry.Create(originalPath);
+            Assert.True(registry.TryGet(sessionId, out var batch));
+            batch.Save();
+
+            bool executeStarted = false;
+            var interceptingBatch = new BeforeExecuteBatch(batch, () =>
+            {
+                executeStarted = true;
+                Directory.Delete(outputDirectory);
+            });
+
+            Assert.Throws<COMException>(() => _commands.SaveAs(
+                interceptingBatch,
+                targetPath,
+                PresentationSaveFormat.Pptx));
+
+            Assert.True(executeStarted);
+            Assert.Equal(Path.GetFullPath(originalPath), batch.PresentationPath, ignoreCase: true);
+            Assert.Equal(
+                Path.GetFullPath(originalPath),
+                batch.Execute((ctx, ct) => ctx.PresentationPath),
+                ignoreCase: true);
+            var session = Assert.Single(registry.List());
+            Assert.Equal(sessionId, session.SessionId);
+            Assert.Equal(
+                Path.GetFullPath(originalPath),
+                session.PresentationPath,
+                ignoreCase: true);
+            Assert.False(File.Exists(targetPath));
+        }
+        finally
+        {
+            registry.Dispose();
+            File.Delete(originalPath);
+            if (Directory.Exists(outputDirectory))
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+        }
+    }
+
+    private static void AddBlankSlide(PresentationContext context)
+    {
+        PowerPoint.Slides? slides = null;
+        PowerPoint.Slide? slide = null;
+        try
+        {
+            slides = context.Presentation.Slides;
+            slide = slides.Add(2, PowerPoint.PpSlideLayout.ppLayoutBlank);
+        }
+        finally
+        {
+            ComUtilities.Release(ref slide);
+            ComUtilities.Release(ref slides);
+        }
+    }
+
+    private static int GetSlideCount(PresentationContext context)
+    {
+        PowerPoint.Slides? slides = null;
+        try
+        {
+            slides = context.Presentation.Slides;
+            return slides.Count;
+        }
+        finally
+        {
+            ComUtilities.Release(ref slides);
+        }
+    }
+
+    private sealed class BeforeExecuteBatch(
+        IPresentationBatch inner,
+        Action beforeExecute) : IPresentationBatch
+    {
+        private int _beforeExecutePending = 1;
+
+        public string PresentationPath => inner.PresentationPath;
+        public bool HasTimedOutOperation => inner.HasTimedOutOperation;
+        public int? PowerPointProcessId => inner.PowerPointProcessId;
+        public PowerPointProcessIdentity? PowerPointProcessIdentity => inner.PowerPointProcessIdentity;
+        public TimeSpan OperationTimeout => inner.OperationTimeout;
+
+        public void Execute(
+            Action<PresentationContext, CancellationToken> operation,
+            CancellationToken cancellationToken = default)
+        {
+            RunBeforeExecute();
+            inner.Execute(operation, cancellationToken);
+        }
+
+        public T Execute<T>(
+            Func<PresentationContext, CancellationToken, T> operation,
+            CancellationToken cancellationToken = default)
+        {
+            RunBeforeExecute();
+            return inner.Execute(operation, cancellationToken);
+        }
+
+        public void Save(CancellationToken cancellationToken = default) =>
+            inner.Save(cancellationToken);
+
+        public void UpdatePresentationPath(string presentationPath) =>
+            inner.UpdatePresentationPath(presentationPath);
+
+        public bool IsPowerPointProcessAlive() =>
+            inner.IsPowerPointProcessAlive();
+
+        public void Dispose()
+        {
+        }
+
+        private void RunBeforeExecute()
+        {
+            if (Interlocked.Exchange(ref _beforeExecutePending, 0) == 1)
+            {
+                beforeExecute();
+            }
         }
     }
 

--- a/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationCommandsTests.cs
@@ -15,6 +15,46 @@ public class PresentationCommandsTests
     private readonly PresentationCommands _commands = new();
 
     [Fact]
+    public void SaveAs_Pptx_ReopensWithEditedContentAndUpdatesSessionPath()
+    {
+        string originalPath = CoreTestHelper.CreateUniqueTestFilePath();
+        string targetPath = CoreTestHelper.CreateUniqueTestFilePath();
+        try
+        {
+            using (var batch = PresentationSession.CreateNew(originalPath))
+            {
+                batch.Execute((ctx, ct) =>
+                {
+                    ctx.Presentation.Slides.Add(
+                        2,
+                        Microsoft.Office.Interop.PowerPoint.PpSlideLayout.ppLayoutBlank);
+                });
+
+                var result = _commands.SaveAs(
+                    batch,
+                    targetPath,
+                    PresentationSaveFormat.Pptx);
+
+                Assert.True(result.Success);
+                Assert.Null(result.ErrorMessage);
+                Assert.Equal(Path.GetFullPath(targetPath), result.PresentationPath, ignoreCase: true);
+                Assert.Equal(Path.GetFullPath(targetPath), batch.PresentationPath, ignoreCase: true);
+                string contextPath = batch.Execute((ctx, ct) => ctx.PresentationPath);
+                Assert.Equal(Path.GetFullPath(targetPath), contextPath, ignoreCase: true);
+            }
+
+            using var reopened = PresentationSession.BeginBatch(targetPath);
+            int slideCount = reopened.Execute((ctx, ct) => ctx.Presentation.Slides.Count);
+            Assert.Equal(2, slideCount);
+        }
+        finally
+        {
+            File.Delete(originalPath);
+            File.Delete(targetPath);
+        }
+    }
+
+    [Fact]
     public void Create_SavesRealPptxFile_ThatPowerPointCanReopen()
     {
         string path = CoreTestHelper.CreateUniqueTestFilePath();

--- a/tests/PowerPointMcp.Core.Tests/PresentationPropertiesTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationPropertiesTests.cs
@@ -21,7 +21,7 @@ namespace Sbroenne.PowerPointMcp.Core.Tests;
 /// </remarks>
 [Trait("Category", "Integration")]
 [Trait("Feature", "Presentation")]
-public class PresentationPropertiesTests : IClassFixture<SharedPresentationFixture>
+public partial class PresentationPropertiesTests : IClassFixture<SharedPresentationFixture>
 {
     private readonly SharedPresentationFixture _fixture;
     private readonly PresentationCommands _commands = new();

--- a/tests/PowerPointMcp.Core.Tests/PresentationSaveTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationSaveTests.cs
@@ -1,0 +1,140 @@
+using Sbroenne.PowerPointMcp.Core.Presentation;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>Real Save As and Save Copy As tests using the presentation fixture.</summary>
+public partial class PresentationPropertiesTests
+{
+    [Fact]
+    public void SaveCopyAs_CreatesCopyAndLeavesSessionPathUnchanged()
+    {
+        string originalPath = _fixture.CreateFreshPresentation();
+        string copyPath = CoreTestHelper.CreateUniqueTestFilePath();
+        _fixture.TrackCreatedPath(copyPath);
+        _fixture.Batch.Save();
+        _fixture.Batch.Execute((ctx, ct) =>
+        {
+            ctx.Presentation.Slides.Add(
+                2,
+                Microsoft.Office.Interop.PowerPoint.PpSlideLayout.ppLayoutBlank);
+        });
+
+        var result = _commands.SaveCopyAs(_fixture.Batch, copyPath);
+
+        Assert.True(result.Success);
+        Assert.Null(result.ErrorMessage);
+        Assert.True(File.Exists(originalPath));
+        Assert.True(File.Exists(copyPath));
+        Assert.Equal(Path.GetFullPath(copyPath), result.PresentationPath, ignoreCase: true);
+        Assert.Equal(Path.GetFullPath(originalPath), _fixture.Batch.PresentationPath, ignoreCase: true);
+
+        _fixture.ReopenPresentation(copyPath);
+        int slideCount = _fixture.Batch.Execute((ctx, ct) => ctx.Presentation.Slides.Count);
+        Assert.Equal(2, slideCount);
+    }
+
+    [Fact]
+    public void SaveAs_FormatExtensionMismatch_ReturnsFailureAndPreservesSessionPath()
+    {
+        string originalPath = _fixture.CreateFreshPresentation();
+        string mismatchedPath = Path.ChangeExtension(
+            CoreTestHelper.CreateUniqueTestFilePath(),
+            ".pptm");
+        _fixture.TrackCreatedPath(mismatchedPath);
+
+        var result = _commands.SaveAs(
+            _fixture.Batch,
+            mismatchedPath,
+            PresentationSaveFormat.Pptx);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        Assert.False(File.Exists(mismatchedPath));
+        Assert.Equal(Path.GetFullPath(originalPath), _fixture.Batch.PresentationPath, ignoreCase: true);
+    }
+
+    [Fact]
+    public void SaveCopyAs_FormatExtensionMismatch_ReturnsFailureAndPreservesSessionPath()
+    {
+        string originalPath = _fixture.CreateFreshPresentation();
+        string mismatchedPath = Path.ChangeExtension(
+            CoreTestHelper.CreateUniqueTestFilePath(),
+            ".pptm");
+        _fixture.TrackCreatedPath(mismatchedPath);
+
+        var result = _commands.SaveCopyAs(_fixture.Batch, mismatchedPath);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        Assert.False(File.Exists(mismatchedPath));
+        Assert.Equal(Path.GetFullPath(originalPath), _fixture.Batch.PresentationPath, ignoreCase: true);
+    }
+
+    [Fact]
+    public void SaveAs_ExistingDestinationWithoutOverwrite_ReturnsFailureAndPreservesSessionPath()
+    {
+        string originalPath = _fixture.CreateFreshPresentation();
+        string existingPath = CoreTestHelper.CreateUniqueTestFilePath();
+        File.WriteAllText(existingPath, "existing destination");
+        _fixture.TrackCreatedPath(existingPath);
+
+        var result = _commands.SaveAs(_fixture.Batch, existingPath);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        Assert.Equal("existing destination", File.ReadAllText(existingPath));
+        Assert.Equal(Path.GetFullPath(originalPath), _fixture.Batch.PresentationPath, ignoreCase: true);
+    }
+
+    [Fact]
+    public void SaveCopyAs_ExistingDestinationWithoutOverwrite_ReturnsFailure()
+    {
+        string originalPath = _fixture.CreateFreshPresentation();
+        string existingPath = CoreTestHelper.CreateUniqueTestFilePath();
+        File.WriteAllText(existingPath, "existing destination");
+        _fixture.TrackCreatedPath(existingPath);
+
+        var result = _commands.SaveCopyAs(_fixture.Batch, existingPath);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        Assert.Equal("existing destination", File.ReadAllText(existingPath));
+        Assert.Equal(Path.GetFullPath(originalPath), _fixture.Batch.PresentationPath, ignoreCase: true);
+    }
+
+    [Fact]
+    public void SaveAsAndSaveCopyAs_WithOverwrite_ReplaceExistingDestinations()
+    {
+        _fixture.CreateFreshPresentation();
+        string saveAsPath = CoreTestHelper.CreateUniqueTestFilePath();
+        string copyPath = CoreTestHelper.CreateUniqueTestFilePath();
+        File.WriteAllText(saveAsPath, "existing save-as destination");
+        File.WriteAllText(copyPath, "existing copy destination");
+        _fixture.TrackCreatedPath(saveAsPath);
+        _fixture.TrackCreatedPath(copyPath);
+
+        var copyResult = _commands.SaveCopyAs(
+            _fixture.Batch,
+            copyPath,
+            overwrite: true);
+        Assert.True(copyResult.Success);
+        _fixture.ReopenPresentation(copyPath);
+        Assert.Equal(
+            1,
+            _fixture.Batch.Execute((ctx, ct) => ctx.Presentation.Slides.Count));
+
+        _fixture.CreateFreshPresentation();
+        var saveAsResult = _commands.SaveAs(
+            _fixture.Batch,
+            saveAsPath,
+            PresentationSaveFormat.Pptx,
+            overwrite: true);
+
+        Assert.True(saveAsResult.Success);
+        Assert.Equal(Path.GetFullPath(saveAsPath), _fixture.Batch.PresentationPath, ignoreCase: true);
+        _fixture.ReopenPresentation(saveAsPath);
+        Assert.Equal(
+            1,
+            _fixture.Batch.Execute((ctx, ct) => ctx.Presentation.Slides.Count));
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/PresentationSaveTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationSaveTests.cs
@@ -1,4 +1,7 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
 using Sbroenne.PowerPointMcp.Core.Presentation;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
 
@@ -14,9 +17,7 @@ public partial class PresentationPropertiesTests
         _fixture.Batch.Save();
         _fixture.Batch.Execute((ctx, ct) =>
         {
-            ctx.Presentation.Slides.Add(
-                2,
-                Microsoft.Office.Interop.PowerPoint.PpSlideLayout.ppLayoutBlank);
+            AddSaveTestBlankSlide(ctx);
         });
 
         var result = _commands.SaveCopyAs(_fixture.Batch, copyPath);
@@ -29,7 +30,7 @@ public partial class PresentationPropertiesTests
         Assert.Equal(Path.GetFullPath(originalPath), _fixture.Batch.PresentationPath, ignoreCase: true);
 
         _fixture.ReopenPresentation(copyPath);
-        int slideCount = _fixture.Batch.Execute((ctx, ct) => ctx.Presentation.Slides.Count);
+        int slideCount = _fixture.Batch.Execute((ctx, ct) => GetSaveTestSlideCount(ctx));
         Assert.Equal(2, slideCount);
     }
 
@@ -121,7 +122,7 @@ public partial class PresentationPropertiesTests
         _fixture.ReopenPresentation(copyPath);
         Assert.Equal(
             1,
-            _fixture.Batch.Execute((ctx, ct) => ctx.Presentation.Slides.Count));
+            _fixture.Batch.Execute((ctx, ct) => GetSaveTestSlideCount(ctx)));
 
         _fixture.CreateFreshPresentation();
         var saveAsResult = _commands.SaveAs(
@@ -135,6 +136,36 @@ public partial class PresentationPropertiesTests
         _fixture.ReopenPresentation(saveAsPath);
         Assert.Equal(
             1,
-            _fixture.Batch.Execute((ctx, ct) => ctx.Presentation.Slides.Count));
+            _fixture.Batch.Execute((ctx, ct) => GetSaveTestSlideCount(ctx)));
+    }
+
+    private static void AddSaveTestBlankSlide(PresentationContext context)
+    {
+        PowerPoint.Slides? slides = null;
+        PowerPoint.Slide? slide = null;
+        try
+        {
+            slides = context.Presentation.Slides;
+            slide = slides.Add(2, PowerPoint.PpSlideLayout.ppLayoutBlank);
+        }
+        finally
+        {
+            ComUtilities.Release(ref slide);
+            ComUtilities.Release(ref slides);
+        }
+    }
+
+    private static int GetSaveTestSlideCount(PresentationContext context)
+    {
+        PowerPoint.Slides? slides = null;
+        try
+        {
+            slides = context.Presentation.Slides;
+            return slides.Count;
+        }
+        finally
+        {
+            ComUtilities.Release(ref slides);
+        }
     }
 }

--- a/tests/PowerPointMcp.Core.Tests/SharedPresentationFixture.cs
+++ b/tests/PowerPointMcp.Core.Tests/SharedPresentationFixture.cs
@@ -71,6 +71,27 @@ public sealed class SharedPresentationFixture : IDisposable
         _batch.ReopenPresentation(_currentPath, createNewFile: false);
     }
 
+    /// <summary>
+    /// Reopens a specific presentation in the shared PowerPoint process and tracks it for cleanup.
+    /// </summary>
+    public void ReopenPresentation(string path)
+    {
+        string fullPath = Path.GetFullPath(path);
+        _batch.ReopenPresentation(fullPath, createNewFile: false);
+        _currentPath = fullPath;
+        TrackCreatedPath(fullPath);
+    }
+
+    /// <summary>Tracks an additional test output for cleanup when the fixture is disposed.</summary>
+    public void TrackCreatedPath(string path)
+    {
+        string fullPath = Path.GetFullPath(path);
+        if (!_createdPaths.Contains(fullPath, StringComparer.OrdinalIgnoreCase))
+        {
+            _createdPaths.Add(fullPath);
+        }
+    }
+
     public void Dispose()
     {
         Batch.Dispose();

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -190,6 +190,8 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.Contains("test", actions);
+        Assert.Contains("save-as", actions);
+        Assert.Contains("save-copy-as", actions);
         Assert.DoesNotContain("save", actions);
 
         var properties = presentation.JsonSchema.GetProperty("properties");
@@ -200,6 +202,19 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
             .ToHashSet(StringComparer.Ordinal);
         Assert.Contains("boolean", saveTypes);
         Assert.Contains("null", saveTypes);
+
+        Assert.True(properties.TryGetProperty("targetPath", out _));
+        Assert.True(properties.TryGetProperty("overwrite", out _));
+        var formatValues = properties
+            .GetProperty("format")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(value => value.GetString())
+            .Where(value => value != null)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(
+            new HashSet<string?> { "auto", "pptx", "pptm", "ppt" },
+            formatValues);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add `presentation` actions `save-as` and `save-copy-as` across Core, MCP, CLI, and the shared service
- update the tracked session path only after Save As succeeds while Save Copy As preserves the active path
- validate formats, extensions, destination paths, and explicit overwrite intent before PowerPoint writes
- document the two narrowly scoped late-bound calls required by the missing Office assembly boundary and add a minor changeset

## Validation
- focused real-PowerPoint Save As/copy tests: 7/7 passed
- combined presentation fixture tests: 21/21 passed
- full `Feature=Presentation` run: 32/34 passed; two unrelated existing COM tests failed (`ApplyTemplateTests.GetThemeName_OnFreshPresentation_ReturnsSuccessWithNonEmptyName` and the `Company` case of `SetDocumentProperty_ThenGetDocumentProperty_RoundTrips_CaseInsensitively`)
- Release build: 0 warnings, 0 errors
- non-COM MCP protocol tests: 21/21 passed
- CLI tests: 10/10 passed
- release metadata and Agent Skills packaging tests: 65/65 passed
- Success invariant, COM cleanup, dynamic-cast justification, Core interface, documentation count, TODO marker, and diff checks passed

## Design note
The restored PowerPoint PIA exposes typed `PpSaveAsFileType`, but binding either Save method also requires `Office.MsoTriState` from an intentionally unreferenced Office assembly. Late binding is therefore restricted to the two Save As invocations while retaining typed file-format values.