### PR TITLE
Fix graceful daemon shutdown handling

### DIFF
--- a/src/PowerPointMcp.CLI/Commands/ServiceCommands.cs
+++ b/src/PowerPointMcp.CLI/Commands/ServiceCommands.cs
@@ -59,6 +59,14 @@ internal sealed class ServiceStopCommand : AsyncCommand<ServiceStopSettings>
             var response = await client.SendAsync(new ServiceRequest { Command = "service.shutdown", Source = "cli" }, cancellationToken);
             if (response.Success)
             {
+                if (!settings.Force)
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(
+                        new { success = true, message = "Daemon shutdown started." },
+                        ServiceProtocol.JsonOptions));
+                    return 0;
+                }
+
                 var gracefulDeadline = OperationDeadline.Start(TimeSpan.FromSeconds(5));
                 while (!gracefulDeadline.IsExpired && DaemonAutoStart.IsDaemonMutexHeld(pipeName))
                 {
@@ -73,11 +81,6 @@ internal sealed class ServiceStopCommand : AsyncCommand<ServiceStopSettings>
                     return 0;
                 }
 
-                if (!settings.Force)
-                {
-                    return CliErrorOutput.WriteError(
-                        "Daemon accepted shutdown but did not exit before the graceful shutdown deadline.");
-                }
             }
 
             if (!settings.Force)

--- a/src/PowerPointMcp.Service/PowerPointMcpService.cs
+++ b/src/PowerPointMcp.Service/PowerPointMcpService.cs
@@ -47,6 +47,7 @@ public sealed class PowerPointMcpService : IDisposable
     private string _pipeName = "";
     private TimeSpan? _idleTimeout;
     private DateTime _lastActivityTime = DateTime.UtcNow;
+    private int _shutdownRequested;
     private bool _disposed;
 
     private readonly PresentationCommands _presentationCommands = new();
@@ -102,10 +103,15 @@ public sealed class PowerPointMcpService : IDisposable
     }
 
     /// <summary>Signals the pipe accept loop to stop, ending <see cref="RunAsync"/>.</summary>
-    public void RequestShutdown() => _shutdownCts.Cancel();
+    public void RequestShutdown()
+    {
+        Interlocked.Exchange(ref _shutdownRequested, 1);
+        _shutdownCts.Cancel();
+    }
 
     private void RequestShutdownAfterResponse()
     {
+        Interlocked.Exchange(ref _shutdownRequested, 1);
         _ = Task.Run(async () =>
         {
             await Task.Delay(100, CancellationToken.None);
@@ -228,6 +234,17 @@ public sealed class PowerPointMcpService : IDisposable
     {
         try
         {
+            if (Volatile.Read(ref _shutdownRequested) != 0 &&
+                !string.Equals(request.Command, "service.shutdown", StringComparison.Ordinal))
+            {
+                return Task.FromResult(new ServiceResponse
+                {
+                    Success = false,
+                    ErrorCategory = "ServiceUnavailable",
+                    ErrorMessage = "The PowerPoint MCP service is shutting down."
+                });
+            }
+
             var parts = request.Command.Split('.', 2);
             var category = parts[0];
             var action = parts.Length > 1 ? parts[1] : "";

--- a/tests/PowerPointMcp.CLI.Tests/ServiceStopRegressionTests.cs
+++ b/tests/PowerPointMcp.CLI.Tests/ServiceStopRegressionTests.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using Sbroenne.PowerPointMcp.Service;
+
+namespace Sbroenne.PowerPointMcp.CLI.Tests;
+
+public sealed class ServiceStopRegressionTests
+{
+    [Fact]
+    public async Task ServiceStop_DisposesShutdownConnectionBeforeWaitingForDaemonExit()
+    {
+        var pipeName = $"PowerPointMcp_StopRegression_{Guid.NewGuid():N}";
+        using var daemon = StartCli(
+            "service", "run",
+            "--pipe-name", pipeName,
+            "--idle-timeout-minutes", "5");
+
+        try
+        {
+            await WaitForDaemonAsync(pipeName);
+
+            using var stop = StartCli("service", "stop", "--pipe-name", pipeName);
+            var stopOutput = await stop.StandardOutput.ReadToEndAsync();
+            var stopError = await stop.StandardError.ReadToEndAsync();
+            await stop.WaitForExitAsync();
+
+            Assert.True(stop.ExitCode == 0, $"{stopOutput}{Environment.NewLine}{stopError}");
+            Assert.Contains("Daemon shutdown started.", stopOutput, StringComparison.Ordinal);
+
+            using var exitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await daemon.WaitForExitAsync(exitTimeout.Token);
+            Assert.Equal(0, daemon.ExitCode);
+        }
+        finally
+        {
+            if (!daemon.HasExited)
+            {
+                daemon.Kill(entireProcessTree: true);
+                await daemon.WaitForExitAsync();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Service_ShutdownRejectsNewSessionCommands()
+    {
+        using var service = new PowerPointMcpService();
+
+        var shutdown = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "service.shutdown",
+            Source = "cli"
+        });
+        var afterShutdown = await service.ProcessAsync(new ServiceRequest
+        {
+            Command = "session.list",
+            Source = "cli"
+        });
+
+        Assert.True(shutdown.Success);
+        Assert.False(afterShutdown.Success);
+        Assert.Equal("ServiceUnavailable", afterShutdown.ErrorCategory);
+        Assert.Contains("shutting down", afterShutdown.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WaitForDaemonAsync(string pipeName)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var status = StartCli("service", "status", "--pipe-name", pipeName);
+            var output = await status.StandardOutput.ReadToEndAsync();
+            await status.WaitForExitAsync();
+
+            if (status.ExitCode == 0 && output.Contains("\"responsive\":true", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException("Test daemon did not become responsive.");
+    }
+
+    private static Process StartCli(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Path.Combine(AppContext.BaseDirectory, "powerpointcli.exe"),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start powerpointcli.exe.");
+    }
+}


### PR DESCRIPTION
## Summary
- return success from non-force `service stop` as soon as graceful shutdown is accepted
- reject new commands after daemon shutdown has begun
- add regression coverage for the stop command and shutdown request gate

## Validation
- `dotnet test tests\PowerPointMcp.CLI.Tests\PowerPointMcp.CLI.Tests.csproj --filter "FullyQualifiedName~ServiceStopRegressionTests" --blame-hang-timeout 2m`
- `dotnet build Sbroenne.PowerPointMcp.slnx --no-restore`
- `dotnet test tests\PowerPointMcp.CLI.Tests\PowerPointMcp.CLI.Tests.csproj --no-build --no-restore --blame-hang-timeout 2m`
- `scripts\pre-commit.ps1`