### PR TITLE
docs: promote Windows MCP Server

### DIFF
--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -31,6 +31,10 @@ hide:
     Check out [Excel MCP Server](https://excelmcpserver.dev/) — the sister
     project, built the same way.
 
+!!! tip "Also automating Windows apps and browsers?"
+    Check out [Windows MCP Server](https://windowsmcpserver.dev/) — automate
+    Windows apps and browsers from your AI assistant.
+
 ## Key features
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary

- add a homepage tip for Windows MCP Server
- link to windowsmcpserver.dev for Windows app and browser automation
- preserve the existing Excel MCP Server promotion