### PR TITLE
Fix published plugin branding

### DIFF
--- a/.github/plugins/marketplace-repo/README.md
+++ b/.github/plugins/marketplace-repo/README.md
@@ -1,6 +1,6 @@
-# PowerPointMcp Copilot CLI Plugins
+# PowerPointMcp Agent Plugins
 
-Windows-only GitHub Copilot CLI plugins for PowerPointMcp.
+Windows-only Agent Plugins for PowerPointMcp.
 
 This repository is the publish target for plugin artifacts from [`sbroenne/mcp-server-powerpoint`](https://github.com/sbroenne/mcp-server-powerpoint).
 

--- a/scripts/Sync-PublishedPluginRepo.ps1
+++ b/scripts/Sync-PublishedPluginRepo.ps1
@@ -197,7 +197,7 @@ $legacyManifestPath = Join-Path $PublishedRepoDir "marketplace.json"
 $canonicalManifest = [ordered]@{
     name = "mcp-server-powerpoint-plugins"
     metadata = [ordered]@{
-        description = "Windows-only GitHub Copilot CLI plugins for PowerPoint automation with PowerPointMcp."
+        description = "Windows-only Agent Plugins for PowerPoint automation with PowerPointMcp."
         version = "1.0.0"
     }
     owner = [ordered]@{

--- a/tests/PowerPointMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/PowerPointMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -449,7 +449,7 @@ public sealed class PluginBootstrapBuildTests
 
             var publishedReadmeLines = File.ReadAllLines(Path.Combine(publishedRepoDir, "README.md"));
             Assert.Equal("# PowerPointMcp Agent Plugins", publishedReadmeLines[0]);
-            Assert.Equal("Windows-only Agent Plugins for PowerPointMcp.", publishedReadmeLines[2]);
+            Assert.Contains("Windows-only Agent Plugins for PowerPointMcp.", publishedReadmeLines);
         }
         finally
         {

--- a/tests/PowerPointMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
+++ b/tests/PowerPointMcp.SkillGeneration.Tests/PluginBootstrapBuildTests.cs
@@ -376,6 +376,9 @@ public sealed class PluginBootstrapBuildTests
             Assert.False(File.Exists(Path.Combine(publishedRepoDir, "marketplace.json")));
 
             using var manifest = JsonDocument.Parse(File.ReadAllText(canonicalManifestPath));
+            Assert.Equal(
+                "Windows-only Agent Plugins for PowerPoint automation with PowerPointMcp.",
+                manifest.RootElement.GetProperty("metadata").GetProperty("description").GetString());
             var plugins = manifest.RootElement.GetProperty("plugins");
             Assert.Equal(2, plugins.GetArrayLength());
 
@@ -443,6 +446,10 @@ public sealed class PluginBootstrapBuildTests
             Assert.Equal(
                 File.ReadAllText(sourceInstructionsPath),
                 File.ReadAllText(publishedInstructionsPath));
+
+            var publishedReadmeLines = File.ReadAllLines(Path.Combine(publishedRepoDir, "README.md"));
+            Assert.Equal("# PowerPointMcp Agent Plugins", publishedReadmeLines[0]);
+            Assert.Equal("Windows-only Agent Plugins for PowerPointMcp.", publishedReadmeLines[2]);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- use the Agent Plugins name in the generated marketplace README
- update generated marketplace metadata to the same public wording
- add regression checks for both generated outputs

## Checks
- plugin packaging tests: 54 passed
- pre-commit checks: passed