### PR TITLE
Fix CLI help test console isolation

### DIFF
--- a/tests/PowerPointMcp.CLI.Tests/SessionCommandContractTests.cs
+++ b/tests/PowerPointMcp.CLI.Tests/SessionCommandContractTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Sbroenne.PowerPointMcp.Core.Presentation;
 using Sbroenne.PowerPointMcp.Service;
@@ -9,21 +10,27 @@ public sealed class SessionCommandContractTests
     [Fact]
     public async Task SessionHelp_ListsSaveAsAndSaveCopyAs()
     {
-        var originalOut = Console.Out;
-        using var output = new StringWriter();
-        Console.SetOut(output);
-        try
+        var startInfo = new ProcessStartInfo
         {
-            int exitCode = await Program.Main(["session", "--help"]);
+            FileName = Path.Combine(AppContext.BaseDirectory, "powerpointcli.exe"),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("session");
+        startInfo.ArgumentList.Add("--help");
 
-            Assert.Equal(0, exitCode);
-            Assert.Contains("save-as", output.ToString(), StringComparison.Ordinal);
-            Assert.Contains("save-copy-as", output.ToString(), StringComparison.Ordinal);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        Assert.True(process.ExitCode == 0, error);
+        Assert.Contains("save-as", output, StringComparison.Ordinal);
+        Assert.Contains("save-copy-as", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- run the CLI help contract through the built `powerpointcli.exe` instead of replacing process-wide `Console.Out`
- isolate help output capture from Spectre.Console.Cli's cached writer so later `Program.Main` tests cannot write through a disposed `StringWriter`

## Validation
- reproduced the order-dependent failure in the full CLI suite: 15/16 passed with `ObjectDisposedException: Cannot write to a closed TextWriter`
- full CLI suite passed 16/16 twice after the fix
- Release solution build passed with 0 warnings and 0 errors using `PowerPointMcpSkipCleanup=true`
- no PowerPoint/COM tests or processes were launched

This is a test-only correction, so repository policy uses the `skip-changelog` label instead of a Changesets fragment.