### PR TITLE
Fix failed startup cleanup and Core test discovery

### DIFF
--- a/.changeset/reliable-startup-cleanup.md
+++ b/.changeset/reliable-startup-cleanup.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": patch
+---
+
+**Reliable failed startup cleanup** (#72): PowerPoint processes created by a timed-out presentation open are now terminated using their verified process identity instead of being left running.

--- a/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
+++ b/src/PowerPointMcp.ComInterop/Session/PresentationBatch.cs
@@ -77,6 +77,12 @@ internal sealed class PresentationBatch : IPresentationBatch
     private PowerPoint.Presentation? _presentation;
     private PresentationContext? _context;
 
+    /// <summary>
+    /// Test-only seam for simulating a startup failure after PowerPoint's exact process identity
+    /// has been captured. Production code must leave this null.
+    /// </summary>
+    internal static Action<PowerPointProcessIdentity, CancellationToken>? AfterProcessIdentityCapturedHook { get; set; }
+
     public PresentationBatch(
         string presentationPath,
         bool createNewFile,
@@ -125,16 +131,34 @@ internal sealed class PresentationBatch : IPresentationBatch
 
             started.Task.GetAwaiter().GetResult();
         }
-        catch
+        catch (Exception startupFailure)
         {
             if (_staThread.IsAlive)
             {
-                if (!_staThread.Join(TimeSpan.FromSeconds(10)) && _powerPointProcessIdentity.HasValue)
+                _ = _staThread.Join(TimeSpan.FromSeconds(10));
+            }
+
+            if (_powerPointProcessIdentity is { } failedStartupIdentity)
+            {
+                try
                 {
-                    TryKillProcess(_powerPointProcessIdentity.Value);
+                    FinalizeFailedStartupOwnedProcess(failedStartupIdentity);
+                }
+                catch (Exception teardownFailure)
+                {
+                    throw new InvalidOperationException(
+                        $"PowerPoint startup failed and exact process teardown could not be confirmed for " +
+                        $"process {failedStartupIdentity.ProcessId}. The process identity remains tracked " +
+                        "for later cleanup.",
+                        new AggregateException(startupFailure, teardownFailure));
+                }
+
+                if (_staThread.IsAlive)
+                {
                     _ = _staThread.Join(TimeSpan.FromSeconds(5));
                 }
             }
+
             throw;
         }
     }
@@ -237,34 +261,18 @@ internal sealed class PresentationBatch : IPresentationBatch
             try { dynApp.Visible = msoTrue; } catch { /* best effort */ }
             tempApp.DisplayAlerts = PowerPoint.PpAlertLevel.ppAlertsNone;
 
-            try
+            CapturePowerPointProcessIdentity(tempApp);
+            if (AfterProcessIdentityCapturedHook is { } afterProcessIdentityCaptured)
             {
-                const int maxRetries = 3;
-                const int retryDelayMs = 500;
-                for (int attempt = 1; attempt <= maxRetries; attempt++)
+                if (_powerPointProcessIdentity is not { } identity)
                 {
-                    int hwnd = tempApp.HWND;
-                    if (hwnd != 0)
-                    {
-                        _ = GetWindowThreadProcessId(new IntPtr(hwnd), out uint processId);
-                        if (processId != 0)
-                        {
-                            _powerPointProcessId = (int)processId;
-                            using var process = System.Diagnostics.Process.GetProcessById(_powerPointProcessId.Value);
-                            _powerPointProcessIdentity = new PowerPointProcessIdentity(
-                                process.Id,
-                                process.StartTime.ToUniversalTime().ToFileTimeUtc());
-                            PresentationSessionRegistry.TrackPowerPointProcess(_powerPointProcessIdentity.Value);
-                            break;
-                        }
-                    }
-                    if (attempt < maxRetries) Thread.Sleep(retryDelayMs);
+                    throw new InvalidOperationException(
+                        "The PowerPoint process identity was not available for the startup test hook.");
                 }
+
+                afterProcessIdentityCaptured(identity, _shutdownCts.Token);
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to capture PowerPoint process ID. Force-kill will not be available.");
-            }
+            _shutdownCts.Token.ThrowIfCancellationRequested();
 
             string fullPath = Path.GetFullPath(_presentationPath);
             PowerPoint.Presentation presentation = OpenOrCreatePresentationCom(tempApp, fullPath, _createNewFile);
@@ -310,6 +318,42 @@ internal sealed class PresentationBatch : IPresentationBatch
             _app = null;
             try { OleMessageFilter.Revoke(); }
             catch (Exception ex) { _logger.LogWarning(ex, "OleMessageFilter.Revoke() failed during STA cleanup"); }
+        }
+    }
+
+    private void CapturePowerPointProcessIdentity(PowerPoint.Application app)
+    {
+        try
+        {
+            const int maxRetries = 3;
+            const int retryDelayMs = 500;
+            for (int attempt = 1; attempt <= maxRetries; attempt++)
+            {
+                int hwnd = app.HWND;
+                if (hwnd != 0)
+                {
+                    _ = GetWindowThreadProcessId(new IntPtr(hwnd), out uint processId);
+                    if (processId != 0)
+                    {
+                        _powerPointProcessId = (int)processId;
+                        using var process = System.Diagnostics.Process.GetProcessById(_powerPointProcessId.Value);
+                        _powerPointProcessIdentity = new PowerPointProcessIdentity(
+                            process.Id,
+                            process.StartTime.ToUniversalTime().ToFileTimeUtc());
+                        PresentationSessionRegistry.TrackPowerPointProcess(_powerPointProcessIdentity.Value);
+                        return;
+                    }
+                }
+
+                if (attempt < maxRetries)
+                {
+                    Thread.Sleep(retryDelayMs);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to capture PowerPoint process ID. Force-kill will not be available.");
         }
     }
 
@@ -643,13 +687,13 @@ internal sealed class PresentationBatch : IPresentationBatch
         _workSignal.Dispose();
     }
 
-    private static void TryKillProcess(PowerPointProcessIdentity identity)
+    private static bool TryKillProcess(PowerPointProcessIdentity identity)
     {
         try
         {
             if (!OwnedProcessGuard.TryOpenMatchingProcess(identity, out var process))
             {
-                return;
+                return false;
             }
 
             using (process)
@@ -657,12 +701,31 @@ internal sealed class PresentationBatch : IPresentationBatch
                 if (process != null)
                 {
                     process.Kill();
-                    process.WaitForExit(5000);
+                    if (!process.WaitForExit(5000))
+                    {
+                        return false;
+                    }
                 }
             }
 
             PresentationSessionRegistry.UntrackPowerPointProcess(identity);
+            return true;
         }
-        catch (Exception) { /* best effort */ }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static void FinalizeFailedStartupOwnedProcess(PowerPointProcessIdentity identity)
+    {
+        if (OwnedProcessGuard.IsAlive(identity) && !TryKillProcess(identity)
+            && !OwnedProcessGuard.TryConfirmExited(identity))
+        {
+            throw new InvalidOperationException(
+                $"PowerPoint process {identity.ProcessId} remained live or inaccessible after startup cleanup.");
+        }
+
+        PresentationSessionRegistry.UntrackPowerPointProcess(identity);
     }
 }

--- a/tests/PowerPointMcp.ComInterop.Tests/PresentationBatchStartupTests.cs
+++ b/tests/PowerPointMcp.ComInterop.Tests/PresentationBatchStartupTests.cs
@@ -1,0 +1,55 @@
+using Sbroenne.PowerPointMcp.ComInterop.Session;
+
+namespace Sbroenne.PowerPointMcp.ComInterop.Tests;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "PresentationBatch")]
+public sealed class PresentationBatchStartupTests
+{
+    [Fact]
+    public void CreateNew_StartupTimeoutAfterApplicationCreation_DoesNotLeavePowerPointRunning()
+    {
+        PowerPointProcessIdentity? createdIdentity = null;
+        string path = Path.Combine(Path.GetTempPath(), $"pptmcp-startup-{Guid.NewGuid():N}.pptx");
+
+        PresentationBatch.AfterProcessIdentityCapturedHook = (identity, cancellationToken) =>
+        {
+            createdIdentity = identity;
+            cancellationToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(30));
+        };
+
+        bool processWasAliveAfterFailure = false;
+        try
+        {
+            _ = Assert.Throws<TimeoutException>(() =>
+                PresentationSession.CreateNew(path, operationTimeout: TimeSpan.FromSeconds(2)));
+
+            Assert.NotNull(createdIdentity);
+            processWasAliveAfterFailure = OwnedProcessGuard.IsAlive(createdIdentity.Value);
+        }
+        finally
+        {
+            PresentationBatch.AfterProcessIdentityCapturedHook = null;
+
+            if (createdIdentity is { } identity
+                && OwnedProcessGuard.TryOpenMatchingProcess(identity, out var process))
+            {
+                using (process)
+                {
+                    if (process is not null)
+                    {
+                        process.Kill();
+                        process.WaitForExit(5000);
+                    }
+                }
+            }
+
+            try { if (File.Exists(path)) File.Delete(path); }
+            catch (IOException) { }
+        }
+
+        Assert.False(
+            processWasAliveAfterFailure,
+            "A PowerPoint process created during failed startup remained alive after the constructor returned.");
+    }
+}

--- a/tests/PowerPointMcp.Core.Tests/PowerPointMcp.Core.Tests.csproj
+++ b/tests/PowerPointMcp.Core.Tests/PowerPointMcp.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <!-- Test-only relaxations: xUnit convention is underscored, descriptive method names
          (e.g. Create_SavesRealPptxFile_ThatPowerPointCanReopen), and test methods don't
          need XML doc comments. -->


### PR DESCRIPTION
## Summary

Fixes two test and lifecycle gaps found while verifying #31:

- Mark the Core integration test project explicitly as a test project so `dotnet test tests\PowerPointMcp.Core.Tests` executes tests under .NET 10 instead of silently skipping them.
- Ensure a timed-out PowerPoint startup aborts before opening a presentation and tears down the exact owned PowerPoint process using its PID and creation time.
- Add a real-COM regression test that blocks startup until cancellation and verifies the constructor leaves no PowerPoint process running.

Closes #71
Closes #72

## Changes

- Capture and retain the PowerPoint process identity before the remaining startup work.
- Check startup cancellation before creating or opening the presentation.
- Confirm failed-startup process termination before removing its identity from the registry.
- Add a patch changeset for the user-visible cleanup fix.

## Testing

- Full pre-commit gate passed.
- Solution Release build: 0 warnings, 0 errors.
- Chart real-COM tests: 22 passed.
- ComInterop tests: 3 passed.
- MCP Server tests: 41 passed.
- Release metadata and Agent Skills packaging tests: 65 passed.

## Changelog

- [x] I added a changeset (`npx changeset` from the repo root) describing this change for end users.
- [ ] This PR doesn't need a changelog entry.