### PR TITLE
chore: prepare v0.1.6 patch release

### DIFF
--- a/.changeset/bright-media-support.md
+++ b/.changeset/bright-media-support.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 Add generated `media` MCP and CLI commands for embedded, link-only, or linked-and-saved audio/video

--- a/.changeset/bright-slides-save.md
+++ b/.changeset/bright-slides-save.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 Add `save-as` and `save-copy-as` presentation operations to the MCP server and CLI. Save As moves

--- a/.changeset/final-presentations.md
+++ b/.changeset/final-presentations.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 Add typed `get-final` and `set-final` presentation operations to the MCP server and CLI, with

--- a/.changeset/linked-picture-assets.md
+++ b/.changeset/linked-picture-assets.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 Add linked-picture insertion and shape-level link inspection, refresh, automatic-update where

--- a/.changeset/neat-powerpoint-tags.md
+++ b/.changeset/neat-powerpoint-tags.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 Add case-insensitive string tags to presentations, slides, and shapes through matching MCP and CLI

--- a/.changeset/quick-chart-formatting.md
+++ b/.changeset/quick-chart-formatting.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 Add chart style, color style, and data-table visibility controls to both the MCP server and CLI,

--- a/.changeset/steady-powerpoint-platform.md
+++ b/.changeset/steady-powerpoint-platform.md
@@ -1,5 +1,5 @@
 ---
-"powerpointmcp": minor
+"powerpointmcp": patch
 ---
 
 PowerPoint MCP now rejects unknown or mis-cased CLI and MCP arguments, saves presentations when


### PR DESCRIPTION
## Summary
- change all pending Changesets from minor to patch
- preserve every release-note entry unchanged
- ensure Changesets resolves 0.1.5 to 0.1.6

## Validation
- `npx --no-install changeset status` reports `newVersion: 0.1.6`
- repository pre-commit checks pass