### PR TITLE
feat(master): read theme color palettes for selected masters

### DIFF
--- a/.changeset/theme-color-palettes.md
+++ b/.changeset/theme-color-palettes.md
@@ -1,0 +1,5 @@
+---
+"powerpointmcp": minor
+---
+
+Read the twelve named theme colors for any slide master with `master get-theme-colors` in the CLI or the matching MCP action. Palette colors are returned as RGB hex strings so new shapes and charts can match the selected template without guessing its accent colors.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ Unified Service Architecture.
 5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 16 tools
    total: one hand-written `presentation` action-dispatch tool plus 15 generated action-dispatch
    tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-   `image`, `media`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 186 operations
+  `image`, `media`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 187 operations
    across 16 domains. See
    `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
    the ground-truth tool list.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ layout regressions that text-only automation simply cannot detect.
 
 ## 🎯 What You Can Do
 
-**16 MCP tools with 186 operations across 16 domains:**
+**16 MCP tools with 187 operations across 16 domains:**
 
 - 🗂️ **Presentation** (20 ops) — create, open, Save As, Save Copy As, close, list sessions, apply a
   `.potx`/`.pptx` template's masters/theme/layouts, read the current theme name, set/read
@@ -59,7 +59,7 @@ layout regressions that text-only automation simply cannot detect.
 - 🖼️ **Layout** (4 ops) — set/get slide layout
 - 📐 **Page Setup** (5 ops) — slide size, first slide number, footer, date/time, slide numbers
 - ♿ **Accessibility** (3 ops) — deterministic audit and reading-order management
-- 🎭 **Master** (10 ops) — slide master title/body placeholder fonts, background color
+- 🎭 **Master** (11 ops) — theme color palettes, slide master title/body placeholder fonts, background color
 - 🎬 **Animation** (5 ops) — shape entrance/emphasis/exit effects, slide transitions
 - 🖼️ **Image** (7 ops) — insert embedded or linked pictures and adjust brightness, contrast,
   recolor, and crop

--- a/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
+++ b/docs/POWERPOINT-NATIVE-FEATURE-AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This audit compares the current 16 tools and 186 operations with the restored
+This audit compares the current 16 tools and 187 operations with the restored
 `Microsoft.Office.Interop.PowerPoint` 15.0.4420.1018 assembly. It looks for useful PowerPoint
 features that fit the existing live-session model. It does not copy Excel-only worksheet, Power
 Query, Data Model, PivotTable, or calculation APIs.

--- a/gh-pages/docs/features.md
+++ b/gh-pages/docs/features.md
@@ -1,12 +1,12 @@
 ---
 title: Complete Feature Reference
-description: 16 MCP tools with 186 operations across 16 domains for live PowerPoint automation through single action-dispatch tools.
+description: 16 MCP tools with 187 operations across 16 domains for live PowerPoint automation through single action-dispatch tools.
 keywords: "PowerPoint MCP features, PowerPoint automation, presentation tool, slide tool, shape tool, media tool, chart tool, SmartArt tool, export-to-verify"
 ---
 
 # Complete Feature Reference
 
-PowerPoint MCP Server exposes **16 MCP tools with 186 operations across 16 domains**.
+PowerPoint MCP Server exposes **16 MCP tools with 187 operations across 16 domains**.
 Every domain is a **single action-dispatch tool** that takes an `action` parameter — for example
 `presentation(action="open", filePath="C:\\Decks\\q4.pptx")` or
 `chart(action="add-chart", session_id="...", slide_index=2, ...)`.
@@ -29,7 +29,7 @@ The CLI mirrors the same domain model:
 | `layout` | 4 | Slide layouts | `layout(action="...", session_id=..., ...)` | `pptcli layout <action> -s <SESSION_ID> ...` |
 | `pagesetup` | 5 | Slide size, numbering, footer, date/time | `pagesetup(action="...", session_id=..., ...)` | `pptcli pagesetup <action> -s <SESSION_ID> ...` |
 | `accessibility` | 3 | Deterministic audit and reading order | `accessibility(action="...", session_id=..., ...)` | `pptcli accessibility <action> -s <SESSION_ID> ...` |
-| `master` | 10 | Slide master fonts and backgrounds | `master(action="...", session_id=..., ...)` | `pptcli master <action> -s <SESSION_ID> ...` |
+| `master` | 11 | Theme color palettes, slide master fonts and backgrounds | `master(action="...", session_id=..., ...)` | `pptcli master <action> -s <SESSION_ID> ...` |
 | `animation` | 5 | Shape effects and slide transitions | `animation(action="...", session_id=..., ...)` | `pptcli animation <action> -s <SESSION_ID> ...` |
 | `image` | 7 | Picture insertion and picture adjustments (brightness/contrast, recolor, crop) | `image(action="...", session_id=..., ...)` | `pptcli image <action> -s <SESSION_ID> ...` |
 | `media` | 2 | Embedded or linked audio/video insertion and native media metadata | `media(action="...", session_id=..., ...)` | `pptcli media <action> -s <SESSION_ID> ...` |
@@ -156,13 +156,13 @@ alternative text on visual content and empty title placeholders; it is not an AI
 
 **Exact action order:** `audit`, `get-reading-order`, `set-reading-order`
 
-### `master` tool (10 operations)
+### `master` tool (11 operations)
 
-Use `master` for deck-wide master placeholder fonts and master backgrounds.
+Use `master` for theme color palettes, deck-wide master placeholder fonts, and master backgrounds.
 
 **Exact action order:** `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`,
 `get-background-color`, `set-background-color`, `set-gradient-background`,
-`get-gradient-background`, `list-masters`, `delete-master`
+`get-gradient-background`, `list-masters`, `get-theme-colors`, `delete-master`
 
 ### `animation` tool (5 operations)
 

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -146,7 +146,7 @@ powerpointmcpserver.dev.
 
 </div>
 
-[See all 16 tools (186 operations) across 16 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
+[See all 16 tools (187 operations) across 16 domains :material-arrow-right:](features.md){ .md-button .md-button--primary }
 
 ## See it in action
 

--- a/gh-pages/docs/installation.md
+++ b/gh-pages/docs/installation.md
@@ -124,7 +124,7 @@ you get back a rendered PNG of a real PowerPoint slide, you're set up correctly.
 
 ## More information
 
-- [Complete Feature Reference](features.md) — all 16 tools (186 operations) across 16 domains
+- [Complete Feature Reference](features.md) — all 16 tools (187 operations) across 16 domains
 - [MCP Server Documentation](mcp-server.md) — MCP tool reference
 - [CLI Documentation](cli.md) — CLI command reference
 - [Agent Skills](skills.md) — AI guidance for Claude Code, Cursor, Windsurf and more

--- a/gh-pages/docs/mcp-server.md
+++ b/gh-pages/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Complete MCP tool reference for PowerPoint MCP Server — 16 tools with 186 operations across 16 domains, session model, and configuration examples.
+description: Complete MCP tool reference for PowerPoint MCP Server — 16 tools with 187 operations across 16 domains, session model, and configuration examples.
 ---
 
 # MCP Server

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -18,7 +18,7 @@ Claude can now create and edit PowerPoint decks directly.
 
 A self-contained Windows x64 build of the MCP server (no .NET runtime install
 required) plus the manifest, license, and changelog. The server exposes 16
-tools (186 operations across 16 domains) — see the
+tools (187 operations across 16 domains) — see the
 [documentation](https://powerpointmcpserver.dev) for the full list.
 Linked pictures are managed through the generated `shape` actions `get-link-info`, `update-link`,
 `break-link`, and `set-link-auto-update`.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "PowerPoint (Windows)",
   "version": "0.1.5",
   "description": "Automate Microsoft PowerPoint - slides, shapes, text, tables, charts, accessibility, PDF export, and more - requires PowerPoint to be installed",
-  "long_description": "MCP server for Microsoft PowerPoint automation. 16 tools (186 operations across 16 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Media, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including string tags, chart quick formatting, linked-picture get-link-info, update-link, break-link, and set-link-auto-update actions, PDF delivery, and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
+  "long_description": "MCP server for Microsoft PowerPoint automation. 16 tools (187 operations across 16 domains: Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, PageSetup, Accessibility, Master, Animation, Image, Media, Chart, SmartArt, Export) that drive a live PowerPoint desktop instance via COM, including string tags, chart quick formatting, linked-picture get-link-info, update-link, break-link, and set-link-auto-update actions, PDF delivery, and slide-to-image export for visual verification. Windows-only, requires Microsoft PowerPoint desktop application.",
   "author": {
     "name": "Stefan Broenner",
     "url": "https://github.com/sbroenne"

--- a/skills/powerpoint-cli/SKILL.md
+++ b/skills/powerpoint-cli/SKILL.md
@@ -246,9 +246,9 @@ Actions: `set-layout`, `get-layout`, `list-layouts`, `delete-layout`
 | `--layout-index` | (required for: delete-layout) |
 
 
-### `master` — Slide master commands: read/edit the title and body placeholder fonts on the presentation's slide master, and read/edit the slide master's background fill color. Operates within an already-open . Changes here apply to every slide that inherits from the master (i.e. any slide that does not itself override the property), which is the practical "edit the master, not each slide" workflow PowerPoint's COM object model supports safely.
+### `master` — Slide master commands: read theme color palettes or read/edit the title and body placeholder fonts on the presentation's slide master, and read/edit the slide master's background fill color. Operates within an already-open . Changes here apply to every slide that inherits from the master (i.e. any slide that does not itself override the property), which is the practical "edit the master, not each slide" workflow PowerPoint's COM object model supports safely.
 
-Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `get-background-color`, `set-background-color`, `set-gradient-background`, `get-gradient-background`, `list-masters`, `delete-master`
+Actions: `get-title-font`, `set-title-font`, `get-body-font`, `set-body-font`, `get-background-color`, `set-background-color`, `set-gradient-background`, `get-gradient-background`, `list-masters`, `get-theme-colors`, `delete-master`
 
 | Flag | Description |
 |------|-------------|

--- a/skills/powerpoint-cli/references/cli-commands.md
+++ b/skills/powerpoint-cli/references/cli-commands.md
@@ -394,7 +394,8 @@ OPTIONS:
         --gradient-variant <GRADIENTVARIANT>    (valid for:
                                                 set-gradient-background)
         --master-index <MASTERINDEX>            (required for: delete-master)
-                                                (valid for: delete-master)
+                                                (valid for: get-theme-colors,
+                                                delete-master)
     -o, --output <PATH>                         Write output to file instead of
                                                 stdout. For image results,
                                                 decodes and saves as binary file

--- a/skills/powerpoint-cli/references/master.md
+++ b/skills/powerpoint-cli/references/master.md
@@ -12,6 +12,8 @@ formatting via `textframe`/`layout`.
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
+| `master` | `list-masters` | `session_id` | Lists masters and layouts; use its 1-based master index to select a palette. |
+| `master` | `get-theme-colors` | `session_id`, `master_index?` | Reads all twelve theme color roles as `#RRGGBB`; defaults to master 1. Does not modify the presentation. |
 | `master` | `get-title-font` | `session_id` | Returns `font_name`, `font_size`, `bold`, `color_rgb` for the master's title placeholder. |
 | `master` | `set-title-font` | `session_id`, `font_name?`, `font_size?`, `bold?`, `red?`, `green?`, `blue?` | Every field is optional — omit any you do not want to change. Pass `red`/`green`/`blue` together to set color. |
 | `master` | `get-body-font` | `session_id` | Same shape as `get-title-font`, for the body placeholder. |
@@ -41,6 +43,34 @@ It does **not** cover:
   "Title and Content") or adding additional slide masters — not exposed by this tool surface.
 
 ## Typical Use
+
+### Match the Template Palette
+
+Read the palette before choosing colors for new shapes and charts:
+
+```text
+master(action: "list-masters", session_id: sessionId)
+master(action: "get-theme-colors", session_id: sessionId, master_index: 1)
+```
+
+CLI equivalent:
+
+```powershell
+pptcli master get-theme-colors --session $sessionId --master-index 1
+```
+
+The result includes `masterIndex`, `masterName`, and `themeColors`: `Dark1`,
+`Light1`, `Dark2`, `Light2`, `Accent1` through `Accent6`, `Hyperlink`, and
+`FollowedHyperlink`. Each value is a normal RGB hex string such as `#0B3D91`,
+not the native `0xBBGGRR` integer returned by existing font/background queries.
+For this example, pass `red=11`, `green=61`, `blue=145` to RGB styling actions.
+
+In multi-design decks, query the master used by the slide you are authoring;
+do not assume master 1 supplies every slide's colors. These are base theme roles,
+not effective colors after slide background mappings, tint/shade, or local overrides.
+An out-of-range index returns a validation failure rather than a partial palette.
+
+### Set Master Styling
 
 Set the deck-wide look once, early, before building individual slides:
 

--- a/skills/powerpoint-cli/references/workflows.md
+++ b/skills/powerpoint-cli/references/workflows.md
@@ -2,7 +2,7 @@
 
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 186 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 187 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/powerpoint-mcp/references/master.md
+++ b/skills/powerpoint-mcp/references/master.md
@@ -10,6 +10,8 @@ formatting via `textframe`/`layout`.
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
+| `master` | `list-masters` | `session_id` | Lists masters and layouts; use its 1-based master index to select a palette. |
+| `master` | `get-theme-colors` | `session_id`, `master_index?` | Reads all twelve theme color roles as `#RRGGBB`; defaults to master 1. Does not modify the presentation. |
 | `master` | `get-title-font` | `session_id` | Returns `font_name`, `font_size`, `bold`, `color_rgb` for the master's title placeholder. |
 | `master` | `set-title-font` | `session_id`, `font_name?`, `font_size?`, `bold?`, `red?`, `green?`, `blue?` | Every field is optional — omit any you do not want to change. Pass `red`/`green`/`blue` together to set color. |
 | `master` | `get-body-font` | `session_id` | Same shape as `get-title-font`, for the body placeholder. |
@@ -39,6 +41,34 @@ It does **not** cover:
   "Title and Content") or adding additional slide masters — not exposed by this tool surface.
 
 ## Typical Use
+
+### Match the Template Palette
+
+Read the palette before choosing colors for new shapes and charts:
+
+```text
+master(action: "list-masters", session_id: sessionId)
+master(action: "get-theme-colors", session_id: sessionId, master_index: 1)
+```
+
+CLI equivalent:
+
+```powershell
+pptcli master get-theme-colors --session $sessionId --master-index 1
+```
+
+The result includes `masterIndex`, `masterName`, and `themeColors`: `Dark1`,
+`Light1`, `Dark2`, `Light2`, `Accent1` through `Accent6`, `Hyperlink`, and
+`FollowedHyperlink`. Each value is a normal RGB hex string such as `#0B3D91`,
+not the native `0xBBGGRR` integer returned by existing font/background queries.
+For this example, pass `red=11`, `green=61`, `blue=145` to RGB styling actions.
+
+In multi-design decks, query the master used by the slide you are authoring;
+do not assume master 1 supplies every slide's colors. These are base theme roles,
+not effective colors after slide background mappings, tint/shade, or local overrides.
+An out-of-range index returns a validation failure rather than a partial palette.
+
+### Set Master Styling
 
 Set the deck-wide look once, early, before building individual slides:
 

--- a/skills/powerpoint-mcp/references/workflows.md
+++ b/skills/powerpoint-mcp/references/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 186 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 187 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/skills/shared/master.md
+++ b/skills/shared/master.md
@@ -10,6 +10,8 @@ formatting via `textframe`/`layout`.
 
 | Tool | Action | Parameters | Notes |
 |------|--------|------------|-------|
+| `master` | `list-masters` | `session_id` | Lists masters and layouts; use its 1-based master index to select a palette. |
+| `master` | `get-theme-colors` | `session_id`, `master_index?` | Reads all twelve theme color roles as `#RRGGBB`; defaults to master 1. Does not modify the presentation. |
 | `master` | `get-title-font` | `session_id` | Returns `font_name`, `font_size`, `bold`, `color_rgb` for the master's title placeholder. |
 | `master` | `set-title-font` | `session_id`, `font_name?`, `font_size?`, `bold?`, `red?`, `green?`, `blue?` | Every field is optional — omit any you do not want to change. Pass `red`/`green`/`blue` together to set color. |
 | `master` | `get-body-font` | `session_id` | Same shape as `get-title-font`, for the body placeholder. |
@@ -39,6 +41,34 @@ It does **not** cover:
   "Title and Content") or adding additional slide masters — not exposed by this tool surface.
 
 ## Typical Use
+
+### Match the Template Palette
+
+Read the palette before choosing colors for new shapes and charts:
+
+```text
+master(action: "list-masters", session_id: sessionId)
+master(action: "get-theme-colors", session_id: sessionId, master_index: 1)
+```
+
+CLI equivalent:
+
+```powershell
+pptcli master get-theme-colors --session $sessionId --master-index 1
+```
+
+The result includes `masterIndex`, `masterName`, and `themeColors`: `Dark1`,
+`Light1`, `Dark2`, `Light2`, `Accent1` through `Accent6`, `Hyperlink`, and
+`FollowedHyperlink`. Each value is a normal RGB hex string such as `#0B3D91`,
+not the native `0xBBGGRR` integer returned by existing font/background queries.
+For this example, pass `red=11`, `green=61`, `blue=145` to RGB styling actions.
+
+In multi-design decks, query the master used by the slide you are authoring;
+do not assume master 1 supplies every slide's colors. These are base theme roles,
+not effective colors after slide background mappings, tint/shade, or local overrides.
+An out-of-range index returns a validation failure rather than a partial palette.
+
+### Set Master Styling
 
 Set the deck-wide look once, early, before building individual slides:
 

--- a/skills/shared/workflows.md
+++ b/skills/shared/workflows.md
@@ -1,6 +1,6 @@
 # Canonical Workflow: Start Session → Build → Verify → Save and Close
 
-The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 186 operations exist
+The standard end-to-end loop for every PowerPoint MCP task. All 16 tools and 187 operations exist
 to support this loop for one of two starting points: a brand-new deck or an existing file.
 
 ## Starting Point A — New Presentation

--- a/src/PowerPointMcp.Core/Master/IMasterCommands.cs
+++ b/src/PowerPointMcp.Core/Master/IMasterCommands.cs
@@ -4,7 +4,7 @@ using Sbroenne.PowerPointMcp.Core.Attributes;
 namespace Sbroenne.PowerPointMcp.Core.Master;
 
 /// <summary>
-/// Slide master commands: read/edit the title and body placeholder fonts on the presentation's
+/// Slide master commands: read theme color palettes or read/edit the title and body placeholder fonts on the presentation's
 /// slide master, and read/edit the slide master's background fill color. Operates within an
 /// already-open <see cref="IPresentationBatch"/>. Changes here apply to every slide that
 /// inherits from the master (i.e. any slide that does not itself override the property), which
@@ -19,7 +19,7 @@ namespace Sbroenne.PowerPointMcp.Core.Master;
 /// </remarks>
 [ServiceCategory("master", "Master")]
 [McpTool("master", Title = "Slide Master Operations", Destructive = true, Category = "content",
-    Description = "Read or edit the slide master's title/body placeholder fonts and background color in an open presentation session. Changes apply to every slide inheriting from the master.")]
+    Description = "Read theme color palettes or read/edit the slide master's title/body placeholder fonts and background color. Use list-masters to select a master for get-theme-colors. Edits apply to every slide inheriting from the master.")]
 public interface IMasterCommands
 {
     /// <summary>Gets the font name, size, bold, and color of the master's title placeholder.</summary>
@@ -84,6 +84,13 @@ public interface IMasterCommands
 
     /// <summary>Lists every slide master in the presentation, along with the layouts attached to it.</summary>
     MasterOperationResult ListMasters(IPresentationBatch batch);
+
+    /// <summary>
+    /// Reads the twelve theme color roles as #RRGGBB strings for the selected master.
+    /// Uses the 1-based masterIndex returned by ListMasters (default: first master).
+    /// Returns theme colors, not slide background-style mappings or tinted shape colors.
+    /// </summary>
+    MasterOperationResult GetThemeColors(IPresentationBatch batch, int masterIndex = 1);
 
     /// <summary>Deletes an unused slide master. Fails if any slide still references it.</summary>
     MasterOperationResult DeleteMaster(IPresentationBatch batch, int masterIndex);

--- a/src/PowerPointMcp.Core/Master/MasterCommands.cs
+++ b/src/PowerPointMcp.Core/Master/MasterCommands.cs
@@ -1,6 +1,9 @@
+extern alias OfficeInterop;
+
 using System.Runtime.InteropServices;
 using Sbroenne.PowerPointMcp.ComInterop;
 using Sbroenne.PowerPointMcp.ComInterop.Session;
+using Office = OfficeInterop::Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Master;
@@ -284,6 +287,73 @@ public sealed class MasterCommands : IMasterCommands
             }
 
             return new MasterOperationResult { Success = true, Masters = masters };
+        });
+    }
+
+    /// <inheritdoc/>
+    public MasterOperationResult GetThemeColors(IPresentationBatch batch, int masterIndex = 1)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        if (masterIndex < 1)
+        {
+            return new MasterOperationResult { ErrorMessage = "Master index must be 1 or greater." };
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Designs? designs = null;
+            PowerPoint.Design? design = null;
+            PowerPoint.Master? master = null;
+            Office.OfficeTheme? theme = null;
+            Office.ThemeColorScheme? scheme = null;
+            try
+            {
+                designs = ctx.Presentation.Designs;
+                if (masterIndex > designs.Count)
+                {
+                    return new MasterOperationResult
+                    {
+                        ErrorMessage = $"Master index {masterIndex} is out of range. The presentation has {designs.Count} master(s) (valid range: 1-{designs.Count})."
+                    };
+                }
+
+                design = designs[masterIndex];
+                master = design.SlideMaster;
+                theme = master.Theme;
+                scheme = theme.ThemeColorScheme;
+                var colors = new Dictionary<string, string>(StringComparer.Ordinal);
+                foreach (var role in Enum.GetValues<Office.MsoThemeColorSchemeIndex>())
+                {
+                    Office.ThemeColor? color = null;
+                    try
+                    {
+                        color = scheme.Colors(role);
+                        int oleRgb = color.RGB;
+                        colors.Add(role.ToString()["msoTheme".Length..],
+                            $"#{oleRgb & 0xff:X2}{(oleRgb >> 8) & 0xff:X2}{(oleRgb >> 16) & 0xff:X2}");
+                    }
+                    finally
+                    {
+                        ComUtilities.Release(ref color);
+                    }
+                }
+
+                return new MasterOperationResult
+                {
+                    Success = true,
+                    MasterIndex = masterIndex,
+                    MasterName = GetMasterName(design, master),
+                    ThemeColors = colors
+                };
+            }
+            finally
+            {
+                ComUtilities.Release(ref scheme);
+                ComUtilities.Release(ref theme);
+                ComUtilities.Release(ref master);
+                ComUtilities.Release(ref design);
+                ComUtilities.Release(ref designs);
+            }
         });
     }
 

--- a/src/PowerPointMcp.Core/Master/MasterOperationResult.cs
+++ b/src/PowerPointMcp.Core/Master/MasterOperationResult.cs
@@ -38,6 +38,15 @@ public sealed class MasterOperationResult
     /// <summary>Inventory of the slide masters in the presentation, for ListMasters.</summary>
     public IReadOnlyList<MasterInventoryEntry>? Masters { get; init; }
 
+    /// <summary>Selected 1-based master index, for GetThemeColors; matches ListMasters.</summary>
+    public int? MasterIndex { get; init; }
+
+    /// <summary>Selected master name, for GetThemeColors.</summary>
+    public string? MasterName { get; init; }
+
+    /// <summary>Twelve named theme roles mapped to #RRGGBB strings, for GetThemeColors.</summary>
+    public IReadOnlyDictionary<string, string>? ThemeColors { get; init; }
+
     /// <summary>Represents one slide master and the layouts attached to it.</summary>
     public sealed class MasterInventoryEntry
     {

--- a/src/PowerPointMcp.McpServer/README.md
+++ b/src/PowerPointMcp.McpServer/README.md
@@ -32,7 +32,7 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 
 ## Capabilities
 
-**16 tools with 186 operations across 16 domains:**
+**16 tools with 187 operations across 16 domains:**
 
 | Tool | Ops | Coverage |
 | --- | --- | --- |
@@ -45,7 +45,7 @@ Desktop, VS Code, GitHub Copilot, etc.) at it over stdio:
 | `layout` | 4 | set/get slide layout |
 | `pagesetup` | 5 | slide size, numbering, footer, date/time |
 | `accessibility` | 3 | deterministic audit and reading order |
-| `master` | 10 | title/body placeholder fonts, solid + gradient master backgrounds |
+| `master` | 11 | theme color palettes, title/body placeholder fonts, solid + gradient master backgrounds |
 | `animation` | 5 | shape effects, transition read/write |
 | `image` | 7 | add picture, brightness/contrast, recolor, crop |
 | `media` | 2 | add embedded/linked audio or video, get native media info |

--- a/tests/PowerPointMcp.Core.Tests/MasterCommandsTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/MasterCommandsTests.cs
@@ -1,4 +1,6 @@
+using Sbroenne.PowerPointMcp.ComInterop;
 using Sbroenne.PowerPointMcp.Core.Master;
+using Office = Microsoft.Office.Core;
 using PowerPoint = Microsoft.Office.Interop.PowerPoint;
 
 namespace Sbroenne.PowerPointMcp.Core.Tests;
@@ -19,6 +21,108 @@ public class MasterCommandsTests : IClassFixture<SharedPresentationFixture>
     public MasterCommandsTests(SharedPresentationFixture fixture)
     {
         _fixture = fixture;
+    }
+
+    [Fact]
+    public void GetThemeColors_ReturnsTwelveNamedRgbColorsForSelectedMaster()
+    {
+        _fixture.CreateFreshPresentation();
+
+        var result = _commands.GetThemeColors(_fixture.Batch, masterIndex: 1);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Null(result.ErrorMessage);
+        Assert.Equal(1, result.MasterIndex);
+        Assert.False(string.IsNullOrWhiteSpace(result.MasterName));
+        Assert.NotNull(result.ThemeColors);
+        string[] roles = ["Dark1", "Light1", "Dark2", "Light2", "Accent1", "Accent2",
+            "Accent3", "Accent4", "Accent5", "Accent6", "Hyperlink", "FollowedHyperlink"];
+        Assert.Equal(roles.Order(), result.ThemeColors.Keys.Order());
+        Assert.All(result.ThemeColors.Values, color => Assert.Matches("^#[0-9A-F]{6}$", color));
+    }
+
+    [Fact]
+    public void GetThemeColors_ReadsDistinctDesignPalettesAndPreservesThemAfterReopen()
+    {
+        _fixture.CreateFreshPresentation();
+        _fixture.Batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Designs? designs = null;
+            PowerPoint.Design? first = null;
+            PowerPoint.Design? second = null;
+            try
+            {
+                designs = ctx.Presentation.Designs;
+                first = designs[1];
+                second = designs.Add("DistinctPalette");
+                SetAccentForPaletteTest(first, 0x913D0B);
+                SetAccentForPaletteTest(second, 0x2367C1);
+            }
+            finally
+            {
+                ComUtilities.Release(ref second);
+                ComUtilities.Release(ref first);
+                ComUtilities.Release(ref designs);
+            }
+        });
+
+        var inventory = _commands.ListMasters(_fixture.Batch);
+        Assert.True(inventory.Success, inventory.ErrorMessage);
+        Assert.Equal(2, inventory.Masters!.Count);
+        var firstPalette = _commands.GetThemeColors(_fixture.Batch);
+        var secondPalette = _commands.GetThemeColors(_fixture.Batch, 2);
+        Assert.True(firstPalette.Success, firstPalette.ErrorMessage);
+        Assert.True(secondPalette.Success, secondPalette.ErrorMessage);
+        Assert.Equal("#0B3D91", firstPalette.ThemeColors!["Accent1"]);
+        Assert.Equal("#C16723", secondPalette.ThemeColors!["Accent1"]);
+        Assert.Equal(inventory.Masters[1].MasterName, secondPalette.MasterName);
+        Assert.Equal(2, secondPalette.MasterIndex);
+
+        _fixture.Batch.Save();
+        _fixture.ReopenCurrentPresentation();
+        var reopened = _commands.GetThemeColors(_fixture.Batch, 1);
+        Assert.True(reopened.Success, reopened.ErrorMessage);
+        Assert.Equal(firstPalette.ThemeColors.OrderBy(entry => entry.Key),
+            reopened.ThemeColors!.OrderBy(entry => entry.Key));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void GetThemeColors_InvalidMaster_ReturnsValidationFailure(int masterIndex)
+    {
+        _fixture.CreateFreshPresentation();
+
+        var result = _commands.GetThemeColors(_fixture.Batch, masterIndex);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
+        Assert.Null(result.ThemeColors);
+        Assert.Single(_commands.ListMasters(_fixture.Batch).Masters!);
+    }
+
+    private static void SetAccentForPaletteTest(PowerPoint.Design design, int oleColor)
+    {
+        PowerPoint.Master? master = null;
+        Office.OfficeTheme? theme = null;
+        Office.ThemeColorScheme? scheme = null;
+        Office.ThemeColor? accent = null;
+        try
+        {
+            master = design.SlideMaster;
+            theme = master.Theme;
+            scheme = theme.ThemeColorScheme;
+            accent = scheme.Colors(Office.MsoThemeColorSchemeIndex.msoThemeAccent1);
+            accent.RGB = oleColor;
+        }
+        finally
+        {
+            ComUtilities.Release(ref accent);
+            ComUtilities.Release(ref scheme);
+            ComUtilities.Release(ref theme);
+            ComUtilities.Release(ref master);
+        }
     }
 
     [Fact]

--- a/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
+++ b/tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs
@@ -104,6 +104,17 @@ public sealed class McpProtocolTests : IAsyncLifetime, IAsyncDisposable
         _cts.Dispose();
     }
 
+    [Fact]
+    public async Task ListTools_MasterExposesThemePaletteActionAndSelector()
+    {
+        var tools = await _client!.ListToolsAsync(cancellationToken: _cts.Token);
+        var master = Assert.Single(tools, tool => tool.Name == "master");
+        var properties = master.JsonSchema.GetProperty("properties");
+        Assert.Contains(properties.GetProperty("action").GetProperty("enum").EnumerateArray(),
+            action => action.GetString() == "get-theme-colors");
+        Assert.True(properties.TryGetProperty("master_index", out _));
+    }
+
     /// <summary>
     /// THE core protocol proof: exactly the 16 expected tools (1 hand-written + 15 generated
     /// action-dispatch tools) are discoverable via <c>tools/list</c> — no more, no less.


### PR DESCRIPTION
## Summary
- Add `master(action: "get-theme-colors", master_index: 1)` and `pptcli master get-theme-colors --session <id> --master-index 1` through the shared Core interface.
- Return the selected master identity and twelve named theme roles as `#RRGGBB` strings. Select any design using the indices from `list-masters`.
- Include canonical agent guidance, generated references, public action counts, site tool inventory, and a minor changeset.

## Contract and Scope
This is read-only palette discovery. It returns base theme roles, not effective slide colors after background mapping, tint/shade, or local overrides. Existing font/background BGR integer results are unchanged. Invalid indices return validation failures. The implementation uses typed Office interop and releases acquired COM references in finally blocks.

Based directly on main after #75. No startup changes, test-discovery changes, or dependency on #73/#74 are included.

## Validation
Run locally on Windows with PowerPoint, against this isolated branch:
- Release solution build: 0 warnings, 0 errors.
- Master real-COM tests: 16/16, including five new cases for all roles, channel order, distinct design palettes, save/reopen persistence, and invalid indices.
- Full MCP suite: 42/42, including the new tool-schema test.
- Release/skill packaging: 65/65.
- Unchanged pre-commit gate passed; strict MkDocs build, 35-page site audit, and 22-source deploy coverage passed.
- Earlier live CLI create/query/close validation returned all twelve colors on an isolated daemon pipe.

Core discovery uses main's fix; no IsTestProject override. Test runners were bounded and no timeout kill was needed. CI does not exercise PowerPoint COM, so local integration evidence is recorded here.