### PR TITLE
fix(tests): enable Core integration test discovery

### DIFF
--- a/tests/PowerPointMcp.Core.Tests/PowerPointMcp.Core.Tests.csproj
+++ b/tests/PowerPointMcp.Core.Tests/PowerPointMcp.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <!-- Test-only relaxations: xUnit convention is underscored, descriptive method names
          (e.g. Create_SavesRealPptxFile_ThatPowerPointCanReopen), and test methods don't
          need XML doc comments. -->

--- a/tests/PowerPointMcp.SkillGeneration.Tests/ReleasePackagingTests.cs
+++ b/tests/PowerPointMcp.SkillGeneration.Tests/ReleasePackagingTests.cs
@@ -134,6 +134,21 @@ public sealed class ReleasePackagingTests
     }
 
     [Fact]
+    public void CoreTestProject_IsExplicitlyMarkedForTestDiscovery()
+    {
+        var project = XDocument.Load(Path.Combine(
+            RepoRoot,
+            "tests",
+            "PowerPointMcp.Core.Tests",
+            "PowerPointMcp.Core.Tests.csproj"));
+
+        Assert.Equal("true", project.Root!
+            .Elements("PropertyGroup")
+            .Elements("IsTestProject")
+            .SingleOrDefault()?.Value);
+    }
+
+    [Fact]
     public void ValidationGates_RunReleasePackagingTests()
     {
         const string testProject = "PowerPointMcp.SkillGeneration.Tests";


### PR DESCRIPTION
## Summary

Fixes #71.

The Core test project references the test SDK and xUnit but does not explicitly set `IsTestProject`. Under the pinned SDK, the documented `dotnet test` invocation can therefore skip the project while returning success.

This change adds `<IsTestProject>true</IsTestProject>` and a regression check in the existing `ReleasePackagingTests` class that reads the actual Core project XML. No production code, chart behavior, fixture lifetime, shutdown policy, package source configuration, or public API changes.

## Verification

Implemented and tested in a fresh checkout of this repository, based on `acf92b9736a68d8c18b8fb3a8158f9fcbf627cd4`; contribution commit `a63a380`.

- Regression first: 1 executed, 1 failed with expected `true`, actual `null` before adding the marker. The identical test passed after the fix: 1 executed, 1 passed.
- Release solution build: 0 warnings, 0 errors.
- Core `Feature=Chart`: 22 executed, 22 passed, 0 failed, 0 skipped, approximately 240 seconds. No command-line `IsTestProject` override. Fresh TRX confirmed execution; runner exit code 0.
- Unchanged `scripts/pre-commit.ps1`: passed, including 41/41 MCP Server tests and 66/66 release metadata/Agent Skills packaging tests, with no skips.
- SDK 10.0.400, test runtime 10.0.11, Office Click-to-Run 16.0.20501.20002 on Windows.

The successful Core run used:

```powershell
dotnet test tests\PowerPointMcp.Core.Tests -c Release --no-build --no-restore --filter 'Feature=Chart' --logger 'trx;LogFileName=chart.trx' --results-directory $resultDirectory --nologo
```

The invocation was wrapped in a ten-minute process-tree timeout and required a fresh TRX with a positive executed count. The first attempt was canceled after approximately 153 seconds without a completed TRX; that attempt is not counted as passing evidence. A single retry passed. No PowerPoint or test-host process remained at the post-Chart check, and the successful run required no force-kill.

The pre-commit gate skips Core tests when no Core domain source changes, so the separate Chart run above supplies the actual Core-discovery/execution evidence. The full Core suite was not run. This PR does not claim to resolve the startup-cleanup issue #72.

## Release Notes

Test-only change, with no end-user runtime behavior change. Per the changeset policy, no changeset is included; please apply `skip-changelog` if contributor permissions prevent me from doing so.