### PR TITLE
Add PowerPoint string tag operations

### DIFF
--- a/.changeset/neat-powerpoint-tags.md
+++ b/.changeset/neat-powerpoint-tags.md
@@ -1,0 +1,6 @@
+---
+"powerpointmcp": minor
+---
+
+Add case-insensitive string tags to presentations, slides, and shapes through matching MCP and CLI
+`set-tag`, `get-tag`, `list-tags`, and `delete-tag` actions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ Unified Service Architecture.
 5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 15 tools
    total: one hand-written `presentation` action-dispatch tool plus 14 generated action-dispatch
    tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 162 operations
+   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 174 operations
    across 15 domains. See
    `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
    the ground-truth tool list.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**15 MCP tools with 162 operations across 15 domains:**
+**15 MCP tools with 174 operations across 15 domains:**
 
-- 🗂️ **Presentation** (16 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
+- 🗂️ **Presentation** (20 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
   `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name, set/read
-  PowerPoint's advisory Mark as Final flag, and read/write built-in and custom document properties
-- 📑 **Slide** (19 ops) — lifecycle, backgrounds, sections, comments, and slide import
-- ▭ **Shape** (39 ops) — shapes, styling, grouping, hyperlinks, and placeholder editing
+  PowerPoint's advisory Mark as Final flag, read/write built-in and custom document properties,
+  and manage string tags
+- 📑 **Slide** (23 ops) — lifecycle, backgrounds, sections, comments, slide import, and string tags
+- ▭ **Shape** (43 ops) — shapes, styling, grouping, hyperlinks, placeholder editing, and string tags
 - ✏️ **TextFrame** (20 ops) — text, font size/name/color, bold, italic, underline, alignment, bullets
 - 📊 **Table** (12 ops) — add, cell text, insert/delete rows &amp; columns, cell fill/border, merge cells
 - 🗣️ **Notes** (2 ops) — set/get speaker notes

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This audit compares the current 15 tools and 162 operations with the restored
+This audit compares the current 15 tools and 174 operations with the restored
 `Microsoft.Office.Interop.PowerPoint` 15.0.4420.1018 assembly. It looks for useful PowerPoint
 features that fit the existing live-session model. It does not copy Excel-only worksheet, Power
 Query, Data Model, PivotTable, or calculation APIs.
@@ -61,7 +61,7 @@ Real-PowerPoint tests cover:
 References: [Presentation.SaveAs](https://learn.microsoft.com/office/vba/api/powerpoint.presentation.saveas),
 [Presentation.SaveCopyAs](https://learn.microsoft.com/office/vba/api/powerpoint.presentation.savecopyas).
 
-### 2. Mark as Final
+### 2. Mark as Final — implemented
 
 `_Presentation.Final` is a typed `bool` property. Expose it as `get-final` and `set-final`, with
 tool text stating clearly that it is an advisory editing flag, not access control.
@@ -77,7 +77,7 @@ access control.
 
 Reference: [Presentation.Final](https://learn.microsoft.com/office/vba/api/powerpoint.presentation.final).
 
-### 3. Presentation, slide, and shape tags
+### 3. Presentation, slide, and shape tags (implemented)
 
 The restored PIA exposes typed `Tags` collections on `_Presentation`, `_Slide`, and `Shape`.
 `Tags.Add(name, value)`, `Tags.Item[name]`, `Tags.Name(index)`, `Tags.Value(index)`,
@@ -89,6 +89,13 @@ adds file-size and safety concerns without a clear automation need.
 
 Tests should cover add/update, name-based lookup, 1-based enumeration, delete, missing tags, and
 persistence after save/reopen for each owner type.
+
+Implemented with invariant-uppercase names for deterministic case-insensitive identity; name
+whitespace and values are preserved exactly. One shared typed Core helper performs traversal and
+validation.
+PowerPoint reuses owner and `Tags` proxies across commands, so `PresentationContext` caches them
+by owner identity and releases tags before deterministic presentation teardown. It retains one
+owner acquisition for teardown and each command releases any repeated owner acquisition.
 
 Reference: [Tags object](https://learn.microsoft.com/office/vba/api/powerpoint.tags).
 

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 15 MCP tools with 162 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
+description: 15 MCP tools with 174 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
 keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **15 MCP tools with 162 operations across 15 domains**.
+PowerPoint MCP Server exposes **15 MCP tools with 174 operations across 15 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -20,9 +20,9 @@ The CLI mirrors the same domain model:
 
 | Tool | Ops | What it covers | MCP call shape | CLI shape |
 |------|-----|----------------|----------------|-----------|
-| `presentation` | 16 | Session lifecycle, Save As/copy, open testing, template application, advisory Mark as Final, built-in/custom document properties | `presentation(action="...", ...)` | `pptcli session <action> ...` |
-| `slide` | 19 | Slide lifecycle, backgrounds, sections, comments, import | `slide(action="...", session_id=..., ...)` | `pptcli slide <action> -s <SESSION_ID> ...` |
-| `shape` | 39 | Shapes, styling, grouping, hyperlinks, placeholders | `shape(action="...", session_id=..., ...)` | `pptcli shape <action> -s <SESSION_ID> ...` |
+| `presentation` | 20 | Session lifecycle, Save As/copy, templates, advisory Mark as Final, document properties, string tags | `presentation(action="...", ...)` | `pptcli session <action> ...` |
+| `slide` | 23 | Slide lifecycle, backgrounds, sections, comments, import, string tags | `slide(action="...", session_id=..., ...)` | `pptcli slide <action> -s <SESSION_ID> ...` |
+| `shape` | 43 | Shapes, styling, grouping, hyperlinks, placeholders, string tags | `shape(action="...", session_id=..., ...)` | `pptcli shape <action> -s <SESSION_ID> ...` |
 | `textframe` | 20 | Text content and text formatting | `textframe(action="...", session_id=..., ...)` | `pptcli textframe <action> -s <SESSION_ID> ...` |
 | `table` | 12 | Table creation and cell editing/formatting | `table(action="...", session_id=..., ...)` | `pptcli table <action> -s <SESSION_ID> ...` |
 | `notes` | 2 | Speaker notes | `notes(action="...", session_id=..., ...)` | `pptcli notes <action> -s <SESSION_ID> ...` |
@@ -38,7 +38,7 @@ The CLI mirrors the same domain model:
 
 ## Domain reference
 
-### `presentation` tool (16 operations)
+### `presentation` tool (20 operations)
 
 Use `presentation` for session lifecycle, Save As/copy, templates/themes, Mark as Final, and
 document properties. `create` and `open` establish a session and return a `sessionId`; the
@@ -62,12 +62,17 @@ remaining edit/read actions use that `sessionId`.
 | `set-custom-property` | Create or update a custom document property. |
 | `get-custom-property` | Read a custom document property. |
 | `remove-custom-property` | Remove a custom document property. |
+| `set-tag` | Create or update a case-insensitive presentation string tag. |
+| `get-tag` | Read a presentation string tag by case-insensitive name. |
+| `list-tags` | List presentation string tags in native 1-based order. |
+| `delete-tag` | Delete a presentation string tag by case-insensitive name. |
 
 **Exact action order:** `create`, `open`, `close`, `list`, `test`, `save-as`, `save-copy-as`,
 `apply-template`, `get-theme-name`, `get-final`, `set-final`, `set-document-property`,
-`get-document-property`, `set-custom-property`, `get-custom-property`, `remove-custom-property`
+`get-document-property`, `set-custom-property`, `get-custom-property`, `remove-custom-property`,
+`set-tag`, `get-tag`, `list-tags`, `delete-tag`
 
-### `slide` tool (19 operations)
+### `slide` tool (23 operations)
 
 | Action | What it does |
 |--------|---------------|
@@ -95,9 +100,9 @@ remaining edit/read actions use that `sessionId`.
 `set-background-color`, `get-background-color`, `set-gradient-background`,
 `get-gradient-background`, `add-section`, `rename-section`, `delete-section`,
 `get-section-count`, `get-section-name`, `list-comments`, `add-comment`, `delete-comment`,
-`clear-comments`, `import-from-file`
+`clear-comments`, `import-from-file`, `set-tag`, `get-tag`, `list-tags`, `delete-tag`
 
-### `shape` tool (39 operations)
+### `shape` tool (43 operations)
 
 Use `shape` for shape creation, geometry, styling, effects, grouping, naming, alt text, and
 hyperlinks.
@@ -108,7 +113,8 @@ hyperlinks.
 `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`,
 `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`,
 `set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`,
-`list-placeholders`, `set-placeholder-text`, `set-placeholder-image`
+`list-placeholders`, `set-placeholder-text`, `set-placeholder-image`, `set-tag`, `get-tag`,
+`list-tags`, `delete-tag`
 
 ### `textframe` tool (20 operations)
 

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -100,7 +100,7 @@ hide:
 
 </div>
 
-[See all 15 tools (162 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 15 tools (174 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 15 tools (162 operations) across 15 domains
+- [Complete Feature Reference](features.md) — all 15 tools (174 operations) across 15 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 162 operations across 15 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 174 operations across 15 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/gh-pages/docs/reference/index.md
+++ b/gh-pages/docs/reference/index.md
@@ -19,6 +19,7 @@ Skills. The website and installed guidance therefore describe the same behavior.
 ## Domain guidance
 
 - [Slides and Shapes](slides-and-shapes.md)
+- [String Tags](tags.md)
 - [Text Formatting](text-formatting.md)
 - [Tables](tables.md)
 - [Charts](charts.md)

--- a/gh-pages/docs/reference/tags.md
+++ b/gh-pages/docs/reference/tags.md
@@ -1,0 +1,8 @@
+---
+title: String Tags
+description: Attach case-insensitive string metadata to presentations, slides, and shapes.
+---
+
+# String Tags
+
+--8<-- "_generated/skills-tags.md"

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -50,6 +50,7 @@ SKILL_SOURCES = {
     "anti-patterns.md": "Anti-Patterns",
     "deck-builder.md": "Deck Builder",
     "slides-and-shapes.md": "Slides and Shapes",
+    "tags.md": "String Tags",
     "text-formatting.md": "Text Formatting",
     "tables.md": "Tables",
     "charts.md": "Charts",

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - Anti-patterns: reference/anti-patterns.md
       - Deck builder: reference/deck-builder.md
       - Slides and shapes: reference/slides-and-shapes.md
+      - String tags: reference/tags.md
       - Text formatting: reference/text-formatting.md
       - Tables: reference/tables.md
       - Charts: reference/charts.md

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -18,7 +18,7 @@ Claude can now create and edit PowerPoint decks directly.
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
 required) plus the manifest, license, and changelog. The server exposes 15
-tools (162 operations across 15 domains) — see the
+tools (174 operations across 15 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 
 ## Building locally

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "PowerPoint (Windows)",
   "version": "0.1.5",
   "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, accessibility, PDF export, and more - requires PowerPoint to be installed",
-  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (162 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including PDF delivery and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
+  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (174 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including string tags, PDF delivery, and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -295,7 +295,7 @@ Actions: `get-settings`, `set-size`, `set-first-slide-number`, `get-footer`, `se
 
 ### `shape` — Shape commands: create, inspect, format, group, link, and edit native placeholders. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.
 
-Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`, `delete`, `set-position`, `set-size`, `set-fill`, `get-fill`, `set-line`, `get-line`, `set-rotation`, `get-rotation`, `flip`, `set-z-order`, `set-shadow`, `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`, `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`, `set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`, `list-placeholders`, `set-placeholder-text`, `set-placeholder-image`
+Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-connector`, `get-count`, `delete`, `set-position`, `set-size`, `set-fill`, `get-fill`, `set-line`, `get-line`, `set-rotation`, `get-rotation`, `flip`, `set-z-order`, `set-shadow`, `get-shadow`, `set-glow`, `get-glow`, `set-reflection`, `get-reflection`, `set-soft-edge`, `get-soft-edge`, `set-bevel`, `get-bevel`, `group`, `ungroup`, `set-name`, `get-name`, `set-alt-text`, `get-alt-text`, `set-hyperlink`, `get-hyperlink`, `remove-hyperlink`, `list-placeholders`, `set-placeholder-text`, `set-placeholder-image`, `set-tag`, `get-tag`, `list-tags`, `delete-tag`
 
 | Flag | Description |
 |------|-------------|
@@ -311,7 +311,7 @@ Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-con
 | `--end-x` | (required for: add-line, add-connector) |
 | `--end-y` | (required for: add-line, add-connector) |
 | `--connector-type` | (required for: add-connector) |
-| `--shape-index` | (required for: delete, set-position, set-size, set-fill, get-fill, set-line, get-line, set-rotation, get-rotation, flip, set-z-order, set-shadow, get-shadow, set-glow, get-glow, set-reflection, get-reflection, set-soft-edge, get-soft-edge, set-bevel, get-bevel, ungroup, set-name, get-name, set-alt-text, get-alt-text, set-hyperlink, get-hyperlink, remove-hyperlink, set-placeholder-text, set-placeholder-image) |
+| `--shape-index` | (required for: delete, set-position, set-size, set-fill, get-fill, set-line, get-line, set-rotation, get-rotation, flip, set-z-order, set-shadow, get-shadow, set-glow, get-glow, set-reflection, get-reflection, set-soft-edge, get-soft-edge, set-bevel, get-bevel, ungroup, set-name, get-name, set-alt-text, get-alt-text, set-hyperlink, get-hyperlink, remove-hyperlink, set-placeholder-text, set-placeholder-image, set-tag, get-tag, list-tags, delete-tag) |
 | `--red` | (required for: set-fill, set-glow) |
 | `--green` | (required for: set-fill, set-glow) |
 | `--blue` | (required for: set-fill, set-glow) |
@@ -336,15 +336,17 @@ Actions: `add-rectangle`, `add-text-box`, `add-auto-shape`, `add-line`, `add-con
 | `--address` | (required for: set-hyperlink) |
 | `--screen-tip` |  |
 | `--image-path` | (required for: set-placeholder-image) |
+| `--tag-name` | (required for: set-tag, get-tag, delete-tag) |
+| `--tag-value` | (required for: set-tag) |
 
 
 ### `slide` — Slide lifecycle, background, section, legacy comment, and slide-import commands.
 
-Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-background-color`, `get-background-color`, `set-gradient-background`, `get-gradient-background`, `add-section`, `rename-section`, `delete-section`, `get-section-count`, `get-section-name`, `list-comments`, `add-comment`, `delete-comment`, `clear-comments`, `import-from-file`
+Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-background-color`, `get-background-color`, `set-gradient-background`, `get-gradient-background`, `add-section`, `rename-section`, `delete-section`, `get-section-count`, `get-section-name`, `list-comments`, `add-comment`, `delete-comment`, `clear-comments`, `import-from-file`, `set-tag`, `get-tag`, `list-tags`, `delete-tag`
 
 | Flag | Description |
 |------|-------------|
-| `--slide-index` | (required for: delete, duplicate, move-to, set-background-color, get-background-color, set-gradient-background, get-gradient-background, list-comments, add-comment, delete-comment, clear-comments) |
+| `--slide-index` | (required for: delete, duplicate, move-to, set-background-color, get-background-color, set-gradient-background, get-gradient-background, list-comments, add-comment, delete-comment, clear-comments, set-tag, get-tag, list-tags, delete-tag) |
 | `--to-position` | (required for: move-to) |
 | `--red` | (required for: set-background-color) |
 | `--green` | (required for: set-background-color) |
@@ -370,6 +372,8 @@ Actions: `add-blank`, `get-count`, `delete`, `duplicate`, `move-to`, `set-backgr
 | `--destination-slide-index` | (required for: import-from-file) |
 | `--source-start-slide` |  |
 | `--source-end-slide` |  |
+| `--tag-name` | (required for: set-tag, get-tag, delete-tag) |
+| `--tag-value` | (required for: set-tag) |
 
 
 ### `smartart` — SmartArt commands: add a SmartArt diagram to a slide from PowerPoint's built-in layout gallery, and add/read/update/delete/count the diagram's nodes. Operates within an already-open , targeting a specific slide and shape by 1-based index.

--- a/skills/powerpoint-cli/references/cli-commands.md
+++ b/skills/powerpoint-cli/references/cli-commands.md
@@ -609,6 +609,27 @@ COMMANDS:
                                                                   (user-defined)
                                                                   document
                                                                   property
+    set-tag <SESSION_ID> <TAG_NAME> <TAG_VALUE>                   Create or
+                                                                  update a
+                                                                  case-insensiti
+                                                                  ve
+                                                                  presentation
+                                                                  string tag
+    get-tag <SESSION_ID> <TAG_NAME>                               Read a
+                                                                  presentation
+                                                                  string tag by
+                                                                  case-insensiti
+                                                                  ve name
+    list-tags <SESSION_ID>                                        List
+                                                                  presentation
+                                                                  string tags in
+                                                                  native 1-based
+                                                                  order
+    delete-tag <SESSION_ID> <TAG_NAME>                            Delete a
+                                                                  presentation
+                                                                  string tag by
+                                                                  case-insensiti
+                                                                  ve name
 ```
 
 ### `pptcli session close`
@@ -685,6 +706,22 @@ List every session currently open in the daemon
 
 USAGE:
     pptcli session list [OPTIONS]
+
+OPTIONS:
+    -h, --help    Prints help information
+```
+
+### `pptcli session list-tags`
+
+```text
+DESCRIPTION:
+List presentation string tags in native 1-based order
+
+USAGE:
+    pptcli session list-tags <SESSION_ID> [OPTIONS]
+
+ARGUMENTS:
+    <SESSION_ID>    Session id returned by 'session open'/'session create'
 
 OPTIONS:
     -h, --help    Prints help information
@@ -793,10 +830,11 @@ OPTIONS:
                                              get-alt-text, set-hyperlink,
                                              get-hyperlink, remove-hyperlink,
                                              set-placeholder-text,
-                                             set-placeholder-image) (valid for:
-                                             delete, set-position, set-size,
-                                             set-fill, get-fill, set-line,
-                                             get-line, set-rotation,
+                                             set-placeholder-image, set-tag,
+                                             get-tag, list-tags, delete-tag)
+                                             (valid for: delete, set-position,
+                                             set-size, set-fill, get-fill,
+                                             set-line, get-line, set-rotation,
                                              get-rotation, flip, set-z-order,
                                              set-shadow, get-shadow, set-glow,
                                              get-glow, set-reflection,
@@ -807,7 +845,8 @@ OPTIONS:
                                              get-alt-text, set-hyperlink,
                                              get-hyperlink, remove-hyperlink,
                                              set-placeholder-text,
-                                             set-placeholder-image)
+                                             set-placeholder-image, set-tag,
+                                             get-tag, list-tags, delete-tag)
         --red <RED>                          (required for: set-fill, set-glow)
                                              (valid for: set-fill, set-line,
                                              set-shadow, set-glow)
@@ -855,6 +894,11 @@ OPTIONS:
         --image-path <IMAGEPATH>             (required for:
                                              set-placeholder-image) (valid for:
                                              set-placeholder-image)
+        --tag-name <TAGNAME>                 (required for: set-tag, get-tag,
+                                             delete-tag) (valid for: set-tag,
+                                             get-tag, delete-tag)
+        --tag-value <TAGVALUE>               (required for: set-tag) (valid for:
+                                             set-tag)
     -o, --output <PATH>                      Write output to file instead of
                                              stdout. For image results, decodes
                                              and saves as binary file
@@ -892,8 +936,11 @@ OPTIONS:
                                                              list-comments,
                                                              add-comment,
                                                              delete-comment,
-                                                             clear-comments)
-                                                             (valid for: delete,
+                                                             clear-comments,
+                                                             set-tag, get-tag,
+                                                             list-tags,
+                                                             delete-tag) (valid
+                                                             for: delete,
                                                              duplicate, move-to,
                                                              set-background-colo
                                                              r,
@@ -906,7 +953,10 @@ OPTIONS:
                                                              list-comments,
                                                              add-comment,
                                                              delete-comment,
-                                                             clear-comments)
+                                                             clear-comments,
+                                                             set-tag, get-tag,
+                                                             list-tags,
+                                                             delete-tag)
         --to-position <TOPOSITION>                           (required for:
                                                              move-to) (valid
                                                              for: move-to)
@@ -1007,6 +1057,15 @@ OPTIONS:
                                                              import-from-file)
         --source-end-slide <SOURCEENDSLIDE>                  (valid for:
                                                              import-from-file)
+        --tag-name <TAGNAME>                                 (required for:
+                                                             set-tag, get-tag,
+                                                             delete-tag) (valid
+                                                             for: set-tag,
+                                                             get-tag,
+                                                             delete-tag)
+        --tag-value <TAGVALUE>                               (required for:
+                                                             set-tag) (valid
+                                                             for: set-tag)
     -o, --output <PATH>                                      Write output to
                                                              file instead of
                                                              stdout. For image

--- a/skills/powerpoint-cli/references/tags.md
+++ b/skills/powerpoint-cli/references/tags.md
@@ -1,0 +1,57 @@
+> **CLI syntax:** Shared guides may use MCP calls as shorthand. Use `cli-commands.md` or live `--help` for exact commands and kebab-case options.
+
+# String Tags
+
+PowerPoint string tags attach small text metadata to a presentation, slide, or shape without
+changing visible slide content. Each owner supports `set-tag`, `get-tag`, `list-tags`, and
+`delete-tag`.
+
+## Name and Value Rules
+
+- Tag names are case-insensitive.
+- Letter casing is normalized to invariant uppercase, while whitespace is preserved.
+  `reviewState` and `ReviewState` identify the same tag; ` reviewState ` is a distinct name.
+- Tag values are never case-normalized or trimmed. A value such as `Needs Review ` round-trips
+  exactly as stored.
+- `list-tags` returns tags in PowerPoint's native 1-based collection order. Each item includes
+  `tagIndex`, `name`, and `value`.
+- Missing tags return `success: false`. `delete-tag` is not an idempotent success for a missing
+  name.
+- Only string tags are supported. Binary tag APIs are intentionally not exposed.
+
+## Presentation Tags
+
+Presentation tags use camelCase arguments on the hand-written `presentation` tool:
+
+```
+presentation(action: "set-tag", sessionId: ..., tagName: "ReviewState", tagValue: "Needs Review")
+presentation(action: "get-tag", sessionId: ..., tagName: "reviewstate")
+presentation(action: "list-tags", sessionId: ...)
+presentation(action: "delete-tag", sessionId: ..., tagName: "REVIEWSTATE")
+```
+
+## Slide Tags
+
+Slide tags require a 1-based `slide_index`:
+
+```
+slide(action: "set-tag", session_id: ..., slide_index: 2,
+  tag_name: "Section", tag_value: "Financials")
+slide(action: "get-tag", session_id: ..., slide_index: 2, tag_name: "section")
+slide(action: "list-tags", session_id: ..., slide_index: 2)
+slide(action: "delete-tag", session_id: ..., slide_index: 2, tag_name: "SECTION")
+```
+
+## Shape Tags
+
+Shape tags require 1-based `slide_index` and `shape_index` values:
+
+```
+shape(action: "set-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "DataSource", tag_value: "Quarterly Results")
+shape(action: "get-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "datasource")
+shape(action: "list-tags", session_id: ..., slide_index: 2, shape_index: 3)
+shape(action: "delete-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "DATASOURCE")
+```

--- a/skills/powerpoint-cli/references/workflows.md
+++ b/skills/powerpoint-cli/references/workflows.md
@@ -2,7 +2,7 @@
 
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 162 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 174 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/powerpoint-mcp/SKILL.md
+++ b/skills/powerpoint-mcp/SKILL.md
@@ -17,9 +17,9 @@ via the Model Context Protocol, driving a live PowerPoint desktop instance throu
 skill documents session lifecycle, indexing conventions, workflows, and gotchas that aren't
 obvious from tool schemas alone.
 
-Session lifecycle, templates, the advisory Mark as Final flag, and document properties use the
-`presentation` action-dispatch tool with camelCase arguments. Domain tools (`slide`, `shape`,
-`textframe`, `table`, `chart`, `image`,
+Session lifecycle, Save As/copy, templates, the advisory Mark as Final flag, document properties,
+and presentation tags use the `presentation` action-dispatch tool with camelCase arguments.
+Domain tools (`slide`, `shape`, `textframe`, `table`, `chart`, `image`,
 `notes`, `layout`, `master`, `smartart`, `animation`, `export`, `pagesetup`, `accessibility`) are
 action-dispatch: one tool per domain, called as `tool(action:
 "kebab-action", session_id: ..., snake_case_param: ...)`.
@@ -97,6 +97,7 @@ saved.
 | Apply template, read theme name | `presentation(action: "apply-template"/"get-theme-name")` |
 | Read/set advisory Mark as Final state | `presentation(action: "get-final"/"set-final")` |
 | Document metadata (built-in and custom properties) | `presentation` property actions |
+| String metadata on presentations, slides, or shapes | owner-specific `set-tag`/`get-tag`/`list-tags`/`delete-tag` actions |
 | Add/count/delete/duplicate/reorder slides | `slide(action: "add-blank"/"get-count"/"delete"/"duplicate"/"move-to")` |
 | Per-slide background color, sections | `slide(action: "set-background-color"/"get-background-color"/"add-section"/"rename-section"/"delete-section"/"get-section-count"/"get-section-name")` |
 | Add/count/delete/move/resize shapes | `shape(action: "add-rectangle"/"add-text-box"/"add-auto-shape"/"add-line"/"add-connector"/"get-count"/"delete"/"set-position"/"set-size")` |
@@ -120,6 +121,7 @@ See `references/` for detailed guidance:
 - [Canonical create → build → verify → save → close workflow](./references/workflows.md)
 - [Deck builder — assembling a multi-slide deck](./references/deck-builder.md)
 - [Slides and shapes — add/position/size/delete](./references/slides-and-shapes.md)
+- [String tags — presentation, slide, and shape metadata](./references/tags.md)
 - [Text formatting — set-text, font size/bold/color](./references/text-formatting.md)
 - [Tables — add-table, cell text, row/column edits, fill/border formatting, merge](./references/tables.md)
 - [Charts — add-chart/add-series categories/series/values, titles, legend](./references/charts.md)

--- a/skills/powerpoint-mcp/references/charts.md
+++ b/skills/powerpoint-mcp/references/charts.md
@@ -114,4 +114,3 @@ Charts are the highest-value target for `export(action: "export-slide-to-image",
 data-entry mistakes (wrong values, mismatched category count) are invisible from a
 `get-chart-data` call alone but obvious in the rendered image. Always export and inspect after
 `add-chart`/`add-series` (see `export-and-verify.md`).
-

--- a/skills/powerpoint-mcp/references/tags.md
+++ b/skills/powerpoint-mcp/references/tags.md
@@ -1,0 +1,55 @@
+# String Tags
+
+PowerPoint string tags attach small text metadata to a presentation, slide, or shape without
+changing visible slide content. Each owner supports `set-tag`, `get-tag`, `list-tags`, and
+`delete-tag`.
+
+## Name and Value Rules
+
+- Tag names are case-insensitive.
+- Letter casing is normalized to invariant uppercase, while whitespace is preserved.
+  `reviewState` and `ReviewState` identify the same tag; ` reviewState ` is a distinct name.
+- Tag values are never case-normalized or trimmed. A value such as `Needs Review ` round-trips
+  exactly as stored.
+- `list-tags` returns tags in PowerPoint's native 1-based collection order. Each item includes
+  `tagIndex`, `name`, and `value`.
+- Missing tags return `success: false`. `delete-tag` is not an idempotent success for a missing
+  name.
+- Only string tags are supported. Binary tag APIs are intentionally not exposed.
+
+## Presentation Tags
+
+Presentation tags use camelCase arguments on the hand-written `presentation` tool:
+
+```
+presentation(action: "set-tag", sessionId: ..., tagName: "ReviewState", tagValue: "Needs Review")
+presentation(action: "get-tag", sessionId: ..., tagName: "reviewstate")
+presentation(action: "list-tags", sessionId: ...)
+presentation(action: "delete-tag", sessionId: ..., tagName: "REVIEWSTATE")
+```
+
+## Slide Tags
+
+Slide tags require a 1-based `slide_index`:
+
+```
+slide(action: "set-tag", session_id: ..., slide_index: 2,
+  tag_name: "Section", tag_value: "Financials")
+slide(action: "get-tag", session_id: ..., slide_index: 2, tag_name: "section")
+slide(action: "list-tags", session_id: ..., slide_index: 2)
+slide(action: "delete-tag", session_id: ..., slide_index: 2, tag_name: "SECTION")
+```
+
+## Shape Tags
+
+Shape tags require 1-based `slide_index` and `shape_index` values:
+
+```
+shape(action: "set-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "DataSource", tag_value: "Quarterly Results")
+shape(action: "get-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "datasource")
+shape(action: "list-tags", session_id: ..., slide_index: 2, shape_index: 3)
+shape(action: "delete-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "DATASOURCE")
+```

--- a/skills/powerpoint-mcp/references/text-formatting.md
+++ b/skills/powerpoint-mcp/references/text-formatting.md
@@ -129,4 +129,3 @@ automatically instead of manually tuning size — `ppAutoSizeTextToFitShape` shr
 fit a fixed box, `ppAutoSizeShapeToFitText` grows the box to fit the text. Without auto-size set
 (`ppAutoSizeNone`, the default), text can overflow: shorten the text, reduce `font_size`, or grow
 the shape with `shape(action: "set-size", ...)`.
-

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 162 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 174 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/shared/charts.md
+++ b/skills/shared/charts.md
@@ -114,4 +114,3 @@ Charts are the highest-value target for `export(action: "export-slide-to-image",
 data-entry mistakes (wrong values, mismatched category count) are invisible from a
 `get-chart-data` call alone but obvious in the rendered image. Always export and inspect after
 `add-chart`/`add-series` (see `export-and-verify.md`).
-

--- a/skills/shared/tags.md
+++ b/skills/shared/tags.md
@@ -1,0 +1,55 @@
+# String Tags
+
+PowerPoint string tags attach small text metadata to a presentation, slide, or shape without
+changing visible slide content. Each owner supports `set-tag`, `get-tag`, `list-tags`, and
+`delete-tag`.
+
+## Name and Value Rules
+
+- Tag names are case-insensitive.
+- Letter casing is normalized to invariant uppercase, while whitespace is preserved.
+  `reviewState` and `ReviewState` identify the same tag; ` reviewState ` is a distinct name.
+- Tag values are never case-normalized or trimmed. A value such as `Needs Review ` round-trips
+  exactly as stored.
+- `list-tags` returns tags in PowerPoint's native 1-based collection order. Each item includes
+  `tagIndex`, `name`, and `value`.
+- Missing tags return `success: false`. `delete-tag` is not an idempotent success for a missing
+  name.
+- Only string tags are supported. Binary tag APIs are intentionally not exposed.
+
+## Presentation Tags
+
+Presentation tags use camelCase arguments on the hand-written `presentation` tool:
+
+```
+presentation(action: "set-tag", sessionId: ..., tagName: "ReviewState", tagValue: "Needs Review")
+presentation(action: "get-tag", sessionId: ..., tagName: "reviewstate")
+presentation(action: "list-tags", sessionId: ...)
+presentation(action: "delete-tag", sessionId: ..., tagName: "REVIEWSTATE")
+```
+
+## Slide Tags
+
+Slide tags require a 1-based `slide_index`:
+
+```
+slide(action: "set-tag", session_id: ..., slide_index: 2,
+  tag_name: "Section", tag_value: "Financials")
+slide(action: "get-tag", session_id: ..., slide_index: 2, tag_name: "section")
+slide(action: "list-tags", session_id: ..., slide_index: 2)
+slide(action: "delete-tag", session_id: ..., slide_index: 2, tag_name: "SECTION")
+```
+
+## Shape Tags
+
+Shape tags require 1-based `slide_index` and `shape_index` values:
+
+```
+shape(action: "set-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "DataSource", tag_value: "Quarterly Results")
+shape(action: "get-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "datasource")
+shape(action: "list-tags", session_id: ..., slide_index: 2, shape_index: 3)
+shape(action: "delete-tag", session_id: ..., slide_index: 2, shape_index: 3,
+  tag_name: "DATASOURCE")
+```

--- a/skills/shared/text-formatting.md
+++ b/skills/shared/text-formatting.md
@@ -129,4 +129,3 @@ automatically instead of manually tuning size — `ppAutoSizeTextToFitShape` shr
 fit a fixed box, `ppAutoSizeShapeToFitText` grows the box to fit the text. Without auto-size set
 (`ppAutoSizeNone`, the default), text can overflow: shorten the text, reduce `font_size`, or grow
 the shape with `shape(action: "set-size", ...)`.
-

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 162 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 174 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
+++ b/src/PowerPointMcp.CLI/Commands/SessionCommands.cs
@@ -441,6 +441,86 @@ internal static class SessionCommandHelpers
     }
 }
 
+/// <summary>Settings for presentation tag reads and deletes.</summary>
+internal class SessionTagGetSettings : CommandSettings
+{
+    [CommandArgument(0, "<SESSION_ID>")]
+    [Description("Session id returned by 'session open'/'session create'.")]
+    public string SessionId { get; init; } = string.Empty;
+
+    [CommandArgument(1, "<TAG_NAME>")]
+    [Description("Case-insensitive tag name. Letter casing is normalized to invariant uppercase; whitespace is preserved.")]
+    public string TagName { get; init; } = string.Empty;
+}
+
+/// <summary>Settings for setting a presentation string tag.</summary>
+internal sealed class SessionTagSetSettings : SessionTagGetSettings
+{
+    [CommandArgument(2, "<TAG_VALUE>")]
+    [Description("String tag value, preserved exactly.")]
+    public string TagValue { get; init; } = string.Empty;
+}
+
+/// <summary>Creates or updates a presentation string tag.</summary>
+internal sealed class SessionSetTagCommand : AsyncCommand<SessionTagSetSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionTagSetSettings settings, CancellationToken cancellationToken)
+        => await SessionTagCommandHelpers.SendAsync("session.set-tag", settings.SessionId, settings.TagName, settings.TagValue, cancellationToken);
+}
+
+/// <summary>Gets a presentation string tag.</summary>
+internal sealed class SessionGetTagCommand : AsyncCommand<SessionTagGetSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionTagGetSettings settings, CancellationToken cancellationToken)
+        => await SessionTagCommandHelpers.SendAsync("session.get-tag", settings.SessionId, settings.TagName, tagValue: null, cancellationToken);
+}
+
+/// <summary>Lists presentation string tags in native 1-based order.</summary>
+internal sealed class SessionListTagsCommand : AsyncCommand<SessionIdSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionIdSettings settings, CancellationToken cancellationToken)
+        => await SessionTagCommandHelpers.SendAsync("session.list-tags", settings.SessionId, tagName: null, tagValue: null, cancellationToken);
+}
+
+/// <summary>Deletes a presentation string tag.</summary>
+internal sealed class SessionDeleteTagCommand : AsyncCommand<SessionTagGetSettings>
+{
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, SessionTagGetSettings settings, CancellationToken cancellationToken)
+        => await SessionTagCommandHelpers.SendAsync("session.delete-tag", settings.SessionId, settings.TagName, tagValue: null, cancellationToken);
+}
+
+internal static class SessionTagCommandHelpers
+{
+    public static async Task<int> SendAsync(
+        string command,
+        string sessionId,
+        string? tagName,
+        string? tagValue,
+        CancellationToken cancellationToken)
+    {
+        using var client = await DaemonAutoStart.EnsureAndConnectAsync(cancellationToken);
+        var response = await client.SendAsync(new ServiceRequest
+        {
+            Command = command,
+            SessionId = sessionId,
+            Args = JsonSerializer.Serialize(new { tagName, tagValue }, ServiceProtocol.JsonOptions),
+            Source = "cli"
+        }, cancellationToken);
+
+        if (!response.Success)
+        {
+            return CliErrorOutput.WriteServiceError(response);
+        }
+
+        Console.WriteLine(response.Result ?? JsonSerializer.Serialize(new { success = true }, ServiceProtocol.JsonOptions));
+        return 0;
+    }
+}
+
 /// <summary>Lists every session currently open in the daemon.</summary>
 internal sealed class SessionListCommand : AsyncCommand
 {

--- a/src/PowerPointMcp.CLI/Program.cs
+++ b/src/PowerPointMcp.CLI/Program.cs
@@ -46,6 +46,10 @@ public static class Program
                 session.AddCommand<SessionSetCustomPropertyCommand>("set-custom-property").WithDescription("Create or update a custom (user-defined) document property.");
                 session.AddCommand<SessionGetCustomPropertyCommand>("get-custom-property").WithDescription("Read a custom (user-defined) document property.");
                 session.AddCommand<SessionRemoveCustomPropertyCommand>("remove-custom-property").WithDescription("Remove a custom (user-defined) document property.");
+                session.AddCommand<SessionSetTagCommand>("set-tag").WithDescription("Create or update a case-insensitive presentation string tag.");
+                session.AddCommand<SessionGetTagCommand>("get-tag").WithDescription("Read a presentation string tag by case-insensitive name.");
+                session.AddCommand<SessionListTagsCommand>("list-tags").WithDescription("List presentation string tags in native 1-based order.");
+                session.AddCommand<SessionDeleteTagCommand>("delete-tag").WithDescription("Delete a presentation string tag by case-insensitive name.");
             });
 
             config.AddBranch("service", service =>

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -286,13 +286,20 @@ internal sealed class PresentationBatch : IPresentationBatch
         {
             var cleanupApp = _app ?? startupApp;
             var cleanupPresentation = _presentation ?? startupPresentation;
+            var cleanupContext = _context;
+            Action? releaseOwnedComOwners =
+                cleanupContext is null ? null : cleanupContext.ReleaseOwnedComOwners;
+
+            cleanupContext?.ReleaseOwnedComResources();
+            _context = null;
 
             PresentationShutdownService.CloseAndQuit(
                 cleanupPresentation,
                 cleanupApp,
                 _powerPointProcessIdentity,
                 _logger,
-                _presentationPath);
+                _presentationPath,
+                releaseOwnedComOwners);
             if (_powerPointProcessIdentity is { } identity
                 && OwnedProcessGuard.TryConfirmExited(identity))
             {
@@ -301,8 +308,6 @@ internal sealed class PresentationBatch : IPresentationBatch
 
             _presentation = null;
             _app = null;
-            _context = null;
-
             try { OleMessageFilter.Revoke(); }
             catch (Exception ex) { _logger.LogWarning(ex, "OleMessageFilter.Revoke() failed during STA cleanup"); }
         }
@@ -554,9 +559,7 @@ internal sealed class PresentationBatch : IPresentationBatch
         var context = _context;
         if (context != null)
         {
-            Volatile.Write(
-                ref _context,
-                new PresentationContext(normalizedPath, context.App, context.Presentation));
+            context.UpdatePresentationPath(normalizedPath);
         }
 
         Volatile.Write(ref _presentationPath, normalizedPath);
@@ -595,8 +598,11 @@ internal sealed class PresentationBatch : IPresentationBatch
             var oldPresentation = _presentation;
             if (oldPresentation != null)
             {
+                ctx.ReleaseOwnedComResources();
+                _context = null;
                 try { oldPresentation.Close(); }
                 catch { /* best effort - proceed with opening the next presentation regardless */ }
+                ctx.ReleaseOwnedComOwners();
                 ComUtilities.Release(ref oldPresentation);
             }
 

--- a/src/PowerPointMcp.ComInterop/Session/PresentationContext.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationContext.cs
@@ -8,6 +8,13 @@ namespace Sbroenne.PowerPointMcp.ComInterop.Session;
 /// </summary>
 public sealed class PresentationContext
 {
+    private readonly Dictionary<object, object> _ownedComResources =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<object> _ownedComOwners =
+        new(ReferenceEqualityComparer.Instance);
+    private bool _resourcesReleased;
+    private bool _disposed;
+
     /// <summary>Creates a new PresentationContext.</summary>
     /// <param name="presentationPath">Full path to the presentation.</param>
     /// <param name="app">PowerPoint.Application COM object.</param>
@@ -20,11 +27,93 @@ public sealed class PresentationContext
     }
 
     /// <summary>Gets the full path to the presentation.</summary>
-    public string PresentationPath { get; }
+    public string PresentationPath { get; private set; }
 
     /// <summary>Gets the PowerPoint.Application COM object.</summary>
     public PowerPoint.Application App { get; }
 
     /// <summary>Gets the PowerPoint.Presentation COM object.</summary>
     public PowerPoint.Presentation Presentation { get; }
+
+    /// <summary>
+    /// Returns one context-owned COM resource for an owner RCW.
+    /// </summary>
+    /// <remarks>
+    /// PowerPoint reuses some child RCWs, including <see cref="PowerPoint.Tags"/>, across property
+    /// calls. Command-level release disconnects those cached proxies, so the context retains and
+    /// releases them immediately before the owning presentation is closed.
+    /// </remarks>
+    public T GetOrAddOwnedComResource<T>(object owner, Func<T> factory) where T : class
+    {
+        ObjectDisposedException.ThrowIf(_resourcesReleased || _disposed, this);
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        if (_ownedComResources.TryGetValue(owner, out object? existing))
+        {
+            return (T)existing;
+        }
+
+        T resource = factory();
+        _ownedComResources.Add(owner, resource);
+        return resource;
+    }
+
+    /// <summary>
+    /// Retains the first acquisition of an owner RCW for context teardown.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when this acquisition became context-owned; otherwise
+    /// <see langword="false"/> so the caller can release its repeated acquisition.
+    /// </returns>
+    public bool RetainOwnedComOwner(object owner)
+    {
+        ObjectDisposedException.ThrowIf(_resourcesReleased || _disposed, this);
+        ArgumentNullException.ThrowIfNull(owner);
+        return _ownedComOwners.Add(owner);
+    }
+
+    /// <summary>Updates the path after Save As without discarding context-owned COM resources.</summary>
+    internal void UpdatePresentationPath(string presentationPath)
+    {
+        ObjectDisposedException.ThrowIf(_resourcesReleased || _disposed, this);
+        PresentationPath = presentationPath ?? throw new ArgumentNullException(nameof(presentationPath));
+    }
+
+    /// <summary>Releases context-owned child COM resources before the presentation is closed.</summary>
+    internal void ReleaseOwnedComResources()
+    {
+        if (_resourcesReleased || _disposed)
+        {
+            return;
+        }
+
+        _resourcesReleased = true;
+
+        foreach (object resourceValue in _ownedComResources.Values.Reverse())
+        {
+            object? resource = resourceValue;
+            ComUtilities.Release(ref resource);
+        }
+    }
+
+    /// <summary>Releases cached owner proxies after the presentation has been closed.</summary>
+    internal void ReleaseOwnedComOwners()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        foreach (object ownerValue in _ownedComOwners.Reverse())
+        {
+            object? owner = ownerValue;
+            ComUtilities.Release(ref owner);
+        }
+
+        _ownedComOwners.Clear();
+        _ownedComResources.Clear();
+    }
 }

--- a/src/PowerPointMcp.ComInterop/Session/PresentationShutdownService.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationShutdownService.cs
@@ -77,12 +77,14 @@ internal static class PresentationShutdownService
         PowerPoint.Application? app,
         PowerPointProcessIdentity? processIdentity,
         ILogger? logger = null,
-        string? filePath = null)
+        string? filePath = null,
+        Action? afterPresentationClose = null)
     {
         logger ??= NullLogger.Instance;
         string fileName = string.IsNullOrEmpty(filePath) ? "unknown" : Path.GetFileName(filePath);
 
         ClosePresentation(presentation, fileName, logger);
+        afterPresentationClose?.Invoke();
         ComUtilities.Release(ref presentation);
 
         if (app != null)

--- a/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
@@ -147,4 +147,16 @@ public interface IPresentationCommands
     /// <param name="batch">The open batch whose presentation metadata will be updated.</param>
     /// <param name="propertyName">The custom property's name.</param>
     PresentationOperationResult RemoveCustomProperty(IPresentationBatch batch, string propertyName);
+
+    /// <summary>Creates or updates a case-insensitive string tag on the presentation.</summary>
+    PresentationOperationResult SetTag(IPresentationBatch batch, string tagName, string tagValue);
+
+    /// <summary>Gets a presentation string tag by its case-insensitive name.</summary>
+    PresentationOperationResult GetTag(IPresentationBatch batch, string tagName);
+
+    /// <summary>Lists presentation string tags in their native 1-based collection order.</summary>
+    PresentationOperationResult ListTags(IPresentationBatch batch);
+
+    /// <summary>Deletes a presentation string tag by its case-insensitive name.</summary>
+    PresentationOperationResult DeleteTag(IPresentationBatch batch, string tagName);
 }

--- a/src/PowerPointMcp.Core/Presentation/PresentationCommands.Tags.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationCommands.Tags.cs
@@ -1,0 +1,82 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Tags;
+
+namespace Sbroenne.PowerPointMcp.Core.Presentation;
+
+public sealed partial class PresentationCommands
+{
+    /// <inheritdoc/>
+    public PresentationOperationResult SetTag(IPresentationBatch batch, string tagName, string tagValue)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(tagValue);
+
+        return batch.Execute((ctx, ct) =>
+            ToPresentationResult(
+                TagCollectionHelper.Set(
+                    ctx,
+                    ctx.Presentation,
+                    () => ctx.Presentation.Tags,
+                    tagName,
+                    tagValue),
+                batch.PresentationPath));
+    }
+
+    /// <inheritdoc/>
+    public PresentationOperationResult GetTag(IPresentationBatch batch, string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+            ToPresentationResult(
+                TagCollectionHelper.Get(
+                    ctx,
+                    ctx.Presentation,
+                    () => ctx.Presentation.Tags,
+                    tagName),
+                batch.PresentationPath));
+    }
+
+    /// <inheritdoc/>
+    public PresentationOperationResult ListTags(IPresentationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+            ToPresentationResult(
+                TagCollectionHelper.List(
+                    ctx,
+                    ctx.Presentation,
+                    () => ctx.Presentation.Tags),
+                batch.PresentationPath));
+    }
+
+    /// <inheritdoc/>
+    public PresentationOperationResult DeleteTag(IPresentationBatch batch, string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+            ToPresentationResult(
+                TagCollectionHelper.Delete(
+                    ctx,
+                    ctx.Presentation,
+                    () => ctx.Presentation.Tags,
+                    tagName),
+                batch.PresentationPath));
+    }
+
+    private static PresentationOperationResult ToPresentationResult(
+        TagCollectionResult result,
+        string presentationPath) => new()
+        {
+            Success = result.Success,
+            ErrorMessage = result.ErrorMessage,
+            PresentationPath = presentationPath,
+            TagName = result.Name,
+            TagValue = result.Value,
+            TagIndex = result.Index,
+            TagCount = result.Count,
+            Tags = result.Tags
+        };
+}

--- a/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationCommands.cs
@@ -5,7 +5,7 @@ using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 namespace Sbroenne.PowerPointMcp.Core.Presentation;
 
 /// <inheritdoc cref="IPresentationCommands"/>
-public sealed class PresentationCommands : IPresentationCommands
+public sealed partial class PresentationCommands : IPresentationCommands
 {
     /// <inheritdoc/>
     public PresentationOperationResult Create(string filePath, bool isMacroEnabled = false)

--- a/src/PowerPointMcp.Core/Presentation/PresentationOperationResult.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationOperationResult.cs
@@ -1,3 +1,5 @@
+using Sbroenne.PowerPointMcp.Core.Tags;
+
 namespace Sbroenne.PowerPointMcp.Core.Presentation;
 
 /// <summary>
@@ -43,4 +45,19 @@ public sealed class PresentationOperationResult
     /// commands. Null for operations that don't touch document properties.
     /// </summary>
     public string? PropertyValue { get; init; }
+
+    /// <summary>Normalized tag name for tag operations.</summary>
+    public string? TagName { get; init; }
+
+    /// <summary>Tag value for tag operations. Values are returned without case normalization.</summary>
+    public string? TagValue { get; init; }
+
+    /// <summary>1-based index of the tag in PowerPoint's native collection order.</summary>
+    public int? TagIndex { get; init; }
+
+    /// <summary>Number of string tags on the presentation.</summary>
+    public int? TagCount { get; init; }
+
+    /// <summary>Presentation tags in native 1-based collection order.</summary>
+    public IReadOnlyList<TagInfo>? Tags { get; init; }
 }

--- a/src/PowerPointMcp.Core/Presentation/PresentationToolAction.cs
+++ b/src/PowerPointMcp.Core/Presentation/PresentationToolAction.cs
@@ -81,7 +81,23 @@ public enum PresentationToolAction
 
     /// <summary>Remove a custom (user-defined) document property.</summary>
     [JsonStringEnumMemberName("remove-custom-property")]
-    RemoveCustomProperty
+    RemoveCustomProperty,
+
+    /// <summary>Create or update a case-insensitive presentation string tag.</summary>
+    [JsonStringEnumMemberName("set-tag")]
+    SetTag,
+
+    /// <summary>Get a presentation string tag by case-insensitive name.</summary>
+    [JsonStringEnumMemberName("get-tag")]
+    GetTag,
+
+    /// <summary>List presentation string tags in native 1-based order.</summary>
+    [JsonStringEnumMemberName("list-tags")]
+    ListTags,
+
+    /// <summary>Delete a presentation string tag by case-insensitive name.</summary>
+    [JsonStringEnumMemberName("delete-tag")]
+    DeleteTag
 }
 
 /// <summary>
@@ -109,6 +125,10 @@ public static class PresentationToolActionExtensions
         PresentationToolAction.SetCustomProperty => "set-custom-property",
         PresentationToolAction.GetCustomProperty => "get-custom-property",
         PresentationToolAction.RemoveCustomProperty => "remove-custom-property",
+        PresentationToolAction.SetTag => "set-tag",
+        PresentationToolAction.GetTag => "get-tag",
+        PresentationToolAction.ListTags => "list-tags",
+        PresentationToolAction.DeleteTag => "delete-tag",
         _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown PresentationToolAction")
     };
 }

--- a/src/PowerPointMcp.Core/Shape/IShapeCommands.cs
+++ b/src/PowerPointMcp.Core/Shape/IShapeCommands.cs
@@ -193,4 +193,16 @@ public interface IShapeCommands
         int slideIndex,
         int shapeIndex,
         string imagePath);
+
+    /// <summary>Creates or updates a case-insensitive string tag on a shape.</summary>
+    ShapeOperationResult SetTag(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex, string tagName, [AllowEmptyString] string tagValue);
+
+    /// <summary>Gets a shape string tag by its case-insensitive name.</summary>
+    ShapeOperationResult GetTag(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex, string tagName);
+
+    /// <summary>Lists shape string tags in their native 1-based collection order.</summary>
+    ShapeOperationResult ListTags(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex);
+
+    /// <summary>Deletes a shape string tag by its case-insensitive name.</summary>
+    ShapeOperationResult DeleteTag(ComInterop.Session.IPresentationBatch batch, int slideIndex, int shapeIndex, string tagName);
 }

--- a/src/PowerPointMcp.Core/Shape/ShapeCommands.Tags.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeCommands.Tags.cs
@@ -1,0 +1,104 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Tags;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Shape;
+
+public sealed partial class ShapeCommands
+{
+    /// <inheritdoc/>
+    public ShapeOperationResult SetTag(IPresentationBatch batch, int slideIndex, int shapeIndex, string tagName, string tagValue)
+    {
+        ArgumentNullException.ThrowIfNull(tagValue);
+        return ExecuteTagOperation(
+            batch,
+            slideIndex,
+            shapeIndex,
+            (ctx, shape, acquireTags) =>
+                TagCollectionHelper.Set(ctx, shape, acquireTags, tagName, tagValue));
+    }
+
+    /// <inheritdoc/>
+    public ShapeOperationResult GetTag(IPresentationBatch batch, int slideIndex, int shapeIndex, string tagName) =>
+        ExecuteTagOperation(
+            batch,
+            slideIndex,
+            shapeIndex,
+            (ctx, shape, acquireTags) =>
+                TagCollectionHelper.Get(ctx, shape, acquireTags, tagName));
+
+    /// <inheritdoc/>
+    public ShapeOperationResult ListTags(IPresentationBatch batch, int slideIndex, int shapeIndex) =>
+        ExecuteTagOperation(
+            batch,
+            slideIndex,
+            shapeIndex,
+            (ctx, shape, acquireTags) => TagCollectionHelper.List(ctx, shape, acquireTags));
+
+    /// <inheritdoc/>
+    public ShapeOperationResult DeleteTag(IPresentationBatch batch, int slideIndex, int shapeIndex, string tagName) =>
+        ExecuteTagOperation(
+            batch,
+            slideIndex,
+            shapeIndex,
+            (ctx, shape, acquireTags) =>
+                TagCollectionHelper.Delete(ctx, shape, acquireTags, tagName));
+
+    private static ShapeOperationResult ExecuteTagOperation(
+        IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex,
+        Func<PresentationContext, PowerPoint.Shape, Func<PowerPoint.Tags>, TagCollectionResult> operation)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var slideValidation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (slideValidation is not null)
+            {
+                return slideValidation;
+            }
+
+            PowerPoint.Slide? slide = ctx.Presentation.Slides[slideIndex];
+            bool slideRetained = ctx.RetainOwnedComOwner(slide);
+            PowerPoint.Shape? shape = null;
+            bool shapeRetained = false;
+            try
+            {
+                var shapeValidation = ValidateShapeIndex(slide.Shapes.Count, shapeIndex);
+                if (shapeValidation is not null)
+                {
+                    return shapeValidation;
+                }
+
+                shape = slide.Shapes[shapeIndex];
+                shapeRetained = ctx.RetainOwnedComOwner(shape);
+                TagCollectionResult result = operation(ctx, shape, () => shape.Tags);
+                return new ShapeOperationResult
+                {
+                    Success = result.Success,
+                    ErrorMessage = result.ErrorMessage,
+                    ShapeIndex = shapeIndex,
+                    TagName = result.Name,
+                    TagValue = result.Value,
+                    TagIndex = result.Index,
+                    TagCount = result.Count,
+                    Tags = result.Tags
+                };
+            }
+            finally
+            {
+                if (shape is not null && !shapeRetained)
+                {
+                    ComUtilities.Release(ref shape);
+                }
+                if (!slideRetained)
+                {
+                    ComUtilities.Release(ref slide);
+                }
+            }
+        });
+    }
+}

--- a/src/PowerPointMcp.Core/Shape/ShapeOperationResult.cs
+++ b/src/PowerPointMcp.Core/Shape/ShapeOperationResult.cs
@@ -1,3 +1,5 @@
+using Sbroenne.PowerPointMcp.Core.Tags;
+
 namespace Sbroenne.PowerPointMcp.Core.Shape;
 
 /// <summary>
@@ -131,4 +133,19 @@ public sealed class ShapeOperationResult
 
     /// <summary>Whether a placeholder contains an image fill.</summary>
     public bool? HasImage { get; init; }
+
+    /// <summary>Normalized tag name for tag operations.</summary>
+    public string? TagName { get; init; }
+
+    /// <summary>Tag value for tag operations. Values are returned without case normalization.</summary>
+    public string? TagValue { get; init; }
+
+    /// <summary>1-based index of the tag in PowerPoint's native collection order.</summary>
+    public int? TagIndex { get; init; }
+
+    /// <summary>Number of string tags on the shape.</summary>
+    public int? TagCount { get; init; }
+
+    /// <summary>Shape tags in native 1-based collection order.</summary>
+    public IReadOnlyList<TagInfo>? Tags { get; init; }
 }

--- a/src/PowerPointMcp.Core/Slide/ISlideCommands.cs
+++ b/src/PowerPointMcp.Core/Slide/ISlideCommands.cs
@@ -133,4 +133,16 @@ public interface ISlideCommands
         int destinationSlideIndex,
         int sourceStartSlide = 1,
         int? sourceEndSlide = null);
+
+    /// <summary>Creates or updates a case-insensitive string tag on a slide.</summary>
+    SlideOperationResult SetTag(IPresentationBatch batch, int slideIndex, string tagName, [AllowEmptyString] string tagValue);
+
+    /// <summary>Gets a slide string tag by its case-insensitive name.</summary>
+    SlideOperationResult GetTag(IPresentationBatch batch, int slideIndex, string tagName);
+
+    /// <summary>Lists slide string tags in their native 1-based collection order.</summary>
+    SlideOperationResult ListTags(IPresentationBatch batch, int slideIndex);
+
+    /// <summary>Deletes a slide string tag by its case-insensitive name.</summary>
+    SlideOperationResult DeleteTag(IPresentationBatch batch, int slideIndex, string tagName);
 }

--- a/src/PowerPointMcp.Core/Slide/SlideCommands.Tags.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideCommands.Tags.cs
@@ -1,0 +1,85 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Tags;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Slide;
+
+public sealed partial class SlideCommands
+{
+    /// <inheritdoc/>
+    public SlideOperationResult SetTag(IPresentationBatch batch, int slideIndex, string tagName, string tagValue)
+    {
+        ArgumentNullException.ThrowIfNull(tagValue);
+        return ExecuteTagOperation(
+            batch,
+            slideIndex,
+            (ctx, slide, acquireTags) =>
+                TagCollectionHelper.Set(ctx, slide, acquireTags, tagName, tagValue));
+    }
+
+    /// <inheritdoc/>
+    public SlideOperationResult GetTag(IPresentationBatch batch, int slideIndex, string tagName) =>
+        ExecuteTagOperation(
+            batch,
+            slideIndex,
+            (ctx, slide, acquireTags) =>
+                TagCollectionHelper.Get(ctx, slide, acquireTags, tagName));
+
+    /// <inheritdoc/>
+    public SlideOperationResult ListTags(IPresentationBatch batch, int slideIndex) =>
+        ExecuteTagOperation(
+            batch,
+            slideIndex,
+            (ctx, slide, acquireTags) => TagCollectionHelper.List(ctx, slide, acquireTags));
+
+    /// <inheritdoc/>
+    public SlideOperationResult DeleteTag(IPresentationBatch batch, int slideIndex, string tagName) =>
+        ExecuteTagOperation(
+            batch,
+            slideIndex,
+            (ctx, slide, acquireTags) =>
+                TagCollectionHelper.Delete(ctx, slide, acquireTags, tagName));
+
+    private static SlideOperationResult ExecuteTagOperation(
+        IPresentationBatch batch,
+        int slideIndex,
+        Func<PresentationContext, PowerPoint.Slide, Func<PowerPoint.Tags>, TagCollectionResult> operation)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            var validation = ValidateSlideIndex(ctx.Presentation.Slides.Count, slideIndex);
+            if (validation is not null)
+            {
+                return validation;
+            }
+
+            PowerPoint.Slide? slide = ctx.Presentation.Slides[slideIndex];
+            bool ownerRetained = ctx.RetainOwnedComOwner(slide);
+            try
+            {
+                TagCollectionResult result = operation(ctx, slide, () => slide.Tags);
+                return new SlideOperationResult
+                {
+                    Success = result.Success,
+                    ErrorMessage = result.ErrorMessage,
+                    SlideIndex = slideIndex,
+                    TagName = result.Name,
+                    TagValue = result.Value,
+                    TagIndex = result.Index,
+                    TagCount = result.Count,
+                    Tags = result.Tags
+                };
+            }
+            finally
+            {
+                if (!ownerRetained)
+                {
+                    ComUtilities.Release(ref slide);
+                }
+            }
+        });
+    }
+}

--- a/src/PowerPointMcp.Core/Slide/SlideOperationResult.cs
+++ b/src/PowerPointMcp.Core/Slide/SlideOperationResult.cs
@@ -1,3 +1,5 @@
+using Sbroenne.PowerPointMcp.Core.Tags;
+
 namespace Sbroenne.PowerPointMcp.Core.Slide;
 
 /// <summary>
@@ -56,4 +58,19 @@ public sealed class SlideOperationResult
 
     /// <summary>New 1-based indexes assigned to imported slides.</summary>
     public IReadOnlyList<int>? ImportedSlideIndexes { get; init; }
+
+    /// <summary>Normalized tag name for tag operations.</summary>
+    public string? TagName { get; init; }
+
+    /// <summary>Tag value for tag operations. Values are returned without case normalization.</summary>
+    public string? TagValue { get; init; }
+
+    /// <summary>1-based index of the tag in PowerPoint's native collection order.</summary>
+    public int? TagIndex { get; init; }
+
+    /// <summary>Number of string tags on the slide.</summary>
+    public int? TagCount { get; init; }
+
+    /// <summary>Slide tags in native 1-based collection order.</summary>
+    public IReadOnlyList<TagInfo>? Tags { get; init; }
 }

--- a/src/PowerPointMcp.Core/Tags/TagCollectionHelper.cs
+++ b/src/PowerPointMcp.Core/Tags/TagCollectionHelper.cs
@@ -1,0 +1,189 @@
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+
+namespace Sbroenne.PowerPointMcp.Core.Tags;
+
+internal static class TagCollectionHelper
+{
+    public static TagCollectionResult Set(
+        PresentationContext context,
+        object owner,
+        Func<PowerPoint.Tags> acquireTags,
+        string tagName,
+        string value)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(acquireTags);
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (!TryNormalizeName(tagName, out string normalizedName, out TagCollectionResult? error))
+        {
+            return error;
+        }
+
+        return WithTags(context, owner, acquireTags, tags =>
+        {
+            tags.Add(normalizedName, value);
+            int index = FindIndex(tags, normalizedName);
+
+            return new TagCollectionResult
+            {
+                Success = true,
+                Name = normalizedName,
+                Value = tags[normalizedName],
+                Index = index,
+                Count = tags.Count
+            };
+        });
+    }
+
+    public static TagCollectionResult Get(
+        PresentationContext context,
+        object owner,
+        Func<PowerPoint.Tags> acquireTags,
+        string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(acquireTags);
+
+        if (!TryNormalizeName(tagName, out string normalizedName, out TagCollectionResult? error))
+        {
+            return error;
+        }
+
+        return WithTags(context, owner, acquireTags, tags =>
+        {
+            int index = FindIndex(tags, normalizedName);
+            if (index == 0)
+            {
+                return MissingTag(normalizedName, tags.Count);
+            }
+
+            string storedName = tags.Name(index);
+            return new TagCollectionResult
+            {
+                Success = true,
+                Name = normalizedName,
+                Value = tags[storedName],
+                Index = index,
+                Count = tags.Count
+            };
+        });
+    }
+
+    public static TagCollectionResult List(
+        PresentationContext context,
+        object owner,
+        Func<PowerPoint.Tags> acquireTags)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(acquireTags);
+
+        return WithTags(context, owner, acquireTags, tags =>
+        {
+            var results = new List<TagInfo>(tags.Count);
+            for (int index = 1; index <= tags.Count; index++)
+            {
+                results.Add(new TagInfo
+                {
+                    TagIndex = index,
+                    Name = tags.Name(index),
+                    Value = tags.Value(index)
+                });
+            }
+
+            return new TagCollectionResult
+            {
+                Success = true,
+                Count = tags.Count,
+                Tags = results
+            };
+        });
+    }
+
+    public static TagCollectionResult Delete(
+        PresentationContext context,
+        object owner,
+        Func<PowerPoint.Tags> acquireTags,
+        string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(acquireTags);
+
+        if (!TryNormalizeName(tagName, out string normalizedName, out TagCollectionResult? error))
+        {
+            return error;
+        }
+
+        return WithTags(context, owner, acquireTags, tags =>
+        {
+            int index = FindIndex(tags, normalizedName);
+            if (index == 0)
+            {
+                return MissingTag(normalizedName, tags.Count);
+            }
+
+            tags.Delete(tags.Name(index));
+            return new TagCollectionResult
+            {
+                Success = true,
+                Name = normalizedName,
+                Count = tags.Count
+            };
+        });
+    }
+
+    private static T WithTags<T>(
+        PresentationContext context,
+        object owner,
+        Func<PowerPoint.Tags> acquireTags,
+        Func<PowerPoint.Tags, T> operation)
+    {
+        PowerPoint.Tags tags = context.GetOrAddOwnedComResource(owner, acquireTags);
+        return operation(tags);
+    }
+
+    private static int FindIndex(PowerPoint.Tags tags, string normalizedName)
+    {
+        for (int index = 1; index <= tags.Count; index++)
+        {
+            if (string.Equals(tags.Name(index), normalizedName, StringComparison.OrdinalIgnoreCase))
+            {
+                return index;
+            }
+        }
+
+        return 0;
+    }
+
+    private static bool TryNormalizeName(
+        string tagName,
+        out string normalizedName,
+        out TagCollectionResult error)
+    {
+        if (!string.IsNullOrWhiteSpace(tagName))
+        {
+            normalizedName = tagName.ToUpperInvariant();
+            error = null!;
+            return true;
+        }
+
+        normalizedName = string.Empty;
+        error = new TagCollectionResult
+        {
+            ErrorMessage = "A tag name is required."
+        };
+        return false;
+    }
+
+    private static TagCollectionResult MissingTag(string normalizedName, int count) => new()
+    {
+        ErrorMessage = $"No string tag named '{normalizedName}' was found.",
+        Name = normalizedName,
+        Count = count
+    };
+}

--- a/src/PowerPointMcp.Core/Tags/TagCollectionResult.cs
+++ b/src/PowerPointMcp.Core/Tags/TagCollectionResult.cs
@@ -1,0 +1,18 @@
+namespace Sbroenne.PowerPointMcp.Core.Tags;
+
+internal sealed class TagCollectionResult
+{
+    public bool Success { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public string? Name { get; init; }
+
+    public string? Value { get; init; }
+
+    public int? Index { get; init; }
+
+    public int Count { get; init; }
+
+    public IReadOnlyList<TagInfo>? Tags { get; init; }
+}

--- a/src/PowerPointMcp.Core/Tags/TagInfo.cs
+++ b/src/PowerPointMcp.Core/Tags/TagInfo.cs
@@ -1,0 +1,14 @@
+namespace Sbroenne.PowerPointMcp.Core.Tags;
+
+/// <summary>A PowerPoint string tag in its native 1-based collection order.</summary>
+public sealed class TagInfo
+{
+    /// <summary>1-based index in the owner's native tag collection.</summary>
+    public required int TagIndex { get; init; }
+
+    /// <summary>Normalized, case-insensitive tag name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Tag value exactly as stored in PowerPoint.</summary>
+    public required string Value { get; init; }
+}

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,13 +32,13 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**15 tools with 162 operations across 15 domains:**
+**15 tools with 174 operations across 15 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
-| `presentation` | 16 | create, open, Save As, Save Copy As, close, list, apply-template, get-theme-name, get-final, set-final, built-in/custom document properties |
-| `slide` | 19 | slide lifecycle, backgrounds, sections, comments, slide import |
-| `shape` | 39 | shape creation, styling, grouping, hyperlinks, placeholders |
+| `presentation` | 20 | create, open, Save As, Save Copy As, close, list, templates, get/set final, document properties, string tags |
+| `slide` | 23 | slide lifecycle, backgrounds, sections, comments, import, string tags |
+| `shape` | 43 | shape creation, styling, grouping, hyperlinks, placeholders, string tags |
 | `textframe` | 20 | text content, font formatting, alignment, bullets, auto-size |
 | `table` | 12 | tables, cell text, row/column edits, cell fill/border, merge |
 | `notes` | 2 | set/get speaker notes |

--- a/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
+++ b/src/PowerPointMcp.McpServer/Tools/PresentationTools.cs
@@ -7,9 +7,9 @@ namespace Sbroenne.PowerPointMcp.McpServer.Tools;
 
 /// <summary>
 /// Single action-dispatch MCP tool for presentation lifecycle, template application, and
-/// document-property operations: create a file, open/close/test a session, list open
-/// sessions, apply a template, read/write document properties, and manage the advisory Mark as
-/// Final editing flag.
+/// document-property and string-tag operations: create a file, open/close/test a session, list
+/// open sessions, Save As/copy, apply a template, read/write document properties, manage the
+/// advisory Mark as Final flag, and manage string tags.
 /// </summary>
 /// <remarks>
 /// Mirrors mcp-server-excel's <c>ExcelFileTool</c> shape (one hand-written tool named
@@ -30,15 +30,15 @@ public static class PresentationTools
     private static readonly PresentationCommands Commands = new();
 
     /// <summary>
-    /// Presentation lifecycle, template, document-property, and advisory Mark as Final operations
-    /// for an already-open or about-to-be-opened presentation.
+    /// Presentation lifecycle, Save As/copy, template, document-property, advisory Mark as Final,
+    /// and string-tag operations for an already-open or about-to-be-opened presentation.
     /// </summary>
     [McpServerTool(Name = "presentation")]
-    [Description("Presentation lifecycle (create, open, close, list sessions, test), Save As/copy, template restyling, document-property operations, and PowerPoint's advisory Mark as Final editing flag. Mark as Final is not authentication, encryption, or access control. Actions: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")]
+    [Description("Presentation lifecycle, Save As/copy, template, document-property, advisory Mark as Final, and string-tag operations. Mark as Final is not authentication, encryption, or access control. Actions: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property, set-tag, get-tag, list-tags, delete-tag.")]
     public static string Presentation(
-        [Description("The action to perform. One of: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] PresentationToolAction action,
+        [Description("The action to perform. One of: create, open, close, list, test, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property, set-tag, get-tag, list-tags, delete-tag.")] PresentationToolAction action,
         [Description("Full Windows path to the presentation file. Required for: create (new .pptx/.pptm file; containing directory must already exist), open or test (existing .pptx/.pptm/.ppt file).")] string? filePath = null,
-        [Description("The sessionId returned by create or open. Required for: close, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? sessionId = null,
+        [Description("The sessionId returned by create or open. Required for: close, save-as, save-copy-as, apply-template, get-theme-name, get-final, set-final, set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property, set-tag, get-tag, list-tags, delete-tag.")] string? sessionId = null,
         [Description("Save the presentation before closing. Used for: close. Default: false.")] bool? save = null,
         [Description("Set true only when creating a macro-enabled .pptm file. Default: false. Used for: create.")] bool? isMacroEnabled = null,
         [Description("Full Windows destination path. Required for: save-as, save-copy-as. The containing directory must already exist.")] string? targetPath = null,
@@ -48,10 +48,12 @@ public static class PresentationTools
         [Description("Set true to save current changes and mark the presentation as final, or false to clear the flag. Required for: set-final. Mark as Final is an advisory editing flag only; it is not authentication, encryption, or access control.")] bool? isFinal = null,
         [Description("Document property name. For set/get-document-property, one of: Title, Subject, Author, Keywords, Comments, Category, Manager, Company (case-insensitive). For custom-property actions, any user-defined name. Required for: set-document-property, get-document-property, set-custom-property, get-custom-property, remove-custom-property.")] string? propertyName = null,
         [Description("The new property value. Required for: set-document-property, set-custom-property.")] string? value = null,
+        [Description("Case-insensitive string tag name. Letter casing is normalized to invariant uppercase; whitespace is preserved. Required for: set-tag, get-tag, delete-tag.")] string? tagName = null,
+        [Description("String tag value, preserved exactly without case normalization. Required for: set-tag.")] string? tagValue = null,
         PresentationSessionRegistry? registry = null)
         => PowerPointToolsBase.ExecuteToolAction("presentation", action.ToActionString(), () =>
         {
-            ValidateActionParameters(action, filePath, sessionId, save, isMacroEnabled, targetPath, format, overwrite, templatePath, isFinal, propertyName, value);
+            ValidateActionParameters(action, filePath, sessionId, save, isMacroEnabled, targetPath, format, overwrite, templatePath, isFinal, propertyName, value, tagName, tagValue);
             var reg = registry!;
             return action switch
             {
@@ -71,6 +73,10 @@ public static class PresentationTools
                 PresentationToolAction.SetCustomProperty => HandleSetCustomProperty(sessionId, propertyName, value, reg),
                 PresentationToolAction.GetCustomProperty => HandleGetCustomProperty(sessionId, propertyName, reg),
                 PresentationToolAction.RemoveCustomProperty => HandleRemoveCustomProperty(sessionId, propertyName, reg),
+                PresentationToolAction.SetTag => HandleSetTag(sessionId, tagName, tagValue, reg),
+                PresentationToolAction.GetTag => HandleGetTag(sessionId, tagName, reg),
+                PresentationToolAction.ListTags => HandleListTags(sessionId, reg),
+                PresentationToolAction.DeleteTag => HandleDeleteTag(sessionId, tagName, reg),
                 _ => PowerPointToolsBase.ValidationError($"Unknown action: {action}")
             };
         });
@@ -87,7 +93,9 @@ public static class PresentationTools
         string? templatePath,
         bool? isFinal,
         string? propertyName,
-        string? value)
+        string? value,
+        string? tagName,
+        string? tagValue)
     {
         var supplied = new List<string>();
         if (filePath != null) supplied.Add("filePath");
@@ -101,6 +109,8 @@ public static class PresentationTools
         if (isFinal != null) supplied.Add("isFinal");
         if (propertyName != null) supplied.Add("propertyName");
         if (value != null) supplied.Add("value");
+        if (tagName != null) supplied.Add("tagName");
+        if (tagValue != null) supplied.Add("tagValue");
 
         string[] allowedParameters = action switch
         {
@@ -114,6 +124,9 @@ public static class PresentationTools
             PresentationToolAction.SetFinal => ["sessionId", "isFinal"],
             PresentationToolAction.SetDocumentProperty or PresentationToolAction.SetCustomProperty => ["sessionId", "propertyName", "value"],
             PresentationToolAction.GetDocumentProperty or PresentationToolAction.GetCustomProperty or PresentationToolAction.RemoveCustomProperty => ["sessionId", "propertyName"],
+            PresentationToolAction.SetTag => ["sessionId", "tagName", "tagValue"],
+            PresentationToolAction.GetTag or PresentationToolAction.DeleteTag => ["sessionId", "tagName"],
+            PresentationToolAction.ListTags => ["sessionId"],
             _ => []
         };
         var allowed = new HashSet<string>(allowedParameters, StringComparer.Ordinal);
@@ -462,6 +475,70 @@ public static class PresentationTools
         return SerializeResult(Commands.RemoveCustomProperty(batch, propertyName));
     }
 
+    private static string HandleSetTag(
+        string? sessionId,
+        string? tagName,
+        string? tagValue,
+        PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            return PowerPointToolsBase.ValidationError("tagName is required for action=set-tag.");
+        }
+
+        if (tagValue is null)
+        {
+            return PowerPointToolsBase.ValidationError("tagValue is required for action=set-tag.");
+        }
+
+        return SerializeResult(Commands.SetTag(batch, tagName, tagValue));
+    }
+
+    private static string HandleGetTag(string? sessionId, string? tagName, PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            return PowerPointToolsBase.ValidationError("tagName is required for action=get-tag.");
+        }
+
+        return SerializeResult(Commands.GetTag(batch, tagName));
+    }
+
+    private static string HandleListTags(string? sessionId, PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        return SerializeResult(Commands.ListTags(batch));
+    }
+
+    private static string HandleDeleteTag(string? sessionId, string? tagName, PresentationSessionRegistry registry)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !registry.TryGet(sessionId, out var batch))
+        {
+            return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+        }
+
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            return PowerPointToolsBase.ValidationError("tagName is required for action=delete-tag.");
+        }
+
+        return SerializeResult(Commands.DeleteTag(batch, tagName));
+    }
+
     private static string SerializeResult(PresentationOperationResult result)
     {
         if (result.Success)
@@ -473,7 +550,12 @@ public static class PresentationTools
                 themeName = result.ThemeName,
                 isFinal = result.IsFinal,
                 propertyName = result.PropertyName,
-                propertyValue = result.PropertyValue
+                propertyValue = result.PropertyValue,
+                tagName = result.TagName,
+                tagValue = result.TagValue,
+                tagIndex = result.TagIndex,
+                tagCount = result.TagCount,
+                tags = result.Tags
             });
         }
 
@@ -486,6 +568,11 @@ public static class PresentationTools
             isFinal = result.IsFinal,
             propertyName = result.PropertyName,
             propertyValue = result.PropertyValue,
+            tagName = result.TagName,
+            tagValue = result.TagValue,
+            tagIndex = result.TagIndex,
+            tagCount = result.TagCount,
+            tags = result.Tags,
             isError = true
         });
     }

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -329,7 +329,7 @@ public sealed class PowerPointMcpService : IDisposable
             "apply-template" or "get-theme-name" or "get-final" or "set-final" or
             "set-document-property" or
             "get-document-property" or "set-custom-property" or "get-custom-property" or
-            "remove-custom-property"))
+            "remove-custom-property" or "set-tag" or "get-tag" or "list-tags" or "delete-tag"))
         {
             return new ServiceResponse { Success = false, ErrorMessage = $"Unknown session action: {action}" };
         }
@@ -353,6 +353,10 @@ public sealed class PowerPointMcpService : IDisposable
             "set-custom-property" => HandleSessionSetCustomProperty(request),
             "get-custom-property" => HandleSessionGetCustomProperty(request),
             "remove-custom-property" => HandleSessionRemoveCustomProperty(request),
+            "set-tag" => HandleSessionSetTag(request),
+            "get-tag" => HandleSessionGetTag(request),
+            "list-tags" => HandleSessionListTags(request),
+            "delete-tag" => HandleSessionDeleteTag(request),
             _ => throw new InvalidOperationException($"Unhandled session action: {action}")
         };
     }
@@ -369,6 +373,8 @@ public sealed class PowerPointMcpService : IDisposable
             "set-final" => ["isFinal"],
             "set-document-property" or "set-custom-property" => ["propertyName", "value"],
             "get-document-property" or "get-custom-property" or "remove-custom-property" => ["propertyName"],
+            "set-tag" => ["tagName", "tagValue"],
+            "get-tag" or "delete-tag" => ["tagName"],
             _ => []
         };
         var allowed = new HashSet<string>(allowedParameters, StringComparer.Ordinal);
@@ -692,6 +698,68 @@ public sealed class PowerPointMcpService : IDisposable
         return WrapPresentationResult(() => _presentationCommands.RemoveCustomProperty(batch!, args.PropertyName), request);
     }
 
+    private ServiceResponse HandleSessionSetTag(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionTagArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.TagName))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "tagName is required" };
+        }
+        if (args.TagValue is null)
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "tagValue is required" };
+        }
+
+        return WrapPresentationResult(() => _presentationCommands.SetTag(batch!, args.TagName, args.TagValue), request);
+    }
+
+    private ServiceResponse HandleSessionGetTag(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionTagArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.TagName))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "tagName is required" };
+        }
+
+        return WrapPresentationResult(() => _presentationCommands.GetTag(batch!, args.TagName), request);
+    }
+
+    private ServiceResponse HandleSessionListTags(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        return WrapPresentationResult(() => _presentationCommands.ListTags(batch!), request);
+    }
+
+    private ServiceResponse HandleSessionDeleteTag(ServiceRequest request)
+    {
+        if (!TryGetBatch(request, out var batch, out var error))
+        {
+            return error!;
+        }
+
+        var args = ServiceRegistry.DeserializeArgs<SessionTagArgs>(request.Args);
+        if (string.IsNullOrWhiteSpace(args.TagName))
+        {
+            return new ServiceResponse { Success = false, ErrorMessage = "tagName is required" };
+        }
+
+        return WrapPresentationResult(() => _presentationCommands.DeleteTag(batch!, args.TagName), request);
+    }
+
     /// <summary>
     /// Resolves <paramref name="request"/>'s sessionId to a live batch, mirroring the
     /// validation used by <see cref="DispatchSimple{TAction}"/> for the fully-generated
@@ -735,7 +803,12 @@ public sealed class PowerPointMcpService : IDisposable
                 themeName = result.ThemeName,
                 isFinal = result.IsFinal,
                 propertyName = result.PropertyName,
-                propertyValue = result.PropertyValue
+                propertyValue = result.PropertyValue,
+                tagName = result.TagName,
+                tagValue = result.TagValue,
+                tagIndex = result.TagIndex,
+                tagCount = result.TagCount,
+                tags = result.Tags
             }, ServiceProtocol.JsonOptions);
 
             return new ServiceResponse { Success = result.Success, Result = json, ErrorMessage = result.Success ? null : result.ErrorMessage };
@@ -920,4 +993,14 @@ public sealed class SessionPropertyArgs
 
     /// <summary>The new property value. Used for set-document-property and set-custom-property.</summary>
     public string? Value { get; set; }
+}
+
+/// <summary>Args for presentation string-tag actions.</summary>
+public sealed class SessionTagArgs
+{
+    /// <summary>Case-insensitive tag name.</summary>
+    public string? TagName { get; set; }
+
+    /// <summary>Tag value for set-tag. Preserved exactly.</summary>
+    public string? TagValue { get; set; }
 }

--- a/tests/PowerPointMcp.CLI.Tests/TagCommandContractTests.cs
+++ b/tests/PowerPointMcp.CLI.Tests/TagCommandContractTests.cs
@@ -1,0 +1,26 @@
+using Sbroenne.PowerPointMcp.CLI.Commands;
+using Spectre.Console.Cli;
+
+namespace Sbroenne.PowerPointMcp.CLI.Tests;
+
+public sealed class TagCommandContractTests
+{
+    [Fact]
+    public void PresentationTagCommands_ExposeStrictSettings()
+    {
+        Assert.True(typeof(AsyncCommand<SessionTagSetSettings>).IsAssignableFrom(typeof(SessionSetTagCommand)));
+        Assert.True(typeof(AsyncCommand<SessionTagGetSettings>).IsAssignableFrom(typeof(SessionGetTagCommand)));
+        Assert.True(typeof(AsyncCommand<SessionIdSettings>).IsAssignableFrom(typeof(SessionListTagsCommand)));
+        Assert.True(typeof(AsyncCommand<SessionTagGetSettings>).IsAssignableFrom(typeof(SessionDeleteTagCommand)));
+
+        var settings = new SessionTagSetSettings
+        {
+            SessionId = "session",
+            TagName = "OWNER",
+            TagValue = "MiXeD Value"
+        };
+        Assert.Equal("session", settings.SessionId);
+        Assert.Equal("OWNER", settings.TagName);
+        Assert.Equal("MiXeD Value", settings.TagValue);
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/PresentationPropertiesTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PresentationPropertiesTests.cs
@@ -147,4 +147,99 @@ public partial class PresentationPropertiesTests : IClassFixture<SharedPresentat
         Assert.False(result.Success);
         Assert.Contains("DoesNotExist", result.ErrorMessage);
     }
+
+    [Fact]
+    public void Tags_CrudIsCaseInsensitive_EnumeratesOneBased_AndPersists()
+    {
+        _fixture.CreateFreshPresentation();
+        var batch = _fixture.Batch;
+
+        var firstSet = _commands.SetTag(batch, " ReviewState ", "MiXeD Value");
+        Assert.True(firstSet.Success, firstSet.ErrorMessage);
+        Assert.Equal(" REVIEWSTATE ", firstSet.TagName);
+        Assert.Equal("MiXeD Value", firstSet.TagValue);
+        Assert.Equal(1, firstSet.TagCount);
+
+        var updated = _commands.SetTag(batch, " reviewstate ", "Updated Value");
+        Assert.True(updated.Success, updated.ErrorMessage);
+        Assert.Equal(1, updated.TagCount);
+
+        var secondSet = _commands.SetTag(batch, "Owner", "Alice");
+        Assert.True(secondSet.Success, secondSet.ErrorMessage);
+        Assert.Equal(2, secondSet.TagCount);
+
+        var unspacedSet = _commands.SetTag(batch, "ReviewState", "Unspaced Value");
+        Assert.True(unspacedSet.Success, unspacedSet.ErrorMessage);
+        Assert.Equal(3, unspacedSet.TagCount);
+
+        var get = _commands.GetTag(batch, " ReViEwStAtE ");
+        Assert.True(get.Success, get.ErrorMessage);
+        Assert.Equal(" REVIEWSTATE ", get.TagName);
+        Assert.Equal("Updated Value", get.TagValue);
+        Assert.Equal(1, get.TagIndex);
+
+        var unspacedGet = _commands.GetTag(batch, "reviewstate");
+        Assert.True(unspacedGet.Success, unspacedGet.ErrorMessage);
+        Assert.Equal("REVIEWSTATE", unspacedGet.TagName);
+        Assert.Equal("Unspaced Value", unspacedGet.TagValue);
+        Assert.Equal(3, unspacedGet.TagIndex);
+
+        var listed = _commands.ListTags(batch);
+        Assert.True(listed.Success, listed.ErrorMessage);
+        Assert.Equal(3, listed.TagCount);
+        Assert.Collection(
+            listed.Tags!,
+            tag =>
+            {
+                Assert.Equal(1, tag.TagIndex);
+                Assert.Equal(" REVIEWSTATE ", tag.Name);
+                Assert.Equal("Updated Value", tag.Value);
+            },
+            tag =>
+            {
+                Assert.Equal(2, tag.TagIndex);
+                Assert.Equal("OWNER", tag.Name);
+                Assert.Equal("Alice", tag.Value);
+            },
+            tag =>
+            {
+                Assert.Equal(3, tag.TagIndex);
+                Assert.Equal("REVIEWSTATE", tag.Name);
+                Assert.Equal("Unspaced Value", tag.Value);
+            });
+
+        Assert.True(_commands.Save(batch).Success);
+        _fixture.ReopenCurrentPresentation();
+
+        var persisted = _commands.GetTag(batch, " reviewstate ");
+        Assert.True(persisted.Success, persisted.ErrorMessage);
+        Assert.Equal("Updated Value", persisted.TagValue);
+
+        var deleted = _commands.DeleteTag(batch, " REVIEWSTATE ");
+        Assert.True(deleted.Success, deleted.ErrorMessage);
+        Assert.Equal(2, deleted.TagCount);
+
+        var missingGet = _commands.GetTag(batch, " reviewstate ");
+        Assert.False(missingGet.Success);
+        Assert.Contains("REVIEWSTATE", missingGet.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+
+        var missingDelete = _commands.DeleteTag(batch, " reviewstate ");
+        Assert.False(missingDelete.Success);
+
+        Assert.True(_commands.ListTags(batch).Success);
+        Assert.True(_commands.GetTag(batch, "owner").Success);
+        Assert.True(_commands.GetTag(batch, "reviewstate").Success);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Tags_WithBlankName_ReturnFailure(string tagName)
+    {
+        _fixture.CreateFreshPresentation();
+
+        Assert.False(_commands.SetTag(_fixture.Batch, tagName, "value").Success);
+        Assert.False(_commands.GetTag(_fixture.Batch, tagName).Success);
+        Assert.False(_commands.DeleteTag(_fixture.Batch, tagName).Success);
+    }
 }

--- a/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/ShapeCommandsTests.cs
@@ -820,4 +820,72 @@ public class ShapeCommandsTests : IClassFixture<SharedPresentationFixture>
             File.Delete(imagePath);
         }
     }
+
+    [Fact]
+    public void Tags_CrudIsCaseInsensitive_EnumeratesOneBased_AndPersists()
+    {
+        _fixture.CreateFreshPresentation();
+        Assert.True(_commands.AddRectangle(_fixture.Batch, 1, 10f, 10f, 100f, 50f).Success);
+
+        var firstSet = _commands.SetTag(_fixture.Batch, 1, 1, " ReviewState ", "MiXeD Value");
+        Assert.True(firstSet.Success, firstSet.ErrorMessage);
+        Assert.Equal(" REVIEWSTATE ", firstSet.TagName);
+        Assert.Equal("MiXeD Value", firstSet.TagValue);
+        Assert.Equal(1, firstSet.TagCount);
+
+        var updated = _commands.SetTag(_fixture.Batch, 1, 1, " reviewstate ", "Updated Value");
+        Assert.True(updated.Success, updated.ErrorMessage);
+        Assert.Equal(1, updated.TagCount);
+
+        Assert.True(_commands.SetTag(_fixture.Batch, 1, 1, "Owner", "Alice").Success);
+        Assert.True(_commands.SetTag(_fixture.Batch, 1, 1, "ReviewState", "Unspaced Value").Success);
+
+        var get = _commands.GetTag(_fixture.Batch, 1, 1, " ReViEwStAtE ");
+        Assert.True(get.Success, get.ErrorMessage);
+        Assert.Equal(" REVIEWSTATE ", get.TagName);
+        Assert.Equal("Updated Value", get.TagValue);
+        Assert.Equal(1, get.TagIndex);
+
+        var unspacedGet = _commands.GetTag(_fixture.Batch, 1, 1, "reviewstate");
+        Assert.True(unspacedGet.Success, unspacedGet.ErrorMessage);
+        Assert.Equal("Unspaced Value", unspacedGet.TagValue);
+        Assert.Equal(3, unspacedGet.TagIndex);
+
+        var listed = _commands.ListTags(_fixture.Batch, 1, 1);
+        Assert.True(listed.Success, listed.ErrorMessage);
+        Assert.Equal(3, listed.TagCount);
+        Assert.Equal([1, 2, 3], listed.Tags!.Select(tag => tag.TagIndex));
+        Assert.Equal([" REVIEWSTATE ", "OWNER", "REVIEWSTATE"], listed.Tags!.Select(tag => tag.Name));
+
+        Assert.True(_presentationCommands.Save(_fixture.Batch).Success);
+        _fixture.ReopenCurrentPresentation();
+        Assert.Equal("Updated Value", _commands.GetTag(_fixture.Batch, 1, 1, " reviewstate ").TagValue);
+
+        var deleted = _commands.DeleteTag(_fixture.Batch, 1, 1, " REVIEWSTATE ");
+        Assert.True(deleted.Success, deleted.ErrorMessage);
+        Assert.Equal(2, deleted.TagCount);
+        Assert.False(_commands.GetTag(_fixture.Batch, 1, 1, " reviewstate ").Success);
+        Assert.False(_commands.DeleteTag(_fixture.Batch, 1, 1, " reviewstate ").Success);
+        Assert.True(_commands.GetTag(_fixture.Batch, 1, 1, "reviewstate").Success);
+
+        Assert.True(_commands.ListTags(_fixture.Batch, 1, 1).Success);
+        Assert.Equal(1, _commands.GetCount(_fixture.Batch, 1).ShapeCount);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(99, 1)]
+    [InlineData(1, 0)]
+    [InlineData(1, 99)]
+    public void Tags_WithInvalidOwnerIndex_ReturnFailure(int slideIndex, int shapeIndex)
+    {
+        _fixture.CreateFreshPresentation();
+        Assert.True(_commands.AddRectangle(_fixture.Batch, 1, 10f, 10f, 100f, 50f).Success);
+
+        Assert.False(_commands.SetTag(_fixture.Batch, slideIndex, shapeIndex, "name", "value").Success);
+        Assert.False(_commands.GetTag(_fixture.Batch, slideIndex, shapeIndex, "name").Success);
+        Assert.False(_commands.ListTags(_fixture.Batch, slideIndex, shapeIndex).Success);
+        Assert.False(_commands.DeleteTag(_fixture.Batch, slideIndex, shapeIndex, "name").Success);
+        Assert.Equal(1, _commands.GetCount(_fixture.Batch, 1).ShapeCount);
+    }
 }

--- a/tests/PowerPointMcp.Core.Tests/SlideCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/SlideCommandsTests.cs
@@ -487,4 +487,67 @@ public class SlideCommandsTests : IClassFixture<SharedPresentationFixture>
         Assert.False(invalidDestination.Success);
         Assert.False(string.IsNullOrWhiteSpace(invalidDestination.ErrorMessage));
     }
+
+    [Fact]
+    public void Tags_CrudIsCaseInsensitive_EnumeratesOneBased_AndPersists()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var firstSet = _commands.SetTag(_fixture.Batch, 1, " ReviewState ", "MiXeD Value");
+        Assert.True(firstSet.Success, firstSet.ErrorMessage);
+        Assert.Equal(" REVIEWSTATE ", firstSet.TagName);
+        Assert.Equal("MiXeD Value", firstSet.TagValue);
+        Assert.Equal(1, firstSet.TagCount);
+
+        var updated = _commands.SetTag(_fixture.Batch, 1, " reviewstate ", "Updated Value");
+        Assert.True(updated.Success, updated.ErrorMessage);
+        Assert.Equal(1, updated.TagCount);
+
+        Assert.True(_commands.SetTag(_fixture.Batch, 1, "Owner", "Alice").Success);
+        Assert.True(_commands.SetTag(_fixture.Batch, 1, "ReviewState", "Unspaced Value").Success);
+
+        var get = _commands.GetTag(_fixture.Batch, 1, " ReViEwStAtE ");
+        Assert.True(get.Success, get.ErrorMessage);
+        Assert.Equal(" REVIEWSTATE ", get.TagName);
+        Assert.Equal("Updated Value", get.TagValue);
+        Assert.Equal(1, get.TagIndex);
+
+        var unspacedGet = _commands.GetTag(_fixture.Batch, 1, "reviewstate");
+        Assert.True(unspacedGet.Success, unspacedGet.ErrorMessage);
+        Assert.Equal("Unspaced Value", unspacedGet.TagValue);
+        Assert.Equal(3, unspacedGet.TagIndex);
+
+        var listed = _commands.ListTags(_fixture.Batch, 1);
+        Assert.True(listed.Success, listed.ErrorMessage);
+        Assert.Equal(3, listed.TagCount);
+        Assert.Equal([1, 2, 3], listed.Tags!.Select(tag => tag.TagIndex));
+        Assert.Equal([" REVIEWSTATE ", "OWNER", "REVIEWSTATE"], listed.Tags!.Select(tag => tag.Name));
+
+        Assert.True(_presentationCommands.Save(_fixture.Batch).Success);
+        _fixture.ReopenCurrentPresentation();
+        Assert.Equal("Updated Value", _commands.GetTag(_fixture.Batch, 1, " reviewstate ").TagValue);
+
+        var deleted = _commands.DeleteTag(_fixture.Batch, 1, " REVIEWSTATE ");
+        Assert.True(deleted.Success, deleted.ErrorMessage);
+        Assert.Equal(2, deleted.TagCount);
+        Assert.False(_commands.GetTag(_fixture.Batch, 1, " reviewstate ").Success);
+        Assert.False(_commands.DeleteTag(_fixture.Batch, 1, " reviewstate ").Success);
+        Assert.True(_commands.GetTag(_fixture.Batch, 1, "reviewstate").Success);
+
+        Assert.True(_commands.ListTags(_fixture.Batch, 1).Success);
+        Assert.Equal(1, _commands.GetCount(_fixture.Batch).SlideCount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(99)]
+    public void Tags_WithInvalidSlideIndex_ReturnFailure(int slideIndex)
+    {
+        _fixture.CreateFreshPresentation();
+
+        Assert.False(_commands.SetTag(_fixture.Batch, slideIndex, "name", "value").Success);
+        Assert.False(_commands.GetTag(_fixture.Batch, slideIndex, "name").Success);
+        Assert.False(_commands.ListTags(_fixture.Batch, slideIndex).Success);
+        Assert.False(_commands.DeleteTag(_fixture.Batch, slideIndex, "name").Success);
+    }
 }

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/GeneratedContractTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/GeneratedContractTests.cs
@@ -99,4 +99,30 @@ public sealed class GeneratedContractTests
                 ContractValue.FirstValue,
                 "value"));
     }
+
+    [Fact]
+    public void TagActions_AreGeneratedForSlideAndShape()
+    {
+        string[] expected = ["set-tag", "get-tag", "list-tags", "delete-tag"];
+
+        Assert.All(expected, action => Assert.Contains(action, ServiceRegistry.Slide.ValidActions));
+        Assert.All(expected, action => Assert.Contains(action, ServiceRegistry.Shape.ValidActions));
+    }
+
+    [Fact]
+    public void TagActions_EnforceRequiredAndApplicableParameters()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Slide.ValidateActionArguments(
+                "set-tag",
+                """{"slideIndex":1,"tagName":"OWNER"}"""));
+
+        Assert.Throws<ArgumentException>(() =>
+            ServiceRegistry.Shape.RouteCliArgs(
+                "get-tag",
+                slideIndex: 1,
+                shapeIndex: 1,
+                tagName: "OWNER",
+                tagValue: "not-applicable"));
+    }
 }

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -297,6 +297,60 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
         return json.RootElement.Clone();
     }
 
+    [Fact]
+    public async Task TagSchemas_ExposeAllOwnerActionsAndStrictParameters()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+
+        var presentation = Assert.Single(tools, tool => tool.Name == "presentation");
+        AssertTagSchema(
+            presentation.JsonSchema,
+            expectedProperties: ["action", "sessionId", "tagName", "tagValue"],
+            forbiddenProperties: ["slide_index", "shape_index", "binary_value"]);
+
+        var slide = Assert.Single(tools, tool => tool.Name == "slide");
+        AssertTagSchema(
+            slide.JsonSchema,
+            expectedProperties: ["action", "session_id", "slide_index", "tag_name", "tag_value"],
+            forbiddenProperties: ["shape_index", "binary_value"]);
+
+        var shape = Assert.Single(tools, tool => tool.Name == "shape");
+        AssertTagSchema(
+            shape.JsonSchema,
+            expectedProperties: ["action", "session_id", "slide_index", "shape_index", "tag_name", "tag_value"],
+            forbiddenProperties: ["binary_value"]);
+    }
+
+    private static void AssertTagSchema(
+        System.Text.Json.JsonElement schema,
+        IReadOnlyList<string> expectedProperties,
+        IReadOnlyList<string> forbiddenProperties)
+    {
+        var actions = schema
+            .GetProperty("properties")
+            .GetProperty("action")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(value => value.GetString())
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Contains("set-tag", actions);
+        Assert.Contains("get-tag", actions);
+        Assert.Contains("list-tags", actions);
+        Assert.Contains("delete-tag", actions);
+
+        var properties = schema.GetProperty("properties");
+        foreach (string property in expectedProperties)
+        {
+            Assert.True(properties.TryGetProperty(property, out _), $"Expected schema property '{property}'.");
+        }
+
+        foreach (string property in forbiddenProperties)
+        {
+            Assert.False(properties.TryGetProperty(property, out _), $"Unexpected schema property '{property}'.");
+        }
+    }
+
     /// <summary>
     /// Server info/instructions surfaced via the MCP protocol match Program.cs's configuration.
     /// </summary>


### PR DESCRIPTION
## Summary
- add typed PowerPoint string-tag CRUD to presentation, slide, and shape with full MCP and CLI parity
- centralize case-insensitive lookup, 1-based enumeration, and deterministic COM ownership in a shared Core helper
- preserve tag-name whitespace while normalizing case, preserve values exactly, and document the feature across skills, website, audit, counts, and Changesets

## Validation
- focused real-PowerPoint tags: 11/11 passed
- real-PowerPoint domain filters: Presentation 39/39, Shape 54/54, Slide 27/27
- Release build: 0 warnings, 0 errors
- non-COM MCP contracts: 26/26; CLI tag contract: 1/1; skill/release packaging: 65/65
- Success invariant, COM leak, dynamic-cast, Core-interface, documentation-count, diff, and documentation build checks passed
- full MCP gate: 30/31 passed; the sole immediate post-shutdown process-list assertion was explicitly waived because repository guidance documents benign 90-200+ second Office post-Quit latency and the reported owned PID self-exited