### PR TITLE
Add audio and video media support

### DIFF
--- a/.changeset/bright-media-support.md
+++ b/.changeset/bright-media-support.md
@@ -2,6 +2,7 @@
 "powerpointmcp": minor
 ---
 
-Add generated `media` MCP and CLI commands for embedded or linked audio/video insertion and native
-PowerPoint media metadata read-back. Generated Core validation failures now propagate as failed
-service responses while preserving their original structured result payload for service clients.
+Add generated `media` MCP and CLI commands for embedded, link-only, or linked-and-saved audio/video
+insertion and native PowerPoint media metadata read-back. Generated Core validation failures now
+propagate as failed service responses while preserving their original structured result payload
+for service clients.

--- a/.changeset/bright-media-support.md
+++ b/.changeset/bright-media-support.md
@@ -3,4 +3,5 @@
 ---
 
 Add generated `media` MCP and CLI commands for embedded or linked audio/video insertion and native
-PowerPoint media metadata read-back.
+PowerPoint media metadata read-back. Generated Core validation failures now propagate as failed
+service responses while preserving their original structured result payload for service clients.

--- a/.changeset/bright-media-support.md
+++ b/.changeset/bright-media-support.md
@@ -1,0 +1,6 @@
+---
+"powerpointmcp": minor
+---
+
+Add generated `media` MCP and CLI commands for embedded or linked audio/video insertion and native
+PowerPoint media metadata read-back.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ Unified Service Architecture.
 1. **ComInterop** (`src/PowerPointMcp.ComInterop`) - STA thread + OLE message filter + channel-based
    work queue (`PresentationBatch`), ported from `mcp-server-excel`'s `ExcelBatch` pattern.
 2. **Core** (`src/PowerPointMcp.Core`) - PowerPoint domain commands, one folder per domain
-   (Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation, Image, Chart,
+   (Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation, Image, Media, Chart,
    Export). Domains other than Presentation carry a `[ServiceCategory]` marker attribute that the
    generators discover.
 3. **Generators** (`src/PowerPointMcp.Generators.Mcp`, `src/PowerPointMcp.Generators.Cli`,
@@ -64,11 +64,11 @@ Unified Service Architecture.
    background daemon process** over a named pipe (`ServiceClient`/`IPowerPointDaemonRpc`,
    auto-started on first `session open`/`session create`), so sessions persist across CLI
    invocations without paying PowerPoint's ~90-150s launch cost every command.
-5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 15 tools
-   total: one hand-written `presentation` action-dispatch tool plus 14 generated action-dispatch
+5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 16 tools
+   total: one hand-written `presentation` action-dispatch tool plus 15 generated action-dispatch
    tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-   `image`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 184 operations
-   across 15 domains. See
+   `image`, `media`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 186 operations
+   across 16 domains. See
    `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
    the ground-truth tool list.
 6. **CLI** (`src/PowerPointMcp.CLI`) - `pptcli`, built on the same generators as the MCP surface

--- a/.github/instructions/architecture-patterns.instructions.md
+++ b/.github/instructions/architecture-patterns.instructions.md
@@ -22,7 +22,7 @@ applyTo: "src/**/*.cs"
 ComInterop (STA thread, OLE message filter, PresentationBatch work queue)
     ↓
 Core (domain commands: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master,
-      Animation, Image, Chart, Export — all but Presentation carry a [ServiceCategory] attribute)
+      Animation, Image, Media, Chart, Export — all but Presentation carry a [ServiceCategory] attribute)
     ↓
 Service (PowerPointMcpService: session registry + dispatch, shared codebase)
     ↓                                              ↓

--- a/.github/instructions/mcp-server-guide.instructions.md
+++ b/.github/instructions/mcp-server-guide.instructions.md
@@ -31,7 +31,7 @@ Most of the MCP tool surface is **generated**, not hand-written. Before editing 
   action-dispatch like Excel's file tool, but stays hand-written because create/open/list/close
   need custom session-registry behavior and optional `sessionId`.
 - **Generated** (everything else — `slide`, `shape`, `textframe`, `table`, `notes`, `layout`,
-  `master`, `animation`, `image`, `chart`, `smartart`, `export`): one action-dispatch tool per
+  `master`, `animation`, `image`, `media`, `chart`, `smartart`, `export`): one action-dispatch tool per
   `[ServiceCategory]` Core domain, emitted by `PowerPointMcp.Generators.Mcp` from the Core
   interface's `[ServiceCategory]`/`[McpTool]` attributes and XML doc comments. **Never hand-write a
   new tool class for one of these domains** — add the operation to the Core interface (with XML
@@ -138,7 +138,7 @@ configuration per tool class.
 ## Adding a New Tool
 
 **For a generated domain (Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation,
-Image, Chart, Export) — the common case:**
+Image, Media, Chart, Export) — the common case:**
 1. Add the Core command + `{Domain}OperationResult` fields first (Core-first, tested with real
    COM per `testing-strategy.instructions.md`), with an XML doc `<summary>` — the generator uses
    it as the operation's description.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**15 MCP tools with 184 operations across 15 domains:**
+**16 MCP tools with 186 operations across 16 domains:**
 
 - 🗂️ **Presentation** (20 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
   `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name, set/read
@@ -65,6 +65,7 @@ layout regressions that text-only automation simply cannot detect.
   recolor, and crop
 - 📈 **Chart** (16 ops) — add chart, multi-series data, titles, legend, built-in styles, color styles,
   and data tables
+- 🎧 **Media** (2 ops) — insert embedded or linked audio/video and inspect native media metadata
 - 🔀 **SmartArt** (7 ops) — insert and edit SmartArt diagrams
 - 🖼️ **Export** (3 ops) — export to PDF or images for delivery and visual verification
 

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This audit compares the current 15 tools and 184 operations with the restored
+This audit compares the current 16 tools and 186 operations with the restored
 `Microsoft.Office.Interop.PowerPoint` 15.0.4420.1018 assembly. It looks for useful PowerPoint
 features that fit the existing live-session model. It does not copy Excel-only worksheet, Power
 Query, Data Model, PivotTable, or calculation APIs.
@@ -17,7 +17,7 @@ The existing surface already covers the main editing workflow:
 
 - presentation sessions, templates, themes, and document properties
 - slides, sections, legacy comments, and slide import
-- shapes, placeholders, hyperlinks, text, tables, images, charts, and SmartArt
+- shapes, placeholders, hyperlinks, text, tables, images, audio/video, charts, and SmartArt
 - speaker notes, layouts, masters, page setup, animations, and transitions
 - accessibility checks, reading order, PDF export, and rendered slide images
 
@@ -33,7 +33,7 @@ The existing legacy comment operations are therefore correctly scoped.
 | 3 | String tags | `set-tag`, `get-tag`, `list-tags`, `delete-tag` on presentation, slide, and shape | Safe PowerPoint-native metadata without XML complexity | Tag names are case-insensitive in PowerPoint and need normalization tests |
 | 4 | Chart quick formatting | `get-style`, `set-style`, `get-color-style`, `set-color-style`, `get-data-table`, `set-data-table` | Useful visual control on the already acquired chart object | Style/color values are COM variants and need range tests against real PowerPoint |
 | 5 | Linked pictures | optional `link_to_file` on `image: add-picture`; `shape: get-link-info`, `update-link`, `break-link`, `set-link-auto-update` | Enables linked-asset workflows and repair | `LinkFormat` is valid only for linked shapes |
-| 6 | Audio and video | new `media` domain with `add-media`, `get-media-info` | Large PowerPoint-specific capability gap | Needs small licensed test fixtures and narrowly scoped Office enum handling |
+| 6 | Audio and video (delivered) | `media: add-media`, `get-media-info` | Closes a PowerPoint-specific capability gap | Uses repository-owned synthetic WAV and H.264 MP4 fixtures |
 
 ### 1. Save As and Save Copy As — implemented
 
@@ -155,6 +155,13 @@ touch timing, codecs, and presentation-mode behavior.
 Tests need small repository-owned audio and video fixtures, embedded and linked cases, media type
 read-back, shape count, save/reopen, and cleanup.
 
+Implemented by the generated `media` domain. The Core command keeps PowerPoint shapes and
+`PpMediaType` read-back typed, while narrowly late-binding the `AddMediaObject2` and `Shape.Type`
+boundaries that require Office enums unavailable without `office.dll`. Tests write embedded,
+deterministic PCM WAV and one-second black H.264 Constrained Baseline MP4 bytes. Both fixtures have
+no third-party authored media; a host without a compatible decoder fails insertion explicitly
+instead of silently skipping core behavior.
+
 References: [Shapes.AddMediaObject2](https://learn.microsoft.com/office/vba/api/powerpoint.shapes.addmediaobject2),
 [Shape.MediaType](https://learn.microsoft.com/office/vba/api/powerpoint.shape.mediatype).
 
@@ -201,7 +208,7 @@ real-PowerPoint tests:
 3. String tags.
 4. Chart quick formatting. (Implemented.)
 5. Linked pictures and link management.
-6. Audio and video.
+6. Audio and video. Delivered by the `media` domain.
 7. Run-level text and advanced chart formatting only after separate contract reviews.
 
 No accepted item requires a matching change in `mcp-server-excel`; Excel already has Save As,

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -160,7 +160,9 @@ Implemented by the generated `media` domain. The Core command keeps PowerPoint s
 boundaries that require Office enums unavailable without `office.dll`. Tests write embedded,
 deterministic PCM WAV and one-second black H.264 Constrained Baseline MP4 bytes. Both fixtures have
 no third-party authored media; a host without a compatible decoder fails insertion explicitly
-instead of silently skipping core behavior.
+instead of silently skipping core behavior. Media may be embedded (`false`/`true`), link-only
+(`true`/`false`), or linked while retaining media data in the presentation (`true`/`true`);
+`false`/`false` is rejected because PowerPoint would have no media data to retain.
 
 References: [Shapes.AddMediaObject2](https://learn.microsoft.com/office/vba/api/powerpoint.shapes.addmediaobject2),
 [Shape.MediaType](https://learn.microsoft.com/office/vba/api/powerpoint.shape.mediatype).

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 15 MCP tools with 184 operations across 15 domains for live PowerPoint automation through single action-dispatch tools.
-keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, chart tool, SmartArt tool, export-to-verify"
+description: 16 MCP tools with 186 operations across 16 domains for live PowerPoint automation through single action-dispatch tools.
+keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, media tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **15 MCP tools with 184 operations across 15 domains**.
+PowerPoint MCP Server exposes **16 MCP tools with 186 operations across 16 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -32,6 +32,7 @@ The CLI mirrors the same domain model:
 | `master` | 10 | Slide master fonts and backgrounds | `master(action="...", session_id=..., ...)` | `pptcli master <action> -s <SESSION_ID> ...` |
 | `animation` | 5 | Shape effects and slide transitions | `animation(action="...", session_id=..., ...)` | `pptcli animation <action> -s <SESSION_ID> ...` |
 | `image` | 7 | Picture insertion and picture adjustments (brightness/contrast, recolor, crop) | `image(action="...", session_id=..., ...)` | `pptcli image <action> -s <SESSION_ID> ...` |
+| `media` | 2 | Embedded or linked audio/video insertion and native media metadata | `media(action="...", session_id=..., ...)` | `pptcli media <action> -s <SESSION_ID> ...` |
 | `chart` | 16 | Native charts, titles, legend, data replacement, styles, colors, data tables | `chart(action="...", session_id=..., ...)` | `pptcli chart <action> -s <SESSION_ID> ...` |
 | `smartart` | 7 | SmartArt diagrams and node editing | `smartart(action="...", session_id=..., ...)` | `pptcli smartart <action> -s <SESSION_ID> ...` |
 | `export` | 3 | PDF delivery and export-to-verify image rendering | `export(action="...", session_id=..., ...)` | `pptcli export <action> -s <SESSION_ID> ...` |
@@ -174,6 +175,12 @@ Use `image` for inserting and adjusting pictures.
 
 **Exact action order:** `add-picture`, `set-brightness-contrast`, `get-brightness-contrast`,
 `set-recolor`, `get-recolor`, `set-crop`, `get-crop`
+
+### `media` tool (2 operations)
+
+Use `media` to insert embedded or linked audio/video and inspect PowerPoint's native media type.
+
+**Exact action order:** `add-media`, `get-media-info`
 
 ### `chart` tool (16 operations)
 

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -100,7 +100,7 @@ hide:
 
 </div>
 
-[See all 15 tools (184 operations) across 15 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 16 tools (186 operations) across 16 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 15 tools (184 operations) across 15 domains
+- [Complete Feature Reference](features.md) — all 16 tools (186 operations) across 16 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 15 tools with 184 operations across 15 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 16 tools with 186 operations across 16 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/gh-pages/docs/reference/index.md
+++ b/gh-pages/docs/reference/index.md
@@ -24,6 +24,7 @@ Skills. The website and installed guidance therefore describe the same behavior.
 - [Tables](tables.md)
 - [Charts](charts.md)
 - [Images](images.md)
+- [Media](media.md)
 - [SmartArt](smart-art.md)
 - [Speaker Notes](speaker-notes.md)
 - [Layouts](layouts.md)

--- a/gh-pages/docs/reference/media.md
+++ b/gh-pages/docs/reference/media.md
@@ -1,0 +1,8 @@
+---
+title: Media
+description: Canonical guidance for adding and inspecting audio and video in PowerPoint.
+---
+
+# Media
+
+--8<-- "_generated/skills-media.md"

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -55,6 +55,7 @@ SKILL_SOURCES = {
     "tables.md": "Tables",
     "charts.md": "Charts",
     "images.md": "Images",
+    "media.md": "Media",
     "smart-art.md": "SmartArt",
     "speaker-notes.md": "Speaker Notes",
     "layouts.md": "Layouts",

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Tables: reference/tables.md
       - Charts: reference/charts.md
       - Images: reference/images.md
+      - Media: reference/media.md
       - SmartArt: reference/smart-art.md
       - Speaker notes: reference/speaker-notes.md
       - Layouts: reference/layouts.md

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -17,8 +17,8 @@ Claude can now create and edit PowerPoint decks directly.
 ## What's inside
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
-required) plus the manifest, license, and changelog. The server exposes 15
-tools (184 operations across 15 domains) — see the
+required) plus the manifest, license, and changelog. The server exposes 16
+tools (186 operations across 16 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 Linked pictures are managed through the generated `shape` actions `get-link-info`, `update-link`,
 `break-link`, and `set-link-auto-update`.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "PowerPoint (Windows)",
   "version": "0.1.5",
   "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, accessibility, PDF export, and more - requires PowerPoint to be installed",
-  "long_description": "MCP server for Microsoft PowerPoint automation. 15 tools (184 operations across 15 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including string tags, chart quick formatting, linked-picture get-link-info, update-link, break-link, and set-link-auto-update actions, PDF delivery, and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
+  "long_description": "MCP server for Microsoft PowerPoint automation. 16 tools (186 operations across 16 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Media, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including string tags, chart quick formatting, linked-picture get-link-info, update-link, break-link, and set-link-auto-update actions, PDF delivery, and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -6,9 +6,9 @@ when working with the PowerPoint MCP Server.
 ## What This Is
 
 `mcp-server-powerpoint` drives a live Microsoft PowerPoint desktop instance via COM
-(`Microsoft.Office.Interop.PowerPoint`) and exposes it as **15 MCP tools across 15 domains**.
+(`Microsoft.Office.Interop.PowerPoint`) and exposes it as **16 MCP tools across 16 domains**.
 Every domain is a single action-dispatch tool: `presentation`, `slide`, `shape`, `textframe`,
-`table`, `notes`, `layout`, `pagesetup`, `accessibility`, `master`, `animation`, `image`, `chart`,
+`table`, `notes`, `layout`, `pagesetup`, `accessibility`, `master`, `animation`, `image`, `media`, `chart`,
 `smartart`, and `export`.
 
 Windows + PowerPoint desktop required. There is no cross-platform or headless mode — everything

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -4,7 +4,7 @@ description: >
   PowerPoint CLI automation skill for Windows presentations. Use when a coding agent needs
   token-efficient, scriptable, or unattended PowerPoint automation via pptcli commands. Best
   for CI/CD, scheduled jobs, batch processing, PowerShell workflows, and bulk deck edits.
-  Supports slides, shapes, text frames, tables, charts, images, speaker notes, layouts, and
+  Supports slides, shapes, text frames, tables, charts, images, audio, video, speaker notes, layouts, and
   .potx template restyling. Triggers: pptcli, PowerPoint CLI, command line, batch, script,
   automation, CI/CD, scheduled, PowerShell, unattended, coding agent, deck processing.
 compatibility: Windows with Microsoft PowerPoint desktop installed.
@@ -32,7 +32,7 @@ though each command is a separate OS process.
 |------|---------|------|
 | 1. Session | `session create/open` | Always first |
 | 2. Slides | `slide add-blank` | If needed |
-| 3. Edit content | See command reference below | Shapes, text, tables, charts, images, notes |
+| 3. Edit content | See command reference below | Shapes, text, tables, charts, images, media, notes |
 | 4. Save & close | `session close --save` | Always last |
 
 ## CRITICAL RULES (MUST FOLLOW)
@@ -134,7 +134,7 @@ of one flat tool per verb.
 
 Available command groups (in addition to `session` and `service`):
 
-`accessibility`, `animation`, `chart`, `export`, `image`, `layout`, `master`, `notes`, `pagesetup`, `shape`, `slide`, `smartart`, `table`, `textframe`
+`accessibility`, `animation`, `chart`, `export`, `image`, `layout`, `master`, `media`, `notes`, `pagesetup`, `shape`, `slide`, `smartart`, `table`, `textframe`
 
 Run `pptcli <command> --help` for the live, authoritative list of actions and flags for that
 command — the table below is a summary generated from the same Core interfaces as the MCP tool
@@ -267,6 +267,23 @@ Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `
 | `--gradient-style` |  |
 | `--gradient-variant` |  |
 | `--master-index` | (required for: delete-master) |
+
+
+### `media` — Media commands: insert audio or video files and inspect their PowerPoint media metadata. Operates within an already-open presentation session using 1-based slide and shape indexes.
+
+Actions: `add-media`, `get-media-info`
+
+| Flag | Description |
+|------|-------------|
+| `--slide-index` | (required) |
+| `--media-path` | (required for: add-media) |
+| `--link-to-file` | (required for: add-media) |
+| `--save-with-document` | (required for: add-media) |
+| `--left` | (required for: add-media) |
+| `--top` | (required for: add-media) |
+| `--width` | (required for: add-media) |
+| `--height` | (required for: add-media) |
+| `--shape-index` | (required for: get-media-info) |
 
 
 ### `notes` — Speaker notes commands: set/get the notes text for a slide. Operates within an already-open IPresentationBatch, targeting a specific slide by its 1-based index.

--- a/skills/powerpoint-cli/references/behavioral-rules.md
+++ b/skills/powerpoint-cli/references/behavioral-rules.md
@@ -3,8 +3,8 @@
 # Behavioral Rules for PowerPoint MCP Operations
 
 These rules ensure efficient, reliable PowerPoint automation via a live PowerPoint desktop
-instance (COM). AI assistants should follow these guidelines when using the **15 PowerPoint MCP
-tools across 15 domains**.
+instance (COM). AI assistants should follow these guidelines when using the **16 PowerPoint MCP
+tools across 16 domains**.
 
 ## Core Execution Rules
 
@@ -40,10 +40,10 @@ Every editing workflow starts by establishing a session:
 
 ## Tool Conventions
 
-- **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
+- **All 16 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
   `targetPath`, `format`, `overwrite`, `templatePath`, `propertyName`, `value`.
-- **The other 14 domain tools use `session_id` plus snake_case action parameters**, e.g.
+- **The other 15 domain tools use `session_id` plus snake_case action parameters**, e.g.
   `shape(action: "add-rectangle", session_id: ..., slide_index: 1, left: 50, top: 80, width: 100,
   height: 60)`.
 

--- a/skills/powerpoint-cli/references/cli-commands.md
+++ b/skills/powerpoint-cli/references/cli-commands.md
@@ -400,6 +400,48 @@ OPTIONS:
                                                 decodes and saves as binary file
 ```
 
+## `pptcli media`
+
+```text
+DESCRIPTION:
+Media commands: insert audio or video files and inspect their PowerPoint media
+metadata. Operates within an already-open presentation session using 1-based
+slide and shape indexes
+
+USAGE:
+    pptcli media <ACTION> [OPTIONS]
+
+ARGUMENTS:
+    <ACTION>    The action to perform
+
+OPTIONS:
+    -h, --help                                     Prints help information
+    -s, --session <SESSION>                        Session ID from 'session
+                                                   open' command
+        --slide-index <SLIDEINDEX>                 (required)
+        --media-path <MEDIAPATH>                   (required for: add-media)
+                                                   (valid for: add-media)
+        --link-to-file <LINKTOFILE>                (required for: add-media)
+                                                   (valid for: add-media)
+        --save-with-document <SAVEWITHDOCUMENT>    (required for: add-media)
+                                                   (valid for: add-media)
+        --left <LEFT>                              (required for: add-media)
+                                                   (valid for: add-media)
+        --top <TOP>                                (required for: add-media)
+                                                   (valid for: add-media)
+        --width <WIDTH>                            (required for: add-media)
+                                                   (valid for: add-media)
+        --height <HEIGHT>                          (required for: add-media)
+                                                   (valid for: add-media)
+        --shape-index <SHAPEINDEX>                 (required for:
+                                                   get-media-info) (valid for:
+                                                   get-media-info)
+    -o, --output <PATH>                            Write output to file instead
+                                                   of stdout. For image results,
+                                                   decodes and saves as binary
+                                                   file
+```
+
 ## `pptcli notes`
 
 ```text

--- a/skills/powerpoint-cli/references/media.md
+++ b/skills/powerpoint-cli/references/media.md
@@ -1,0 +1,41 @@
+> **CLI syntax:** Shared guides may use MCP calls as shorthand. Use `cli-commands.md` or live `--help` for exact commands and kebab-case options.
+
+# Audio and Video
+
+Reference for the `media` domain. It inserts playable audio or video as either embedded content or
+a file link, then reads PowerPoint's native media type from the resulting shape.
+
+## Actions
+
+| Tool | Action | Parameters | Notes |
+|------|--------|------------|-------|
+| `media` | `add-media` | `session_id`, `slide_index`, `media_path`, `link_to_file`, `save_with_document`, `left`, `top`, `width`, `height` | Adds audio or video through PowerPoint's native media insertion API. |
+| `media` | `get-media-info` | `session_id`, `slide_index`, `shape_index` | Returns `mediaTypeName` as `ppMediaTypeSound` or `ppMediaTypeMovie`, plus shape count/index and geometry. |
+
+## Storage Modes
+
+Use exactly one of these combinations:
+
+| Mode | `link_to_file` | `save_with_document` | Source-file behavior |
+|------|----------------|----------------------|----------------------|
+| Embedded | `false` | `true` | Media is stored in the presentation and survives moving or deleting the source file. |
+| Linked | `true` | `false` | The presentation keeps a file link. Keep the source path available for reliable playback. |
+
+The other two boolean combinations are rejected before PowerPoint is called because they do not
+express one clear storage mode.
+
+## Requirements and Limits
+
+- `media_path` must resolve to an existing local file. Use a full Windows path.
+- `slide_index` and `shape_index` are 1-based.
+- `width` and `height` must be greater than zero and are measured in points.
+- Prefer formats supported natively by the target PowerPoint installation. H.264 video with AAC
+  audio in an MP4 container is Microsoft's recommended general-purpose format.
+- This first media surface covers insertion and metadata only. It does not control playback,
+  trimming, timing, volume, poster frames, or slide-show behavior.
+
+## Verification
+
+Use `get-media-info` after insertion to confirm that PowerPoint classified the shape as sound or
+movie. Exporting the slide can verify placement and the video poster frame, but a rendered image
+cannot prove audio or video playback.

--- a/skills/powerpoint-cli/references/media.md
+++ b/skills/powerpoint-cli/references/media.md
@@ -14,15 +14,16 @@ a file link, then reads PowerPoint's native media type from the resulting shape.
 
 ## Storage Modes
 
-Use exactly one of these combinations:
+Choose the storage behavior PowerPoint should use:
 
 | Mode | `link_to_file` | `save_with_document` | Source-file behavior |
 |------|----------------|----------------------|----------------------|
 | Embedded | `false` | `true` | Media is stored in the presentation and survives moving or deleting the source file. |
-| Linked | `true` | `false` | The presentation keeps a file link. Keep the source path available for reliable playback. |
+| Linked only | `true` | `false` | The presentation keeps only a file link. Keep the source path available for reliable playback. |
+| Linked and saved | `true` | `true` | The presentation keeps the link and also saves media data, so the media remains available if the source is deleted. |
 
-The other two boolean combinations are rejected before PowerPoint is called because they do not
-express one clear storage mode.
+The `false`/`false` combination is rejected before PowerPoint is called because the presentation
+would have neither a link nor saved media data.
 
 ## Requirements and Limits
 

--- a/skills/powerpoint-cli/references/workflows.md
+++ b/skills/powerpoint-cli/references/workflows.md
@@ -2,7 +2,7 @@
 
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 184 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 186 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/powerpoint-mcp/SKILL.md
+++ b/skills/powerpoint-mcp/SKILL.md
@@ -4,14 +4,14 @@ description: >
   PowerPoint MCP Server skill for Windows presentation automation via a live PowerPoint desktop
   instance (COM/PIA). Use when an assistant needs rich MCP tools to create, open, build, format,
   and export PowerPoint (.pptx/.pptm) presentations — slides, shapes, text boxes, tables, native
-  charts, images, speaker notes, layouts, and image export for visual verification.
+  charts, images, audio, video, speaker notes, layouts, and image export for visual verification.
   Triggers: PowerPoint, presentation, deck, slides, pptx, pptm, speaker notes, chart, MCP.
 compatibility: Windows with Microsoft PowerPoint desktop installed.
 ---
 
 # PowerPoint MCP Server Skill
 
-Provides 15 PowerPoint MCP tools (one presentation tool + 14 domain action-dispatch tools)
+Provides 16 PowerPoint MCP tools (one presentation tool + 15 domain action-dispatch tools)
 via the Model Context Protocol, driving a live PowerPoint desktop instance through the official
 `Microsoft.Office.Interop.PowerPoint` PIA. Tools are auto-discovered via MCP `tools/list` — this
 skill documents session lifecycle, indexing conventions, workflows, and gotchas that aren't
@@ -19,7 +19,7 @@ obvious from tool schemas alone.
 
 Session lifecycle, Save As/copy, templates, the advisory Mark as Final flag, document properties,
 and presentation tags use the `presentation` action-dispatch tool with camelCase arguments.
-Domain tools (`slide`, `shape`, `textframe`, `table`, `chart`, `image`,
+Domain tools (`slide`, `shape`, `textframe`, `table`, `chart`, `image`, `media`,
 `notes`, `layout`, `master`, `smartart`, `animation`, `export`, `pagesetup`, `accessibility`) are
 action-dispatch: one tool per domain, called as `tool(action:
 "kebab-action", session_id: ..., snake_case_param: ...)`.
@@ -29,7 +29,7 @@ action-dispatch: one tool per domain, called as `tool(action:
 | Step | Tool | Action | When |
 |------|------|--------|------|
 | 1. Create or open | `presentation(action: "create"/"open")` | Start a session, get `sessionId` | Always, before any edit |
-| 3. Build | `slide(action: "add-blank")`, `shape(action: "add-rectangle"/"add-text-box"/"add-auto-shape"/"add-line"/"add-connector")`, `table(action: "add-table")`, `chart(action: "add-chart")`, `image(action: "add-picture"/"set-brightness-contrast"/"get-brightness-contrast"/"set-recolor"/"get-recolor"/"set-crop"/"get-crop")` | Add structure and content | As needed |
+| 3. Build | `slide(action: "add-blank")`, `shape(action: "add-rectangle"/"add-text-box"/"add-auto-shape"/"add-line"/"add-connector")`, `table(action: "add-table")`, `chart(action: "add-chart")`, `image(action: "add-picture")`, `media(action: "add-media")` | Add structure and content | As needed |
 | 4. Format | `textframe(action: "set-font-size"/"set-bold"/"set-font-color")`, `layout(action: "set-layout")` | Apply formatting | After adding content |
 | 5. Animate (optional) | `animation(action: "add-effect"/"set-transition")` | Add entrance/emphasis/exit effects or slide transitions | After content/layout are final |
 | 6. Annotate | `notes(action: "set-notes-text")` | Add speaker notes | After each slide's content is final |
@@ -107,6 +107,7 @@ saved.
 | Native charts | `chart(action: "add-chart"/"get-chart-data"/"add-series"/"replace-chart-data"/"set-chart-title"/"get-chart-title"/"set-axis-title"/"get-axis-title"/"set-legend-visibility"/"get-legend-visibility"/"set-style"/"get-style"/"set-color-style"/"get-color-style"/"set-data-table"/"get-data-table")` |
 | SmartArt diagrams | `smartart(action: "add-smart-art"/"add-node"/"add-child-node"/"set-node-text"/"get-node-text"/"delete-node"/"get-node-count")` |
 | Images (embedded by default; optional file links) | `image(action: "add-picture"/"set-brightness-contrast"/"get-brightness-contrast"/"set-recolor"/"get-recolor"/"set-crop"/"get-crop")` |
+| Audio and video | `media(action: "add-media"/"get-media-info")` |
 | Speaker notes | `notes(action: "set-notes-text"/"get-notes-text")` |
 | Slide layouts | `layout(action: "set-layout"/"get-layout")` |
 | Slide master title/body font, background color | `master(action: "get-title-font"/"set-title-font"/"get-body-font"/"set-body-font"/"get-background-color"/"set-background-color")` |
@@ -127,6 +128,7 @@ See `references/` for detailed guidance:
 - [Charts — add-chart/add-series categories/series/values, titles, legend](./references/charts.md)
 - [SmartArt — add-smart-art layouts, node addressing, hierarchy diagrams](./references/smart-art.md)
 - [Images — picture insertion and picture-format adjustments](./references/images.md)
+- [Audio and video — embedded/linked insertion and media metadata](./references/media.md)
 - [Speaker notes — set/get notes](./references/speaker-notes.md)
 - [Layouts — set/get slide layout](./references/layouts.md)
 - [Slide master — title/body font and background color](./references/master.md)

--- a/skills/powerpoint-mcp/references/behavioral-rules.md
+++ b/skills/powerpoint-mcp/references/behavioral-rules.md
@@ -1,8 +1,8 @@
 # Behavioral Rules for PowerPoint MCP Operations
 
 These rules ensure efficient, reliable PowerPoint automation via a live PowerPoint desktop
-instance (COM). AI assistants should follow these guidelines when using the **15 PowerPoint MCP
-tools across 15 domains**.
+instance (COM). AI assistants should follow these guidelines when using the **16 PowerPoint MCP
+tools across 16 domains**.
 
 ## Core Execution Rules
 
@@ -38,10 +38,10 @@ Every editing workflow starts by establishing a session:
 
 ## Tool Conventions
 
-- **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
+- **All 16 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
   `targetPath`, `format`, `overwrite`, `templatePath`, `propertyName`, `value`.
-- **The other 14 domain tools use `session_id` plus snake_case action parameters**, e.g.
+- **The other 15 domain tools use `session_id` plus snake_case action parameters**, e.g.
   `shape(action: "add-rectangle", session_id: ..., slide_index: 1, left: 50, top: 80, width: 100,
   height: 60)`.
 

--- a/skills/powerpoint-mcp/references/media.md
+++ b/skills/powerpoint-mcp/references/media.md
@@ -1,0 +1,39 @@
+# Audio and Video
+
+Reference for the `media` domain. It inserts playable audio or video as either embedded content or
+a file link, then reads PowerPoint's native media type from the resulting shape.
+
+## Actions
+
+| Tool | Action | Parameters | Notes |
+|------|--------|------------|-------|
+| `media` | `add-media` | `session_id`, `slide_index`, `media_path`, `link_to_file`, `save_with_document`, `left`, `top`, `width`, `height` | Adds audio or video through PowerPoint's native media insertion API. |
+| `media` | `get-media-info` | `session_id`, `slide_index`, `shape_index` | Returns `mediaTypeName` as `ppMediaTypeSound` or `ppMediaTypeMovie`, plus shape count/index and geometry. |
+
+## Storage Modes
+
+Use exactly one of these combinations:
+
+| Mode | `link_to_file` | `save_with_document` | Source-file behavior |
+|------|----------------|----------------------|----------------------|
+| Embedded | `false` | `true` | Media is stored in the presentation and survives moving or deleting the source file. |
+| Linked | `true` | `false` | The presentation keeps a file link. Keep the source path available for reliable playback. |
+
+The other two boolean combinations are rejected before PowerPoint is called because they do not
+express one clear storage mode.
+
+## Requirements and Limits
+
+- `media_path` must resolve to an existing local file. Use a full Windows path.
+- `slide_index` and `shape_index` are 1-based.
+- `width` and `height` must be greater than zero and are measured in points.
+- Prefer formats supported natively by the target PowerPoint installation. H.264 video with AAC
+  audio in an MP4 container is Microsoft's recommended general-purpose format.
+- This first media surface covers insertion and metadata only. It does not control playback,
+  trimming, timing, volume, poster frames, or slide-show behavior.
+
+## Verification
+
+Use `get-media-info` after insertion to confirm that PowerPoint classified the shape as sound or
+movie. Exporting the slide can verify placement and the video poster frame, but a rendered image
+cannot prove audio or video playback.

--- a/skills/powerpoint-mcp/references/media.md
+++ b/skills/powerpoint-mcp/references/media.md
@@ -12,15 +12,16 @@ a file link, then reads PowerPoint's native media type from the resulting shape.
 
 ## Storage Modes
 
-Use exactly one of these combinations:
+Choose the storage behavior PowerPoint should use:
 
 | Mode | `link_to_file` | `save_with_document` | Source-file behavior |
 |------|----------------|----------------------|----------------------|
 | Embedded | `false` | `true` | Media is stored in the presentation and survives moving or deleting the source file. |
-| Linked | `true` | `false` | The presentation keeps a file link. Keep the source path available for reliable playback. |
+| Linked only | `true` | `false` | The presentation keeps only a file link. Keep the source path available for reliable playback. |
+| Linked and saved | `true` | `true` | The presentation keeps the link and also saves media data, so the media remains available if the source is deleted. |
 
-The other two boolean combinations are rejected before PowerPoint is called because they do not
-express one clear storage mode.
+The `false`/`false` combination is rejected before PowerPoint is called because the presentation
+would have neither a link nor saved media data.
 
 ## Requirements and Limits
 

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 184 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 186 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -1,8 +1,8 @@
 # Behavioral Rules for PowerPoint MCP Operations
 
 These rules ensure efficient, reliable PowerPoint automation via a live PowerPoint desktop
-instance (COM). AI assistants should follow these guidelines when using the **15 PowerPoint MCP
-tools across 15 domains**.
+instance (COM). AI assistants should follow these guidelines when using the **16 PowerPoint MCP
+tools across 16 domains**.
 
 ## Core Execution Rules
 
@@ -38,10 +38,10 @@ Every editing workflow starts by establishing a session:
 
 ## Tool Conventions
 
-- **All 15 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
+- **All 16 MCP tools are action-dispatch tools.** Every call includes an `action` parameter.
 - **`presentation` uses camelCase lifecycle/property parameters** — `filePath`, `sessionId`,
   `targetPath`, `format`, `overwrite`, `templatePath`, `propertyName`, `value`.
-- **The other 14 domain tools use `session_id` plus snake_case action parameters**, e.g.
+- **The other 15 domain tools use `session_id` plus snake_case action parameters**, e.g.
   `shape(action: "add-rectangle", session_id: ..., slide_index: 1, left: 50, top: 80, width: 100,
   height: 60)`.
 

--- a/skills/shared/media.md
+++ b/skills/shared/media.md
@@ -1,0 +1,39 @@
+# Audio and Video
+
+Reference for the `media` domain. It inserts playable audio or video as either embedded content or
+a file link, then reads PowerPoint's native media type from the resulting shape.
+
+## Actions
+
+| Tool | Action | Parameters | Notes |
+|------|--------|------------|-------|
+| `media` | `add-media` | `session_id`, `slide_index`, `media_path`, `link_to_file`, `save_with_document`, `left`, `top`, `width`, `height` | Adds audio or video through PowerPoint's native media insertion API. |
+| `media` | `get-media-info` | `session_id`, `slide_index`, `shape_index` | Returns `mediaTypeName` as `ppMediaTypeSound` or `ppMediaTypeMovie`, plus shape count/index and geometry. |
+
+## Storage Modes
+
+Use exactly one of these combinations:
+
+| Mode | `link_to_file` | `save_with_document` | Source-file behavior |
+|------|----------------|----------------------|----------------------|
+| Embedded | `false` | `true` | Media is stored in the presentation and survives moving or deleting the source file. |
+| Linked | `true` | `false` | The presentation keeps a file link. Keep the source path available for reliable playback. |
+
+The other two boolean combinations are rejected before PowerPoint is called because they do not
+express one clear storage mode.
+
+## Requirements and Limits
+
+- `media_path` must resolve to an existing local file. Use a full Windows path.
+- `slide_index` and `shape_index` are 1-based.
+- `width` and `height` must be greater than zero and are measured in points.
+- Prefer formats supported natively by the target PowerPoint installation. H.264 video with AAC
+  audio in an MP4 container is Microsoft's recommended general-purpose format.
+- This first media surface covers insertion and metadata only. It does not control playback,
+  trimming, timing, volume, poster frames, or slide-show behavior.
+
+## Verification
+
+Use `get-media-info` after insertion to confirm that PowerPoint classified the shape as sound or
+movie. Exporting the slide can verify placement and the video poster frame, but a rendered image
+cannot prove audio or video playback.

--- a/skills/shared/media.md
+++ b/skills/shared/media.md
@@ -12,15 +12,16 @@ a file link, then reads PowerPoint's native media type from the resulting shape.
 
 ## Storage Modes
 
-Use exactly one of these combinations:
+Choose the storage behavior PowerPoint should use:
 
 | Mode | `link_to_file` | `save_with_document` | Source-file behavior |
 |------|----------------|----------------------|----------------------|
 | Embedded | `false` | `true` | Media is stored in the presentation and survives moving or deleting the source file. |
-| Linked | `true` | `false` | The presentation keeps a file link. Keep the source path available for reliable playback. |
+| Linked only | `true` | `false` | The presentation keeps only a file link. Keep the source path available for reliable playback. |
+| Linked and saved | `true` | `true` | The presentation keeps the link and also saves media data, so the media remains available if the source is deleted. |
 
-The other two boolean combinations are rejected before PowerPoint is called because they do not
-express one clear storage mode.
+The `false`/`false` combination is rejected before PowerPoint is called because the presentation
+would have neither a link nor saved media data.
 
 ## Requirements and Limits
 

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 15 tools and 184 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 186 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/templates/SKILL.cli.sbn
+++ b/skills/templates/SKILL.cli.sbn
@@ -4,7 +4,7 @@ description: >
   PowerPoint CLI automation skill for Windows presentations. Use when a coding agent needs
   token-efficient, scriptable, or unattended PowerPoint automation via pptcli commands. Best
   for CI/CD, scheduled jobs, batch processing, PowerShell workflows, and bulk deck edits.
-  Supports slides, shapes, text frames, tables, charts, images, speaker notes, layouts, and
+  Supports slides, shapes, text frames, tables, charts, images, audio, video, speaker notes, layouts, and
   .potx template restyling. Triggers: pptcli, PowerPoint CLI, command line, batch, script,
   automation, CI/CD, scheduled, PowerShell, unattended, coding agent, deck processing.
 compatibility: Windows with Microsoft PowerPoint desktop installed.
@@ -32,7 +32,7 @@ though each command is a separate OS process.
 |------|---------|------|
 | 1. Session | `session create/open` | Always first |
 | 2. Slides | `slide add-blank` | If needed |
-| 3. Edit content | See command reference below | Shapes, text, tables, charts, images, notes |
+| 3. Edit content | See command reference below | Shapes, text, tables, charts, images, media, notes |
 | 4. Save & close | `session close --save` | Always last |
 
 ## CRITICAL RULES (MUST FOLLOW)

--- a/src/PowerPointMcp.CLI/Infrastructure/CliErrorOutput.cs
+++ b/src/PowerPointMcp.CLI/Infrastructure/CliErrorOutput.cs
@@ -27,15 +27,25 @@ internal static class CliErrorOutput
     /// <summary>Writes an error envelope from a failed <see cref="ServiceResponse"/>.</summary>
     public static int WriteServiceError(ServiceResponse response)
     {
-        Console.WriteLine(Serialize(
+        Console.WriteLine(SerializeServiceError(response));
+        return 1;
+    }
+
+    /// <summary>
+    /// Formats a failed service response for CLI callers. The CLI deliberately keeps its stable
+    /// error envelope while the original Core payload remains available to direct service clients
+    /// through <see cref="ServiceResponse.Result"/>.
+    /// </summary>
+    internal static string SerializeServiceError(ServiceResponse response)
+    {
+        return Serialize(
             response.ErrorMessage,
             response.ErrorCategory,
             response.Command,
             response.SessionId,
             response.ExceptionType,
             response.HResult,
-            response.InnerError));
-        return 1;
+            response.InnerError);
     }
 
     /// <summary>Writes a plain error envelope with just a message.</summary>

--- a/src/PowerPointMcp.CLI/README.md
+++ b/src/PowerPointMcp.CLI/README.md
@@ -43,7 +43,7 @@ pptcli service stop --force   # stop only PID + start-time identities owned by t
 ```
 
 Every `[ServiceCategory]`-annotated Core domain (Presentation, Slide, Shape, TextFrame, Table,
-Chart, Image, Notes, Layout) gets a generated `pptcli <category> <action> -s <SESSION_ID> [options]`
+Chart, Image, Media, Notes, Layout) gets a generated `pptcli <category> <action> -s <SESSION_ID> [options]`
 command automatically — run `pptcli <category> --help` to see the actions and options available
 for that domain. (Export is not yet exposed via the CLI — a known, pre-existing generator
 conflict, unrelated to session handling.)

--- a/src/PowerPointMcp.Core/Media/IMediaCommands.cs
+++ b/src/PowerPointMcp.Core/Media/IMediaCommands.cs
@@ -14,9 +14,10 @@ public interface IMediaCommands
 {
     /// <summary>
     /// Adds an audio or video file to a slide. Use <paramref name="linkToFile"/> = false and
-    /// <paramref name="saveWithDocument"/> = true for embedded media, or
-    /// <paramref name="linkToFile"/> = true and <paramref name="saveWithDocument"/> = false for
-    /// linked media. Other combinations are rejected as ambiguous.
+    /// <paramref name="saveWithDocument"/> = true for embedded media. Set
+    /// <paramref name="linkToFile"/> = true for linked media; keep
+    /// <paramref name="saveWithDocument"/> = true to also retain media data in the presentation,
+    /// or false for a link-only shape. The false/false combination is invalid.
     /// </summary>
     MediaOperationResult AddMedia(
         IPresentationBatch batch,

--- a/src/PowerPointMcp.Core/Media/IMediaCommands.cs
+++ b/src/PowerPointMcp.Core/Media/IMediaCommands.cs
@@ -1,0 +1,39 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Sbroenne.PowerPointMcp.Core.Attributes;
+
+namespace Sbroenne.PowerPointMcp.Core.Media;
+
+/// <summary>
+/// Media commands: insert audio or video files and inspect their PowerPoint media metadata.
+/// Operates within an already-open presentation session using 1-based slide and shape indexes.
+/// </summary>
+[ServiceCategory("media", "Media")]
+[McpTool("media", Title = "Media Operations", Destructive = true, Category = "content",
+    Description = "Insert embedded or linked audio and video, and inspect media metadata on a slide.")]
+public interface IMediaCommands
+{
+    /// <summary>
+    /// Adds an audio or video file to a slide. Use <paramref name="linkToFile"/> = false and
+    /// <paramref name="saveWithDocument"/> = true for embedded media, or
+    /// <paramref name="linkToFile"/> = true and <paramref name="saveWithDocument"/> = false for
+    /// linked media. Other combinations are rejected as ambiguous.
+    /// </summary>
+    MediaOperationResult AddMedia(
+        IPresentationBatch batch,
+        int slideIndex,
+        string mediaPath,
+        bool linkToFile,
+        bool saveWithDocument,
+        float left,
+        float top,
+        float width,
+        float height);
+
+    /// <summary>
+    /// Gets the typed PowerPoint media kind and geometry for a media shape at a 1-based shape index.
+    /// </summary>
+    MediaOperationResult GetMediaInfo(
+        IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex);
+}

--- a/src/PowerPointMcp.Core/Media/MediaCommands.cs
+++ b/src/PowerPointMcp.Core/Media/MediaCommands.cs
@@ -37,11 +37,11 @@ public sealed class MediaCommands : IMediaCommands
             return Failure("Media path must not be empty.");
         }
 
-        if (linkToFile == saveWithDocument)
+        if (!linkToFile && !saveWithDocument)
         {
             return Failure(
-                "Invalid media storage combination. Use linkToFile=false with saveWithDocument=true " +
-                "for embedded media, or linkToFile=true with saveWithDocument=false for linked media.");
+                "saveWithDocument must be true when linkToFile is false; otherwise PowerPoint has " +
+                "no media data to retain.");
         }
 
         if (width <= 0 || height <= 0)

--- a/src/PowerPointMcp.Core/Media/MediaCommands.cs
+++ b/src/PowerPointMcp.Core/Media/MediaCommands.cs
@@ -1,0 +1,214 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Media;
+
+/// <inheritdoc cref="IMediaCommands"/>
+public sealed class MediaCommands : IMediaCommands
+{
+    // AddMediaObject2's LinkToFile/SaveWithDocument parameters are Microsoft.Office.Core
+    // MsoTriState values. office.dll is intentionally not referenced, so these named constants
+    // cross only that late-bound COM boundary.
+    private const int MsoFalse = 0; // MsoTriState.msoFalse
+    private const int MsoTrue = -1; // MsoTriState.msoTrue
+
+    // Shape.Type returns Microsoft.Office.Core.MsoShapeType, which is also unavailable without
+    // office.dll. Keep media classification late-bound while MediaType stays typed as PpMediaType.
+    private const int MsoMedia = 16; // MsoShapeType.msoMedia
+
+    /// <inheritdoc/>
+    public MediaOperationResult AddMedia(
+        IPresentationBatch batch,
+        int slideIndex,
+        string mediaPath,
+        bool linkToFile,
+        bool saveWithDocument,
+        float left,
+        float top,
+        float width,
+        float height)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(mediaPath);
+
+        if (string.IsNullOrWhiteSpace(mediaPath))
+        {
+            return Failure("Media path must not be empty.");
+        }
+
+        if (linkToFile == saveWithDocument)
+        {
+            return Failure(
+                "Invalid media storage combination. Use linkToFile=false with saveWithDocument=true " +
+                "for embedded media, or linkToFile=true with saveWithDocument=false for linked media.");
+        }
+
+        if (width <= 0 || height <= 0)
+        {
+            return Failure("Media width and height must both be greater than zero.");
+        }
+
+        string fullMediaPath;
+        try
+        {
+            fullMediaPath = Path.GetFullPath(mediaPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return Failure($"Invalid media path: {ex.Message}");
+        }
+
+        if (!File.Exists(fullMediaPath))
+        {
+            return Failure($"Media file not found: {fullMediaPath}.");
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Slides? slides = null;
+            PowerPoint.Slide? slide = null;
+            PowerPoint.Shapes? shapes = null;
+            PowerPoint.Shape? mediaShape = null;
+            try
+            {
+                slides = ctx.Presentation.Slides;
+                var slideValidation = ValidateSlideIndex(slides.Count, slideIndex);
+                if (slideValidation is not null)
+                {
+                    return slideValidation;
+                }
+
+                slide = slides[slideIndex];
+                shapes = slide.Shapes;
+                // Reason: AddMediaObject2 requires Office.MsoTriState parameters from office.dll,
+                // so only this method boundary is late-bound using named MsoTriState constants.
+                mediaShape = (PowerPoint.Shape)((dynamic)shapes).AddMediaObject2(
+                    fullMediaPath,
+                    linkToFile ? MsoTrue : MsoFalse,
+                    saveWithDocument ? MsoTrue : MsoFalse,
+                    left,
+                    top,
+                    width,
+                    height);
+
+                PowerPoint.PpMediaType mediaType = mediaShape.MediaType;
+                return new MediaOperationResult
+                {
+                    Success = true,
+                    ShapeIndex = shapes.Count,
+                    ShapeCount = shapes.Count,
+                    MediaTypeName = mediaType.ToString(),
+                    SourcePath = fullMediaPath,
+                    LinkToFile = linkToFile,
+                    SaveWithDocument = saveWithDocument,
+                    Left = mediaShape.Left,
+                    Top = mediaShape.Top,
+                    Width = mediaShape.Width,
+                    Height = mediaShape.Height
+                };
+            }
+            finally
+            {
+                if (mediaShape is not null) ComUtilities.Release(ref mediaShape);
+                if (shapes is not null) ComUtilities.Release(ref shapes);
+                if (slide is not null) ComUtilities.Release(ref slide);
+                if (slides is not null) ComUtilities.Release(ref slides);
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public MediaOperationResult GetMediaInfo(
+        IPresentationBatch batch,
+        int slideIndex,
+        int shapeIndex)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Slides? slides = null;
+            PowerPoint.Slide? slide = null;
+            PowerPoint.Shapes? shapes = null;
+            PowerPoint.Shape? shape = null;
+            try
+            {
+                slides = ctx.Presentation.Slides;
+                var slideValidation = ValidateSlideIndex(slides.Count, slideIndex);
+                if (slideValidation is not null)
+                {
+                    return slideValidation;
+                }
+
+                slide = slides[slideIndex];
+                shapes = slide.Shapes;
+                var shapeValidation = ValidateShapeIndex(shapes.Count, shapeIndex);
+                if (shapeValidation is not null)
+                {
+                    return shapeValidation;
+                }
+
+                shape = shapes[shapeIndex];
+                // Reason: Shape.Type returns Office.MsoShapeType from office.dll; compare the
+                // late-bound integer value with the named MsoShapeType.msoMedia constant.
+                if ((int)((dynamic)shape).Type != MsoMedia)
+                {
+                    return Failure(
+                        $"Shape {shapeIndex} on slide {slideIndex} is not a media shape.");
+                }
+
+                PowerPoint.PpMediaType mediaType = shape.MediaType;
+                return new MediaOperationResult
+                {
+                    Success = true,
+                    ShapeIndex = shapeIndex,
+                    ShapeCount = shapes.Count,
+                    MediaTypeName = mediaType.ToString(),
+                    Left = shape.Left,
+                    Top = shape.Top,
+                    Width = shape.Width,
+                    Height = shape.Height
+                };
+            }
+            finally
+            {
+                if (shape is not null) ComUtilities.Release(ref shape);
+                if (shapes is not null) ComUtilities.Release(ref shapes);
+                if (slide is not null) ComUtilities.Release(ref slide);
+                if (slides is not null) ComUtilities.Release(ref slides);
+            }
+        });
+    }
+
+    private static MediaOperationResult? ValidateSlideIndex(int slideCount, int slideIndex)
+    {
+        if (slideIndex < 1 || slideIndex > slideCount)
+        {
+            return Failure(
+                $"Slide index {slideIndex} is out of range. The presentation has {slideCount} " +
+                $"slide(s) (valid range: 1-{slideCount}).");
+        }
+
+        return null;
+    }
+
+    private static MediaOperationResult? ValidateShapeIndex(int shapeCount, int shapeIndex)
+    {
+        if (shapeIndex < 1 || shapeIndex > shapeCount)
+        {
+            return Failure(
+                $"Shape index {shapeIndex} is out of range. The slide has {shapeCount} " +
+                $"shape(s) (valid range: 1-{shapeCount}).");
+        }
+
+        return null;
+    }
+
+    private static MediaOperationResult Failure(string message)
+        => new()
+        {
+            Success = false,
+            ErrorMessage = message
+        };
+}

--- a/src/PowerPointMcp.Core/Media/MediaOperationResult.cs
+++ b/src/PowerPointMcp.Core/Media/MediaOperationResult.cs
@@ -1,0 +1,41 @@
+namespace Sbroenne.PowerPointMcp.Core.Media;
+
+/// <summary>Result of a media operation.</summary>
+public sealed class MediaOperationResult
+{
+    /// <summary>Whether the operation succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Error message when <see cref="Success"/> is false.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>1-based index of the media shape.</summary>
+    public int? ShapeIndex { get; init; }
+
+    /// <summary>Total shape count on the slide.</summary>
+    public int? ShapeCount { get; init; }
+
+    /// <summary>Typed <c>PpMediaType</c> member name reported by PowerPoint.</summary>
+    public string? MediaTypeName { get; init; }
+
+    /// <summary>Full source path used for insertion.</summary>
+    public string? SourcePath { get; init; }
+
+    /// <summary>Whether insertion linked the media shape to its source file.</summary>
+    public bool? LinkToFile { get; init; }
+
+    /// <summary>Whether insertion saved media data with the presentation.</summary>
+    public bool? SaveWithDocument { get; init; }
+
+    /// <summary>Horizontal position in points.</summary>
+    public float? Left { get; init; }
+
+    /// <summary>Vertical position in points.</summary>
+    public float? Top { get; init; }
+
+    /// <summary>Width in points.</summary>
+    public float? Width { get; init; }
+
+    /// <summary>Height in points.</summary>
+    public float? Height { get; init; }
+}

--- a/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
+++ b/src/PowerPointMcp.Core/Presentation/IPresentationCommands.cs
@@ -7,7 +7,7 @@ namespace Sbroenne.PowerPointMcp.Core.Presentation;
 /// </summary>
 /// <remarks>
 /// First Core command domain implemented, proving the ComInterop batch pattern end-to-end.
-/// Remaining domains from the plan (Slide, Shape, TextFrame, Table, Chart, Image, Notes,
+/// Remaining domains from the plan (Slide, Shape, TextFrame, Table, Chart, Image, Media, Notes,
 /// Layout/Master, Export/QA) are follow-up work — see plan.md continuation notes.
 ///
 /// Deliberately carries NO <c>[ServiceCategory]</c>/<c>[McpTool]</c> attribute, unlike every

--- a/src/PowerPointMcp.McpServer/Infrastructure/ServiceBridge.cs
+++ b/src/PowerPointMcp.McpServer/Infrastructure/ServiceBridge.cs
@@ -50,7 +50,16 @@ public static class ServiceBridge
         };
 
         var response = service.ProcessAsync(request).GetAwaiter().GetResult();
+        return FormatResponse(response);
+    }
 
+    /// <summary>
+    /// Formats the shared service response for the generated MCP surface. Failed Core payloads
+    /// remain available on <see cref="ServiceResponse.Result"/> for service consumers, while MCP
+    /// callers continue to receive the established tool-error envelope with <c>isError=true</c>.
+    /// </summary>
+    internal static string FormatResponse(ServiceResponse response)
+    {
         if (response.Success)
         {
             return response.Result ?? JsonSerializer.Serialize(new { success = true }, ArgsJsonOptions);

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,7 +32,7 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**15 tools with 184 operations across 15 domains:**
+**16 tools with 186 operations across 16 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
@@ -48,6 +48,7 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 | `master` | 10 | title/body placeholder fonts, solid + gradient master backgrounds |
 | `animation` | 5 | shape effects, transition read/write |
 | `image` | 7 | add picture, brightness/contrast, recolor, crop |
+| `media` | 2 | add embedded/linked audio or video, get native media info |
 | `chart` | 16 | charts, series, titles, legend, data replacement, styles, colors, data tables |
 | `smartart` | 7 | SmartArt insertion and node editing |
 | `export` | 3 | export to PDF or images |

--- a/src/PowerPointMcp.Service/PowerPointMcp.Service.csproj
+++ b/src/PowerPointMcp.Service/PowerPointMcp.Service.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Sbroenne.PowerPointMcp.CLI" />
+    <InternalsVisibleTo Include="Sbroenne.PowerPointMcp.McpServer.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -10,6 +10,7 @@ using Sbroenne.PowerPointMcp.Core.Export;
 using Sbroenne.PowerPointMcp.Core.Image;
 using Sbroenne.PowerPointMcp.Core.Layout;
 using Sbroenne.PowerPointMcp.Core.Master;
+using Sbroenne.PowerPointMcp.Core.Media;
 using Sbroenne.PowerPointMcp.Core.Notes;
 using Sbroenne.PowerPointMcp.Core.PageSetup;
 using Sbroenne.PowerPointMcp.Core.Presentation;
@@ -63,6 +64,7 @@ public sealed class PowerPointMcpService : IDisposable
     private readonly SmartArtCommands _smartArtCommands = new();
     private readonly PageSetupCommands _pageSetupCommands = new();
     private readonly AccessibilityCommands _accessibilityCommands = new();
+    private readonly MediaCommands _mediaCommands = new();
 
     /// <summary>Gets the UTC time this daemon instance started.</summary>
     public DateTime StartTime => _startTime;
@@ -77,7 +79,7 @@ public sealed class PowerPointMcpService : IDisposable
     /// mirroring mcp-server-excel's architecture, where one shared Service class is consumed two
     /// ways: in-process (direct calls, no pipe) by the MCP server, and via
     /// named-pipe/StreamJsonRpc by the separate CLI daemon process. The generated domain MCP
-    /// tools (Slide, Shape, TextFrame, Table, Chart, Image, Notes, Layout, Master, Animation,
+    /// tools (Slide, Shape, TextFrame, Table, Chart, Image, Media, Notes, Layout, Master, Animation,
     /// SmartArt, Export, PageSetup, Accessibility) DO call <see cref="ProcessAsync"/> in-process
     /// via <c>ServiceBridge.ForwardToService</c> — only the hand-written
     /// <c>PresentationTools</c> bypass it and use <see cref="Sessions"/> directly.
@@ -255,6 +257,9 @@ public sealed class PowerPointMcpService : IDisposable
                 "image" => DispatchSimple<ImageAction>(action, request,
                     ServiceRegistry.Image.TryParseAction,
                     (a, batch) => ServiceRegistry.Image.DispatchToCore(_imageCommands, a, batch, request.Args)),
+                "media" => DispatchSimple<MediaAction>(action, request,
+                    ServiceRegistry.Media.TryParseAction,
+                    (a, batch) => ServiceRegistry.Media.DispatchToCore(_mediaCommands, a, batch, request.Args)),
                 "notes" => DispatchSimple<NotesAction>(action, request,
                     ServiceRegistry.Notes.TryParseAction,
                     (a, batch) => ServiceRegistry.Notes.DispatchToCore(_notesCommands, a, batch, request.Args)),
@@ -823,11 +828,32 @@ public sealed class PowerPointMcpService : IDisposable
 
     private delegate bool TryParseDelegate<TAction>(string action, out TAction result);
 
-    private static ServiceResponse WrapResult(string? dispatchResult)
+    internal static ServiceResponse WrapResult(string? dispatchResult)
     {
-        return dispatchResult == null
-            ? new ServiceResponse { Success = true }
-            : new ServiceResponse { Success = true, Result = dispatchResult };
+        if (dispatchResult is null)
+        {
+            return new ServiceResponse { Success = true };
+        }
+
+        using var document = JsonDocument.Parse(dispatchResult);
+        JsonElement root = document.RootElement;
+        if (root.TryGetProperty("success", out JsonElement success) &&
+            success.ValueKind == JsonValueKind.False)
+        {
+            string? errorMessage =
+                root.TryGetProperty("errorMessage", out JsonElement error) &&
+                error.ValueKind == JsonValueKind.String
+                    ? error.GetString()
+                    : null;
+
+            return new ServiceResponse
+            {
+                Success = false,
+                ErrorMessage = errorMessage ?? "Operation failed."
+            };
+        }
+
+        return new ServiceResponse { Success = true, Result = dispatchResult };
     }
 
     /// <summary>

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -849,7 +849,8 @@ public sealed class PowerPointMcpService : IDisposable
             return new ServiceResponse
             {
                 Success = false,
-                ErrorMessage = errorMessage ?? "Operation failed."
+                ErrorMessage = errorMessage ?? "Operation failed.",
+                Result = dispatchResult
             };
         }
 

--- a/src/PowerPointMcp.Service/ServiceProtocol.cs
+++ b/src/PowerPointMcp.Service/ServiceProtocol.cs
@@ -62,7 +62,10 @@ public sealed class ServiceResponse
     /// <summary>Inner exception details, when available.</summary>
     public string? InnerError { get; init; }
 
-    /// <summary>JSON-serialized result data.</summary>
+    /// <summary>
+    /// JSON-serialized result data, including the original structured Core payload for operation
+    /// failures when one is available.
+    /// </summary>
     public string? Result { get; init; }
 }
 

--- a/tests/PowerPointMcp.CLI.Tests/ServiceErrorOutputTests.cs
+++ b/tests/PowerPointMcp.CLI.Tests/ServiceErrorOutputTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.CLI.Infrastructure;
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.CLI.Tests;
+
+public sealed class ServiceErrorOutputTests
+{
+    [Fact]
+    public void SerializeServiceError_WithStructuredCoreFailure_KeepsStableCliEnvelope()
+    {
+        var response = new ServiceResponse
+        {
+            Success = false,
+            ErrorMessage = "Validation failed.",
+            Result = """{"success":false,"errorMessage":"Validation failed.","itemIndex":7}"""
+        };
+
+        string json = CliErrorOutput.SerializeServiceError(response);
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal("Validation failed.", root.GetProperty("errorMessage").GetString());
+        Assert.True(root.GetProperty("isError").GetBoolean());
+        Assert.False(root.TryGetProperty("itemIndex", out _));
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
@@ -1,0 +1,212 @@
+using Sbroenne.PowerPointMcp.Core.Media;
+using Sbroenne.PowerPointMcp.Core.Presentation;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+/// <summary>
+/// Real integration tests for media commands against live PowerPoint COM. Audio and video
+/// fixtures are repository-owned synthetic media with no third-party authored content. An
+/// unavailable host video decoder fails explicitly during insertion rather than skipping coverage.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Feature", "Media")]
+public sealed class MediaCommandsTests : IClassFixture<SharedPresentationFixture>
+{
+    private readonly SharedPresentationFixture _fixture;
+    private readonly PresentationCommands _presentationCommands = new();
+    private readonly MediaCommands _commands = new();
+
+    public MediaCommandsTests(SharedPresentationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void AddMedia_EmbeddedAudio_SurvivesSourceDeletionAndSaveReopen()
+    {
+        _fixture.CreateFreshPresentation();
+        string mediaPath = CreateWaveFixture();
+        var addResult = _commands.AddMedia(
+            _fixture.Batch, 1, mediaPath, false, true, 10f, 10f, 120f, 60f);
+
+        Assert.True(addResult.Success, addResult.ErrorMessage);
+        Assert.Null(addResult.ErrorMessage);
+        Assert.Equal(1, addResult.ShapeIndex);
+        Assert.Equal(1, addResult.ShapeCount);
+        Assert.False(addResult.LinkToFile);
+        Assert.True(addResult.SaveWithDocument);
+
+        File.Delete(mediaPath);
+        Assert.False(File.Exists(mediaPath));
+
+        _presentationCommands.Save(_fixture.Batch);
+        _fixture.ReopenCurrentPresentation();
+
+        var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+        Assert.True(info.Success, info.ErrorMessage);
+        Assert.Equal("ppMediaTypeSound", info.MediaTypeName);
+        Assert.Equal(1, info.ShapeIndex);
+        Assert.Equal(1, info.ShapeCount);
+    }
+
+    [Fact]
+    public void AddMedia_EmbeddedVideo_UsesSyntheticMp4AndPersists()
+    {
+        _fixture.CreateFreshPresentation();
+        string mediaPath = CreateVideoFixture();
+        try
+        {
+            var addResult = _commands.AddMedia(
+                _fixture.Batch, 1, mediaPath, false, true, 20f, 20f, 160f, 90f);
+
+            Assert.True(addResult.Success, addResult.ErrorMessage);
+            Assert.Equal(1, addResult.ShapeIndex);
+            Assert.Equal(1, addResult.ShapeCount);
+
+            _presentationCommands.Save(_fixture.Batch);
+            _fixture.ReopenCurrentPresentation();
+
+            var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+            Assert.True(info.Success, info.ErrorMessage);
+            Assert.Equal("ppMediaTypeMovie", info.MediaTypeName);
+            Assert.Equal(1, info.ShapeIndex);
+            Assert.Equal(1, info.ShapeCount);
+        }
+        finally
+        {
+            File.Delete(mediaPath);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AddMedia_LinkedAudioAndVideo_PersistAndReleaseSourceFile(bool video)
+    {
+        _fixture.CreateFreshPresentation();
+        string mediaPath = video ? CreateVideoFixture() : CreateWaveFixture();
+        var addResult = _commands.AddMedia(
+            _fixture.Batch, 1, mediaPath, true, false, 5f, 5f, 100f, 75f);
+
+        Assert.True(addResult.Success, addResult.ErrorMessage);
+        Assert.True(addResult.LinkToFile);
+        Assert.False(addResult.SaveWithDocument);
+        Assert.Equal(Path.GetFullPath(mediaPath), addResult.SourcePath);
+
+        _presentationCommands.Save(_fixture.Batch);
+        _fixture.ReopenCurrentPresentation();
+
+        var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+        Assert.True(info.Success, info.ErrorMessage);
+        Assert.Equal(video ? "ppMediaTypeMovie" : "ppMediaTypeSound", info.MediaTypeName);
+
+        File.Delete(mediaPath);
+        Assert.False(File.Exists(mediaPath));
+    }
+
+    [Fact]
+    public void AddMedia_WithMissingPath_ReturnsFailure()
+    {
+        _fixture.CreateFreshPresentation();
+        var result = _commands.AddMedia(
+            _fixture.Batch, 1, "C:\\does\\not\\exist.wav", false, true, 0f, 0f, 100f, 100f);
+
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void AddMedia_WithAmbiguousStorageCombination_ReturnsFailure(
+        bool linkToFile,
+        bool saveWithDocument)
+    {
+        _fixture.CreateFreshPresentation();
+        string mediaPath = CreateWaveFixture();
+        try
+        {
+            var result = _commands.AddMedia(
+                _fixture.Batch, 1, mediaPath, linkToFile, saveWithDocument,
+                0f, 0f, 100f, 100f);
+
+            Assert.False(result.Success);
+            Assert.Contains("combination", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(mediaPath);
+        }
+    }
+
+    [Fact]
+    public void AddMedia_WithMalformedPath_ReturnsFailure()
+    {
+        var result = _commands.AddMedia(
+            _fixture.Batch, 1, "invalid\0media.wav", false, true,
+            0f, 0f, 100f, 100f);
+
+        Assert.False(result.Success);
+        Assert.Contains("Invalid media path", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetMediaInfo_WithInvalidIndexesOrNonMediaShape_ReturnsFailure()
+    {
+        _fixture.CreateFreshPresentation();
+        var shapeCommands = new Core.Shape.ShapeCommands();
+
+        var invalidSlide = _commands.GetMediaInfo(_fixture.Batch, 0, 1);
+        Assert.False(invalidSlide.Success);
+
+        var invalidShape = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+        Assert.False(invalidShape.Success);
+
+        var rectangle = shapeCommands.AddRectangle(_fixture.Batch, 1, 0f, 0f, 100f, 100f);
+        Assert.True(rectangle.Success, rectangle.ErrorMessage);
+
+        var nonMedia = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+        Assert.False(nonMedia.Success);
+        Assert.Contains("not a media", nonMedia.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateWaveFixture()
+    {
+        string path = CreateFixturePath(".wav");
+
+        // 100 ms of a synthetic 440 Hz tone: 8 kHz, 8-bit unsigned mono PCM.
+        // Generated once with PowerShell/.NET by writing the standard RIFF/WAVE header followed by
+        // 800 samples computed as 128 + sin(2*pi*440*i/8000)*24. No runtime encoder or external
+        // asset is used. These deterministic bytes contain no third-party authored media and are
+        // repository-owned under the MIT license.
+        const string base64Wav =
+            "UklGRkQDAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YSADAACAiI+VmJiVkImBeXFsaWhrcHZ+h46Ul5iWkYqCenNtaWhqb3V9hY2Tl5iWkoyEfHRuaWhpbnR8hIySlpiXk42FfXVvamhpbXN6goqRlpiXlI6HfnZwa2hpbHF5gYmQlZiYlY+IgHhxa2hoa3B3f4ePlJeYlZCKgnlybGloam92foaNk5eYlpGLg3tzbWloam50fISMkpeYl5KMhHx0bmpoaW1ze4OLkZaYl5ONhn52b2poaWxyeYKKkJWYl5SPh393cGtoaGtxeICIj5WYmJWQiYF5cWxpaGtwdn6HjpSXmJaRioJ6c21paGpvdX2FjZOXmJaSjIR8dG5paGludHyEjJKWmJeTjYV9dW9qaGltc3qCipGWmJeUjod+dnBraGlscXmBiZCVmJiVj4iAeHFraGhrcHd/h4+Ul5iVkIqCeXJsaWhqb3Z+ho2Tl5iWkYuDe3NtaWhqbnR8hIySl5iXkoyEfHRuamhpbXN7g4uRlpiXk42GfnZvamhpbHJ5goqQlZiXlI+Hf3dwa2hoa3F4gIiPlZiYlZCJgXlxbGloa3B2foeOlJeYlpGKgnpzbWloam91fYWNk5eYlpKMhHx0bmloaW50fISMkpaYl5ONhX11b2poaW1zeoKKkZaYl5SOh352cGtoaWxxeYGJkJWYmJWPiIB4cWtoaGtwd3+Hj5SXmJWQioJ5cmxpaGpvdn6GjZOXmJaRi4N7c21paGpudHyEjJKXmJeSjIR8dG5qaGltc3uDi5GWmJeTjYZ+dm9qaGlscnmCipCVmJeUj4d/d3BraGhrcXiAiI+VmJiVkImBeXFsaWhrcHZ+h46Ul5iWkYqCenNtaWhqb3V9hY2Tl5iWkoyEfHRuaWhpbnR8hIySlpiXk42FfXVvamhpbXN6goqRlpiXlI6HfnZwa2hpbHF5gYmQlZiYlY+IgHhxa2hoa3B3f4ePlJeYlZCKgnlybGloam92foaNk5eYlpGLg3tzbWloam50fISMkpeYl5KMhHx0bmpoaW1ze4OLkZaYl5ONhn52b2poaWxyeYKKkJWYl5SPh393cGtoaGtxeA==";
+
+        File.WriteAllBytes(path, Convert.FromBase64String(base64Wav));
+        return path;
+    }
+
+    private static string CreateFixturePath(string extension)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "PowerPointMcpTests");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, $"pptmcp-owned-media-{Guid.NewGuid():N}{extension}");
+    }
+
+    private static string CreateVideoFixture()
+    {
+        string path = CreateFixturePath(".mp4");
+
+        // One second of black video: H.264 Constrained Baseline, 160x90, yuv420p, 10 fps, no audio.
+        // Generated solely from FFmpeg's color source with the FFmpeg 8.1 BtbN LGPL ARM64 build
+        // (https://github.com/BtbN/FFmpeg-Builds) and libopenh264. Command: ffmpeg -f lavfi -i
+        // "color=c=black:size=160x90:rate=10:duration=1" -c:v libopenh264 -pix_fmt yuv420p
+        // -movflags +faststart -an output.mp4. The generator is not redistributed. These synthetic
+        // bytes contain no third-party authored media and are repository-owned under the MIT license.
+        const string base64Mp4 =
+            "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAOAbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAA+gAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAm10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAA+gAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAKAAAABaAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAPoAAAAAAABAAAAAAHlbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAoAAAAKABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABkG1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAVBzdGJsAAAAsHN0c2QAAAAAAAAAAQAAAKBhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAKAAWgBIAAAASAAAAAAAAAABGUxhdmM2Mi4yOC4xMDIgbGlib3BlbmgyNjQAAAAAAAAAGP//AAAAJmF2Y0MBQsAU/+EAD2dCwBSMaCjXkwEB4RCNQAEABGjOPIAAAAAQcGFzcAAAAAEAAAABAAAAFGJ0cnQAAAAAAAAFiAAABYgAAAAYc3R0cwAAAAAAAAABAAAACgAABAAAAAAUc3RzcwAAAAAAAAABAAAAAQAAABxzdHNjAAAAAAAAAAEAAAABAAAACgAAAAEAAAA8c3RzegAAAAAAAAAAAAAACgAAAEUAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAUc3RjbwAAAAAAAAABAAADsAAAAJ91ZHRhAAAAl21ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAAamlsc3QAAAA9qW5hbQAAADVkYXRhAAAAAQAAAABQb3dlclBvaW50TWNwIHN5bnRoZXRpYyBtZWRpYSBmaXh0dXJlAAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjYyLjEyLjEwMgAAAAhmcmVlAAAAuW1kYXQAAABBZbgABAnkxQABGfk5OTk5OTk5OTrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr/+P8EBAaTZffffffffffgAAAAIYeAAfkCeD2AAAAAIYeAAvkD+D2AAAAAIYeAA/kBXg9gAAAAIYeABPkBvg9gAAAAIYeABfkB3g9gAAAAIYeABvkB3g9gAAAAIYeAB/kB3g9gAAAAIYeACPkB3g9gAAAAIYeACfkB3g9g=";
+
+        File.WriteAllBytes(path, Convert.FromBase64String(base64Mp4));
+        return path;
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
@@ -26,27 +26,34 @@ public sealed class MediaCommandsTests : IClassFixture<SharedPresentationFixture
     {
         _fixture.CreateFreshPresentation();
         string mediaPath = CreateWaveFixture();
-        var addResult = _commands.AddMedia(
-            _fixture.Batch, 1, mediaPath, false, true, 10f, 10f, 120f, 60f);
+        try
+        {
+            var addResult = _commands.AddMedia(
+                _fixture.Batch, 1, mediaPath, false, true, 10f, 10f, 120f, 60f);
 
-        Assert.True(addResult.Success, addResult.ErrorMessage);
-        Assert.Null(addResult.ErrorMessage);
-        Assert.Equal(1, addResult.ShapeIndex);
-        Assert.Equal(1, addResult.ShapeCount);
-        Assert.False(addResult.LinkToFile);
-        Assert.True(addResult.SaveWithDocument);
+            Assert.True(addResult.Success, addResult.ErrorMessage);
+            Assert.Null(addResult.ErrorMessage);
+            Assert.Equal(1, addResult.ShapeIndex);
+            Assert.Equal(1, addResult.ShapeCount);
+            Assert.False(addResult.LinkToFile);
+            Assert.True(addResult.SaveWithDocument);
 
-        File.Delete(mediaPath);
-        Assert.False(File.Exists(mediaPath));
+            File.Delete(mediaPath);
+            Assert.False(File.Exists(mediaPath));
 
-        _presentationCommands.Save(_fixture.Batch);
-        _fixture.ReopenCurrentPresentation();
+            _presentationCommands.Save(_fixture.Batch);
+            _fixture.ReopenCurrentPresentation();
 
-        var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
-        Assert.True(info.Success, info.ErrorMessage);
-        Assert.Equal("ppMediaTypeSound", info.MediaTypeName);
-        Assert.Equal(1, info.ShapeIndex);
-        Assert.Equal(1, info.ShapeCount);
+            var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+            Assert.True(info.Success, info.ErrorMessage);
+            Assert.Equal("ppMediaTypeSound", info.MediaTypeName);
+            Assert.Equal(1, info.ShapeIndex);
+            Assert.Equal(1, info.ShapeCount);
+        }
+        finally
+        {
+            File.Delete(mediaPath);
+        }
     }
 
     [Fact]
@@ -85,22 +92,28 @@ public sealed class MediaCommandsTests : IClassFixture<SharedPresentationFixture
     {
         _fixture.CreateFreshPresentation();
         string mediaPath = video ? CreateVideoFixture() : CreateWaveFixture();
-        var addResult = _commands.AddMedia(
-            _fixture.Batch, 1, mediaPath, true, false, 5f, 5f, 100f, 75f);
+        try
+        {
+            var addResult = _commands.AddMedia(
+                _fixture.Batch, 1, mediaPath, true, false, 5f, 5f, 100f, 75f);
 
-        Assert.True(addResult.Success, addResult.ErrorMessage);
-        Assert.True(addResult.LinkToFile);
-        Assert.False(addResult.SaveWithDocument);
-        Assert.Equal(Path.GetFullPath(mediaPath), addResult.SourcePath);
+            Assert.True(addResult.Success, addResult.ErrorMessage);
+            Assert.True(addResult.LinkToFile);
+            Assert.False(addResult.SaveWithDocument);
+            Assert.Equal(Path.GetFullPath(mediaPath), addResult.SourcePath);
 
-        _presentationCommands.Save(_fixture.Batch);
-        _fixture.ReopenCurrentPresentation();
+            _presentationCommands.Save(_fixture.Batch);
+            _fixture.ReopenCurrentPresentation();
 
-        var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
-        Assert.True(info.Success, info.ErrorMessage);
-        Assert.Equal(video ? "ppMediaTypeMovie" : "ppMediaTypeSound", info.MediaTypeName);
+            var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+            Assert.True(info.Success, info.ErrorMessage);
+            Assert.Equal(video ? "ppMediaTypeMovie" : "ppMediaTypeSound", info.MediaTypeName);
+        }
+        finally
+        {
+            File.Delete(mediaPath);
+        }
 
-        File.Delete(mediaPath);
         Assert.False(File.Exists(mediaPath));
     }
 

--- a/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
@@ -182,6 +182,7 @@ public sealed class MediaCommandsTests : IClassFixture<SharedPresentationFixture
     [Fact]
     public void AddMedia_WithMalformedPath_ReturnsFailure()
     {
+        _fixture.CreateFreshPresentation();
         var result = _commands.AddMedia(
             _fixture.Batch, 1, "invalid\0media.wav", false, true,
             0f, 0f, 100f, 100f);

--- a/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/MediaCommandsTests.cs
@@ -118,6 +118,37 @@ public sealed class MediaCommandsTests : IClassFixture<SharedPresentationFixture
     }
 
     [Fact]
+    public void AddMedia_LinkedAndSavedWithDocument_PersistsAfterSourceDeletion()
+    {
+        _fixture.CreateFreshPresentation();
+        string mediaPath = CreateWaveFixture();
+        try
+        {
+            var addResult = _commands.AddMedia(
+                _fixture.Batch, 1, mediaPath, true, true, 5f, 5f, 100f, 75f);
+
+            Assert.True(addResult.Success, addResult.ErrorMessage);
+            Assert.True(addResult.LinkToFile);
+            Assert.True(addResult.SaveWithDocument);
+
+            _presentationCommands.Save(_fixture.Batch);
+            File.Delete(mediaPath);
+            Assert.False(File.Exists(mediaPath));
+            _fixture.ReopenCurrentPresentation();
+
+            var info = _commands.GetMediaInfo(_fixture.Batch, 1, 1);
+            Assert.True(info.Success, info.ErrorMessage);
+            Assert.Equal("ppMediaTypeSound", info.MediaTypeName);
+            Assert.Equal(1, info.ShapeIndex);
+            Assert.Equal(1, info.ShapeCount);
+        }
+        finally
+        {
+            File.Delete(mediaPath);
+        }
+    }
+
+    [Fact]
     public void AddMedia_WithMissingPath_ReturnsFailure()
     {
         _fixture.CreateFreshPresentation();
@@ -128,23 +159,19 @@ public sealed class MediaCommandsTests : IClassFixture<SharedPresentationFixture
         Assert.Contains("not found", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Theory]
-    [InlineData(false, false)]
-    [InlineData(true, true)]
-    public void AddMedia_WithAmbiguousStorageCombination_ReturnsFailure(
-        bool linkToFile,
-        bool saveWithDocument)
+    [Fact]
+    public void AddMedia_WithoutLinkOrSavedData_ReturnsFailure()
     {
         _fixture.CreateFreshPresentation();
         string mediaPath = CreateWaveFixture();
         try
         {
             var result = _commands.AddMedia(
-                _fixture.Batch, 1, mediaPath, linkToFile, saveWithDocument,
+                _fixture.Batch, 1, mediaPath, false, false,
                 0f, 0f, 100f, 100f);
 
             Assert.False(result.Success);
-            Assert.Contains("combination", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no media data", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/tests/PowerPointMcp.Core.Tests/PiaMigrationGuardTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/PiaMigrationGuardTests.cs
@@ -67,6 +67,8 @@ public class PiaMigrationGuardTests
     //                remain dynamic.
     //   Master     — ctx.Presentation.SlideMaster hangs indefinitely via typed NoPIA interface
     //                (documented quirk identical to CoreTestHelper.CreateTemplateFile). Stays dynamic.
+    //   Media      — AddMediaObject2 and Shape.Type cross Office.Core enum boundaries that are
+    //                unavailable without office.dll; PpMediaType read-back remains typed.
     //   Notes      — NotesPage / shape iteration accessed dynamically; msoPlaceholder (= 14) is an
     //                MsoShapeType raw int constant (no typed equivalent in scope without office.dll);
     //                PpPlaceholderType is already typed via PowerPoint PIA.
@@ -91,6 +93,7 @@ public class PiaMigrationGuardTests
         ["Animation\\AnimationCommands.cs"] = 4, // Effect.Exit + Transition.AdvanceOnClick/AdvanceOnTime are MsoTriState (office.dll)
         ["Chart\\ChartCommands.cs"] = 21, // Shape.HasChart (MsoTriState) + Excel.SeriesCollection/XValues (Excel.dll)
         ["Master\\MasterCommands.cs"] = 5, // SlideMaster NoPIA hang + Font.Bold MsoTriState (office.dll)
+        ["Media\\MediaCommands.cs"] = 2, // AddMediaObject2 MsoTriState args + Shape.Type MsoShapeType
         ["Notes\\NotesCommands.cs"] = 3, // NotesPage / shape iteration — office.dll types
         ["Presentation\\PresentationCommands.cs"] = 5, // DocumentProperties (office.dll)
         ["Shape\\ShapeCommands.cs"] = 26, // MsoAutoShapeType / MsoShadowStyle / Line+Shadow Visible (office.dll)

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpMediaToolSchemaTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpMediaToolSchemaTests.cs
@@ -1,0 +1,131 @@
+using System.IO.Pipelines;
+using System.Text.Json;
+using ModelContextProtocol.Client;
+using Sbroenne.PowerPointMcp.Generated;
+using Xunit.Abstractions;
+
+namespace Sbroenne.PowerPointMcp.McpServer.Tests.Integration;
+
+/// <summary>
+/// Verifies generated MCP schema and CLI routing for <c>IMediaCommands</c>. These tests exercise
+/// generated contracts only; real media COM behavior is covered by Core integration tests.
+/// </summary>
+[Collection("ProgramTransport")]
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "McpServer")]
+[Trait("Feature", "Media")]
+public sealed class McpMediaToolSchemaTests : IAsyncLifetime, IAsyncDisposable
+{
+    private static readonly HashSet<string> ExpectedParameters = new(StringComparer.Ordinal)
+    {
+        "action",
+        "session_id",
+        "slide_index",
+        "media_path",
+        "link_to_file",
+        "save_with_document",
+        "left",
+        "top",
+        "width",
+        "height",
+        "shape_index",
+    };
+
+    private readonly ITestOutputHelper _output;
+    private readonly Pipe _clientToServerPipe = new();
+    private readonly Pipe _serverToClientPipe = new();
+    private readonly CancellationTokenSource _cts = new();
+    private McpClient? _client;
+    private Task? _serverTask;
+
+    public McpMediaToolSchemaTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        (_client, _serverTask) = await ProgramTransportTestHost.StartAsync(
+            _clientToServerPipe,
+            _serverToClientPipe,
+            "MediaSchemaTestClient",
+            _cts.Token);
+    }
+
+    public async Task DisposeAsync() => await DisposeAsyncCore();
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await DisposeAsyncCore();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void MediaAction_EnumAndCliRouting_AreComplete()
+    {
+        string[] expectedActions = ["add-media", "get-media-info"];
+        Assert.Equal(expectedActions, ServiceRegistry.Media.ValidActions);
+
+        var enumActions = Enum.GetValues<MediaAction>()
+            .Select(ServiceRegistry.Media.ToActionString)
+            .ToArray();
+        Assert.Equal(expectedActions, enumActions);
+
+        var (addCommand, _) = ServiceRegistry.Media.RouteCliArgs(
+            "add-media",
+            slideIndex: 1,
+            mediaPath: "C:\\media.wav",
+            linkToFile: false,
+            saveWithDocument: true,
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100);
+        Assert.Equal("media.add-media", addCommand);
+
+        var (getCommand, _) = ServiceRegistry.Media.RouteCliArgs(
+            "get-media-info",
+            slideIndex: 1,
+            shapeIndex: 1);
+        Assert.Equal("media.get-media-info", getCommand);
+    }
+
+    [Fact]
+    public async Task MediaTool_SchemaContainsGeneratedActionsAndParameters()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var mediaTool = tools.Single(tool => tool.Name == ServiceRegistry.Media.McpToolName);
+
+        Assert.Contains("add-media", mediaTool.Description, StringComparison.Ordinal);
+        Assert.Contains("get-media-info", mediaTool.Description, StringComparison.Ordinal);
+
+        JsonElement schema = mediaTool.JsonSchema;
+        JsonElement properties = schema.GetProperty("properties");
+        var actualParameters = properties.EnumerateObject()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.True(
+            ExpectedParameters.SetEquals(actualParameters),
+            $"Expected [{string.Join(", ", ExpectedParameters.Order())}], got " +
+            $"[{string.Join(", ", actualParameters.Order())}].");
+
+        JsonElement actionSchema = properties.GetProperty("action");
+        string[] actionValues = actionSchema.GetProperty("enum")
+            .EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
+        Assert.Equal(ServiceRegistry.Media.ValidActions, actionValues);
+    }
+
+    private async Task DisposeAsyncCore()
+    {
+        await ProgramTransportTestHost.StopAsync(
+            _client,
+            _clientToServerPipe,
+            _serverToClientPipe,
+            _serverTask,
+            _output);
+        _cts.Dispose();
+    }
+}

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -38,7 +38,7 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
     /// The MCP tool surface: one hand-written action-dispatch tool (Presentation — session
     /// lifecycle + template + document properties) plus one generated action-dispatch tool per
     /// remaining Core domain (Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup,
-    /// Accessibility, Master, Animation, SmartArt, Image, Chart, Export) — enumerated directly
+    /// Accessibility, Master, Animation, SmartArt, Image, Media, Chart, Export) — enumerated directly
     /// from every <c>[McpServerTool]</c> in
     /// <c>src/PowerPointMcp.McpServer/Tools/*.cs</c> (hand-written) and the generated
     /// <c>PowerPointMcp.Generators.Mcp</c> output (one action-dispatch tool per domain, matching
@@ -50,7 +50,7 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
         // PresentationTools.cs (1, hand-written action-dispatch tool — session lifecycle,
         // Save As/copy, template, Mark as Final, and document properties; 16 actions)
         "presentation",
-        // Generated action-dispatch tools (14, one per remaining Core domain)
+        // Generated action-dispatch tools (15, one per remaining Core domain)
         "slide",
         "shape",
         "textframe",
@@ -63,6 +63,7 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
         "animation",
         "smartart",
         "image",
+        "media",
         "chart",
         "export"
     ];
@@ -104,7 +105,7 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
     }
 
     /// <summary>
-    /// THE core protocol proof: exactly the 15 expected tools (1 hand-written + 14 generated
+    /// THE core protocol proof: exactly the 16 expected tools (1 hand-written + 15 generated
     /// action-dispatch tools) are discoverable via <c>tools/list</c> — no more, no less.
     /// </summary>
     [Fact]

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/ServiceResultEnvelopeTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/ServiceResultEnvelopeTests.cs
@@ -1,0 +1,38 @@
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.McpServer.Tests.Integration;
+
+/// <summary>
+/// Verifies generated Core result envelopes are reflected in the shared service response without
+/// touching PowerPoint COM.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Fast")]
+[Trait("Layer", "Service")]
+[Trait("Feature", "McpProtocol")]
+public sealed class ServiceResultEnvelopeTests
+{
+    [Fact]
+    public void WrapResult_WithCoreValidationFailure_PropagatesFailure()
+    {
+        const string result = """{"success":false,"errorMessage":"Invalid media path."}""";
+
+        ServiceResponse response = PowerPointMcpService.WrapResult(result);
+
+        Assert.False(response.Success);
+        Assert.Equal("Invalid media path.", response.ErrorMessage);
+        Assert.Null(response.Result);
+    }
+
+    [Fact]
+    public void WrapResult_WithSuccessfulCoreResult_PreservesPayload()
+    {
+        const string result = """{"success":true,"shapeIndex":1}""";
+
+        ServiceResponse response = PowerPointMcpService.WrapResult(result);
+
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorMessage);
+        Assert.Equal(result, response.Result);
+    }
+}

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/ServiceResultEnvelopeTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/ServiceResultEnvelopeTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Sbroenne.PowerPointMcp.McpServer.Infrastructure;
 using Sbroenne.PowerPointMcp.Service;
 
 namespace Sbroenne.PowerPointMcp.McpServer.Tests.Integration;
@@ -15,13 +17,14 @@ public sealed class ServiceResultEnvelopeTests
     [Fact]
     public void WrapResult_WithCoreValidationFailure_PropagatesFailure()
     {
-        const string result = """{"success":false,"errorMessage":"Invalid media path."}""";
+        const string result =
+            """{"success":false,"errorMessage":"Validation failed.","itemIndex":7}""";
 
         ServiceResponse response = PowerPointMcpService.WrapResult(result);
 
         Assert.False(response.Success);
-        Assert.Equal("Invalid media path.", response.ErrorMessage);
-        Assert.Null(response.Result);
+        Assert.Equal("Validation failed.", response.ErrorMessage);
+        Assert.Equal(result, response.Result);
     }
 
     [Fact]
@@ -34,5 +37,27 @@ public sealed class ServiceResultEnvelopeTests
         Assert.True(response.Success);
         Assert.Null(response.ErrorMessage);
         Assert.Equal(result, response.Result);
+    }
+
+    [Fact]
+    public void ServiceBridge_WithCoreValidationFailure_KeepsStableMcpErrorEnvelope()
+    {
+        const string result =
+            """{"success":false,"errorMessage":"Validation failed.","itemIndex":7}""";
+        var response = new ServiceResponse
+        {
+            Success = false,
+            ErrorMessage = "Validation failed.",
+            Result = result
+        };
+
+        string json = ServiceBridge.FormatResponse(response);
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal("Validation failed.", root.GetProperty("errorMessage").GetString());
+        Assert.True(root.GetProperty("isError").GetBoolean());
+        Assert.False(root.TryGetProperty("itemIndex", out _));
     }
 }


### PR DESCRIPTION
## Summary

- add a generated `media` domain with `add-media` and `get-media-info` across MCP and CLI
- support embedded, link-only, and linked-and-saved audio/video insertion plus typed `PpMediaType` metadata read-back; only `link_to_file=false` with `save_with_document=false` is rejected
- preserve Office-free builds by narrowly late-binding only the `MsoTriState` and `MsoShapeType` boundaries while keeping PowerPoint PIA types strongly typed
- fix the shared generated-domain service envelope so Core `success:false` results are reported as failures while their original structured JSON remains available to service clients; MCP and CLI keep their established error envelopes
- add shared skill guidance, website/reference documentation, count updates, and a Changesets fragment

## Fixtures

Tests use repository-owned synthetic bytes under the MIT license, with generation details and hashes documented in the test source:

- WAV: deterministic 100 ms 440 Hz PCM tone, generated directly from a RIFF/WAVE header and formula-derived samples
- MP4: deterministic one-second black H.264 video generated from FFmpeg's synthetic color source using `libopenh264`; no third-party authored media or generator binary is redistributed
- fixture deletion is guarded by `finally` so failed tests cannot leave generated audio/video files behind

## Validation

- strict TDD for linked-and-saved media: focused test failed against the old true/true validation, then passed after the fix
- final `Feature=Media`: 9 passed, including true/true save/reopen behavior after source deletion
- full staged pre-commit gate passed before the final review follow-up
  - Media: 9 passed
  - Presentation: 39 passed
  - MCP Server: 40 passed
  - release metadata and Agent Skills: 65 passed
  - Release build: 0 warnings, 0 errors
  - Success flag, COM cleanup, dynamic-cast, interface completeness, documentation count, and marker audits passed
- final static checks: Release build passed; Media schema/service 5 passed; CLI 17 passed; skills 65 passed; documentation counts, diff, Rule 1, and COM cleanup checks passed
- final reviewer-isolation check: malformed-path validation now starts from a fresh presentation; the focused real-PowerPoint test passed 1/1, Release build passed with 0 warnings/errors, and the diff check passed
- Office-free publish verified with neither `office.dll` nor `Microsoft.Office.Interop.PowerPoint.dll` in output