### PR TITLE
feat(skills): add four verified editable slide recipes

### DIFF
--- a/.changeset/composition-recipes.md
+++ b/.changeset/composition-recipes.md
@@ -1,0 +1,6 @@
+---
+"powerpointmcp": minor
+---
+
+Add four editable slide composition recipes to the shared agent guidance, with
+content limits and reproducible PowerPoint-rendered examples in 16:9 and 4:3.

--- a/gh-pages/docs/reference/composition-recipes.md
+++ b/gh-pages/docs/reference/composition-recipes.md
@@ -1,0 +1,8 @@
+---
+title: Composition Recipes
+description: Four editable PowerPoint slide recipes with content limits and reproducible 16:9 and 4:3 examples.
+---
+
+# Composition Recipes
+
+--8<-- "_generated/skills-composition-recipes.md"

--- a/gh-pages/docs/reference/index.md
+++ b/gh-pages/docs/reference/index.md
@@ -14,6 +14,7 @@ Skills. The website and installed guidance therefore describe the same behavior.
 - [Behavioral Rules](behavioral-rules.md)
 - [Anti-Patterns](anti-patterns.md)
 - [Deck Builder](deck-builder.md)
+- [Composition Recipes](composition-recipes.md)
 - [Export and Verify](export-and-verify.md)
 
 ## Domain guidance

--- a/gh-pages/hooks.py
+++ b/gh-pages/hooks.py
@@ -49,6 +49,7 @@ SKILL_SOURCES = {
     "behavioral-rules.md": "Behavioral Rules",
     "anti-patterns.md": "Anti-Patterns",
     "deck-builder.md": "Deck Builder",
+    "composition-recipes.md": "Composition Recipes",
     "slides-and-shapes.md": "Slides and Shapes",
     "tags.md": "String Tags",
     "text-formatting.md": "Text Formatting",

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Behavioral rules: reference/behavioral-rules.md
       - Anti-patterns: reference/anti-patterns.md
       - Deck builder: reference/deck-builder.md
+      - Composition recipes: reference/composition-recipes.md
       - Slides and shapes: reference/slides-and-shapes.md
       - String tags: reference/tags.md
       - Text formatting: reference/text-formatting.md

--- a/skills/powerpoint-cli/references/composition-recipes.md
+++ b/skills/powerpoint-cli/references/composition-recipes.md
@@ -1,0 +1,125 @@
+> **CLI syntax:** Shared guides may use MCP calls as shorthand. Use `cli-commands.md` or live `--help` for exact commands and kebab-case options.
+
+# Composition Recipes
+
+Four editable slide patterns built with existing shape, textframe, chart, and notes
+commands. Choose a pattern for the content, then export and inspect the result.
+These are constrained examples, not automatic layout or overflow correction.
+
+## Shared Geometry
+
+Read `pagesetup(action: "get-settings", session_id: ...)` first. Let `W` and `H`
+be the slide dimensions in points. The examples use `H=540` and `W=960` (16:9)
+or `W=720` (4:3). Horizontal coordinates below are fractions of `W`; vertical
+coordinates and font sizes are points at `H=540`. For a different height, multiply
+vertical coordinates, heights, and font sizes by `H/540`, then verify the render.
+Only the two example sizes have been tested.
+
+- Start with `slide(action: "add-blank", ...)`. Use its returned slide index.
+- Content starts at `0.055W`; its width is `0.89W`.
+- Title box: left `0.055W`, top `40`, width `0.89W`, height `75`, 32pt bold.
+- Examples use Aptos, dark text `RGB(28,35,40)`, and teal rules `RGB(0,115,110)`
+  on white. For a branded deck, use its approved palette and verify
+  foreground/background contrast.
+- Add text with `shape(action: "add-text-box", ...)`, then use the returned
+  shape index for `textframe` font and color actions. Rules are rectangles with
+  a solid fill and no visible line. All elements remain editable.
+- Add speaker notes, export the slide to PNG, and inspect it at its intended size.
+  Check chart labels separately: text-box bounds do not validate chart internals.
+
+## Comparison
+
+Use for two alternatives evaluated on the same three criteria. Do not imply one
+option is preferred through unequal widths or inconsistent ordering.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Left/right heading | `0.055W` / `0.525W` | 150 | `0.42W` | 50 | 26pt bold |
+| Left/right rule | same | 211 | `0.42W` | 4 | Filled rectangle |
+| Left/right criteria | same | 245 | `0.42W` | 175 | 22pt, three short lines |
+| Decision footer | `0.055W` | 455 | `0.89W` | 45 | 18pt |
+
+Example: **Shared service** vs **Dedicated team**, with Start, Capacity, and Best
+for in that order on both sides. Keep headings to a few words and each criterion
+to a short phrase. More alternatives or long paragraphs belong on another slide
+or in a table. At 4:3, rewrite long labels before reducing the body font.
+
+## Chart and Insight
+
+Use for one numeric series and one supported takeaway. Keep the chart native,
+not a screenshot or a collection of hand-drawn bars.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Native chart | `0.055W` | 145 | `0.57W` | 285 | `chart` add-chart |
+| Takeaway | `0.65W` | 165 | `0.295W` | 75 | 28pt bold |
+| Interpretation | `0.65W` | 255 | `0.295W` | 150 | 22pt |
+| Source footer | `0.055W` | 455 | `0.89W` | 45 | 16pt |
+
+Tested example: `chart_type: "bar"`, categories Q1-Q4, series Active teams,
+values `[12,18,25,34]`, chart title Active teams, legend hidden. The takeaway is
+**+22 teams**, the difference between Q4 and Q1, not a percentage. Interpretation:
+"Growth continues. Next: verify retention." The source explicitly identifies
+the data as synthetic.
+
+Use short category labels and no more than four categories for this recipe.
+More series or dense labels need a full-width chart. Preserve units, relevant
+baseline, and source context; do not invent a causal explanation from a trend.
+
+## Three-Step Timeline
+
+Use for three ordered milestones, not a duration-scaled project schedule.
+
+For step `i=0,1,2`, left is `0.055W + i*0.305W`; width is `0.28W`.
+
+| Element | Top | Height | Type |
+|---------|-----|--------|------|
+| Period | 160 | 60 | 22pt |
+| Rule | 235 | 5 | Filled rectangle |
+| Milestone name | 265 | 60 | 26pt bold |
+| Outcome | 335 | 100 | 20pt |
+
+Example: Weeks 1-2 / Discover / Confirm the need; Weeks 3-4 / Pilot / Validate
+with users; Week 5 / Launch / Release and monitor. Use one short outcome per
+milestone. Add a 16pt footer at top `455`, height `45`, explaining that spacing
+is not elapsed time. Dependencies, overlapping phases, or more milestones need
+a different layout; equal spacing would misrepresent a true schedule.
+
+## Metric Callout
+
+Use for one value that needs a definition and a meaningful comparison.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Value and unit | `0.055W` | 150 | `0.89W` | 120 | 78pt bold |
+| Definition | same | 290 | same | 65 | 28pt |
+| Rule | same | 380 | same | 4 | Filled rectangle |
+| Baseline and cohort | same | 410 | same | 70 | 20pt, two lines |
+
+Example: **18 days**, Median time to first result; Previously 24 days; Synthetic
+cohort: 40 teams, last quarter. Do not omit the unit, denominator, time period,
+or qualification needed to interpret the number. Multiple competing metrics or
+a long qualification need a different slide, not several oversized numbers.
+
+## Reproduce the Examples
+
+`CompositionRecipeTests.Recipes_RenderWithContentInsideSlideBounds` in the Core
+test project builds all four examples through public commands at both sizes.
+It verifies text read-back, COM text bounds, chart category count, and PNG export.
+All labels and data are authored synthetic examples; no external deck is needed.
+
+On Windows with PowerPoint installed, run from the repository root:
+
+```powershell
+$env:PPTMCP_RECIPE_OUTPUT = Join-Path $env:TEMP 'powerpoint-composition-recipes'
+try {
+    dotnet test tests/PowerPointMcp.Core.Tests -c Release --filter 'FullyQualifiedName~CompositionRecipeTests' --blame-hang-timeout 5m
+} finally {
+    Remove-Item Env:PPTMCP_RECIPE_OUTPUT
+}
+```
+
+The output contains `720x540` and `960x540` folders, each with `recipe-1.png`
+through `recipe-4.png` in the order above. Without the environment variable,
+the test deletes its temporary exports. Inspect all eight images after changing
+fonts, content, or geometry. Passing bounds checks alone is not a visual review.

--- a/skills/powerpoint-cli/references/deck-builder.md
+++ b/skills/powerpoint-cli/references/deck-builder.md
@@ -38,6 +38,10 @@ PowerPoint's placeholder scaffolding, not what you add via shapes.
 
 ## Layout Variety
 
+For concrete geometry and content limits, see [Composition Recipes](composition-recipes.md):
+comparison, chart and insight, three-step timeline, and metric callout, with reproducible
+16:9 and 4:3 examples.
+
 Don't build every slide the same way. Vary the composition to match content:
 
 | Content type | Suggested composition |

--- a/skills/powerpoint-mcp/references/composition-recipes.md
+++ b/skills/powerpoint-mcp/references/composition-recipes.md
@@ -1,0 +1,123 @@
+# Composition Recipes
+
+Four editable slide patterns built with existing shape, textframe, chart, and notes
+commands. Choose a pattern for the content, then export and inspect the result.
+These are constrained examples, not automatic layout or overflow correction.
+
+## Shared Geometry
+
+Read `pagesetup(action: "get-settings", session_id: ...)` first. Let `W` and `H`
+be the slide dimensions in points. The examples use `H=540` and `W=960` (16:9)
+or `W=720` (4:3). Horizontal coordinates below are fractions of `W`; vertical
+coordinates and font sizes are points at `H=540`. For a different height, multiply
+vertical coordinates, heights, and font sizes by `H/540`, then verify the render.
+Only the two example sizes have been tested.
+
+- Start with `slide(action: "add-blank", ...)`. Use its returned slide index.
+- Content starts at `0.055W`; its width is `0.89W`.
+- Title box: left `0.055W`, top `40`, width `0.89W`, height `75`, 32pt bold.
+- Examples use Aptos, dark text `RGB(28,35,40)`, and teal rules `RGB(0,115,110)`
+  on white. For a branded deck, use its approved palette and verify
+  foreground/background contrast.
+- Add text with `shape(action: "add-text-box", ...)`, then use the returned
+  shape index for `textframe` font and color actions. Rules are rectangles with
+  a solid fill and no visible line. All elements remain editable.
+- Add speaker notes, export the slide to PNG, and inspect it at its intended size.
+  Check chart labels separately: text-box bounds do not validate chart internals.
+
+## Comparison
+
+Use for two alternatives evaluated on the same three criteria. Do not imply one
+option is preferred through unequal widths or inconsistent ordering.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Left/right heading | `0.055W` / `0.525W` | 150 | `0.42W` | 50 | 26pt bold |
+| Left/right rule | same | 211 | `0.42W` | 4 | Filled rectangle |
+| Left/right criteria | same | 245 | `0.42W` | 175 | 22pt, three short lines |
+| Decision footer | `0.055W` | 455 | `0.89W` | 45 | 18pt |
+
+Example: **Shared service** vs **Dedicated team**, with Start, Capacity, and Best
+for in that order on both sides. Keep headings to a few words and each criterion
+to a short phrase. More alternatives or long paragraphs belong on another slide
+or in a table. At 4:3, rewrite long labels before reducing the body font.
+
+## Chart and Insight
+
+Use for one numeric series and one supported takeaway. Keep the chart native,
+not a screenshot or a collection of hand-drawn bars.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Native chart | `0.055W` | 145 | `0.57W` | 285 | `chart` add-chart |
+| Takeaway | `0.65W` | 165 | `0.295W` | 75 | 28pt bold |
+| Interpretation | `0.65W` | 255 | `0.295W` | 150 | 22pt |
+| Source footer | `0.055W` | 455 | `0.89W` | 45 | 16pt |
+
+Tested example: `chart_type: "bar"`, categories Q1-Q4, series Active teams,
+values `[12,18,25,34]`, chart title Active teams, legend hidden. The takeaway is
+**+22 teams**, the difference between Q4 and Q1, not a percentage. Interpretation:
+"Growth continues. Next: verify retention." The source explicitly identifies
+the data as synthetic.
+
+Use short category labels and no more than four categories for this recipe.
+More series or dense labels need a full-width chart. Preserve units, relevant
+baseline, and source context; do not invent a causal explanation from a trend.
+
+## Three-Step Timeline
+
+Use for three ordered milestones, not a duration-scaled project schedule.
+
+For step `i=0,1,2`, left is `0.055W + i*0.305W`; width is `0.28W`.
+
+| Element | Top | Height | Type |
+|---------|-----|--------|------|
+| Period | 160 | 60 | 22pt |
+| Rule | 235 | 5 | Filled rectangle |
+| Milestone name | 265 | 60 | 26pt bold |
+| Outcome | 335 | 100 | 20pt |
+
+Example: Weeks 1-2 / Discover / Confirm the need; Weeks 3-4 / Pilot / Validate
+with users; Week 5 / Launch / Release and monitor. Use one short outcome per
+milestone. Add a 16pt footer at top `455`, height `45`, explaining that spacing
+is not elapsed time. Dependencies, overlapping phases, or more milestones need
+a different layout; equal spacing would misrepresent a true schedule.
+
+## Metric Callout
+
+Use for one value that needs a definition and a meaningful comparison.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Value and unit | `0.055W` | 150 | `0.89W` | 120 | 78pt bold |
+| Definition | same | 290 | same | 65 | 28pt |
+| Rule | same | 380 | same | 4 | Filled rectangle |
+| Baseline and cohort | same | 410 | same | 70 | 20pt, two lines |
+
+Example: **18 days**, Median time to first result; Previously 24 days; Synthetic
+cohort: 40 teams, last quarter. Do not omit the unit, denominator, time period,
+or qualification needed to interpret the number. Multiple competing metrics or
+a long qualification need a different slide, not several oversized numbers.
+
+## Reproduce the Examples
+
+`CompositionRecipeTests.Recipes_RenderWithContentInsideSlideBounds` in the Core
+test project builds all four examples through public commands at both sizes.
+It verifies text read-back, COM text bounds, chart category count, and PNG export.
+All labels and data are authored synthetic examples; no external deck is needed.
+
+On Windows with PowerPoint installed, run from the repository root:
+
+```powershell
+$env:PPTMCP_RECIPE_OUTPUT = Join-Path $env:TEMP 'powerpoint-composition-recipes'
+try {
+    dotnet test tests/PowerPointMcp.Core.Tests -c Release --filter 'FullyQualifiedName~CompositionRecipeTests' --blame-hang-timeout 5m
+} finally {
+    Remove-Item Env:PPTMCP_RECIPE_OUTPUT
+}
+```
+
+The output contains `720x540` and `960x540` folders, each with `recipe-1.png`
+through `recipe-4.png` in the order above. Without the environment variable,
+the test deletes its temporary exports. Inspect all eight images after changing
+fonts, content, or geometry. Passing bounds checks alone is not a visual review.

--- a/skills/powerpoint-mcp/references/deck-builder.md
+++ b/skills/powerpoint-mcp/references/deck-builder.md
@@ -36,6 +36,10 @@ PowerPoint's placeholder scaffolding, not what you add via shapes.
 
 ## Layout Variety
 
+For concrete geometry and content limits, see [Composition Recipes](composition-recipes.md):
+comparison, chart and insight, three-step timeline, and metric callout, with reproducible
+16:9 and 4:3 examples.
+
 Don't build every slide the same way. Vary the composition to match content:
 
 | Content type | Suggested composition |

--- a/skills/shared/composition-recipes.md
+++ b/skills/shared/composition-recipes.md
@@ -1,0 +1,123 @@
+# Composition Recipes
+
+Four editable slide patterns built with existing shape, textframe, chart, and notes
+commands. Choose a pattern for the content, then export and inspect the result.
+These are constrained examples, not automatic layout or overflow correction.
+
+## Shared Geometry
+
+Read `pagesetup(action: "get-settings", session_id: ...)` first. Let `W` and `H`
+be the slide dimensions in points. The examples use `H=540` and `W=960` (16:9)
+or `W=720` (4:3). Horizontal coordinates below are fractions of `W`; vertical
+coordinates and font sizes are points at `H=540`. For a different height, multiply
+vertical coordinates, heights, and font sizes by `H/540`, then verify the render.
+Only the two example sizes have been tested.
+
+- Start with `slide(action: "add-blank", ...)`. Use its returned slide index.
+- Content starts at `0.055W`; its width is `0.89W`.
+- Title box: left `0.055W`, top `40`, width `0.89W`, height `75`, 32pt bold.
+- Examples use Aptos, dark text `RGB(28,35,40)`, and teal rules `RGB(0,115,110)`
+  on white. For a branded deck, use its approved palette and verify
+  foreground/background contrast.
+- Add text with `shape(action: "add-text-box", ...)`, then use the returned
+  shape index for `textframe` font and color actions. Rules are rectangles with
+  a solid fill and no visible line. All elements remain editable.
+- Add speaker notes, export the slide to PNG, and inspect it at its intended size.
+  Check chart labels separately: text-box bounds do not validate chart internals.
+
+## Comparison
+
+Use for two alternatives evaluated on the same three criteria. Do not imply one
+option is preferred through unequal widths or inconsistent ordering.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Left/right heading | `0.055W` / `0.525W` | 150 | `0.42W` | 50 | 26pt bold |
+| Left/right rule | same | 211 | `0.42W` | 4 | Filled rectangle |
+| Left/right criteria | same | 245 | `0.42W` | 175 | 22pt, three short lines |
+| Decision footer | `0.055W` | 455 | `0.89W` | 45 | 18pt |
+
+Example: **Shared service** vs **Dedicated team**, with Start, Capacity, and Best
+for in that order on both sides. Keep headings to a few words and each criterion
+to a short phrase. More alternatives or long paragraphs belong on another slide
+or in a table. At 4:3, rewrite long labels before reducing the body font.
+
+## Chart and Insight
+
+Use for one numeric series and one supported takeaway. Keep the chart native,
+not a screenshot or a collection of hand-drawn bars.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Native chart | `0.055W` | 145 | `0.57W` | 285 | `chart` add-chart |
+| Takeaway | `0.65W` | 165 | `0.295W` | 75 | 28pt bold |
+| Interpretation | `0.65W` | 255 | `0.295W` | 150 | 22pt |
+| Source footer | `0.055W` | 455 | `0.89W` | 45 | 16pt |
+
+Tested example: `chart_type: "bar"`, categories Q1-Q4, series Active teams,
+values `[12,18,25,34]`, chart title Active teams, legend hidden. The takeaway is
+**+22 teams**, the difference between Q4 and Q1, not a percentage. Interpretation:
+"Growth continues. Next: verify retention." The source explicitly identifies
+the data as synthetic.
+
+Use short category labels and no more than four categories for this recipe.
+More series or dense labels need a full-width chart. Preserve units, relevant
+baseline, and source context; do not invent a causal explanation from a trend.
+
+## Three-Step Timeline
+
+Use for three ordered milestones, not a duration-scaled project schedule.
+
+For step `i=0,1,2`, left is `0.055W + i*0.305W`; width is `0.28W`.
+
+| Element | Top | Height | Type |
+|---------|-----|--------|------|
+| Period | 160 | 60 | 22pt |
+| Rule | 235 | 5 | Filled rectangle |
+| Milestone name | 265 | 60 | 26pt bold |
+| Outcome | 335 | 100 | 20pt |
+
+Example: Weeks 1-2 / Discover / Confirm the need; Weeks 3-4 / Pilot / Validate
+with users; Week 5 / Launch / Release and monitor. Use one short outcome per
+milestone. Add a 16pt footer at top `455`, height `45`, explaining that spacing
+is not elapsed time. Dependencies, overlapping phases, or more milestones need
+a different layout; equal spacing would misrepresent a true schedule.
+
+## Metric Callout
+
+Use for one value that needs a definition and a meaningful comparison.
+
+| Element | Left | Top | Width | Height | Type |
+|---------|------|-----|-------|--------|------|
+| Value and unit | `0.055W` | 150 | `0.89W` | 120 | 78pt bold |
+| Definition | same | 290 | same | 65 | 28pt |
+| Rule | same | 380 | same | 4 | Filled rectangle |
+| Baseline and cohort | same | 410 | same | 70 | 20pt, two lines |
+
+Example: **18 days**, Median time to first result; Previously 24 days; Synthetic
+cohort: 40 teams, last quarter. Do not omit the unit, denominator, time period,
+or qualification needed to interpret the number. Multiple competing metrics or
+a long qualification need a different slide, not several oversized numbers.
+
+## Reproduce the Examples
+
+`CompositionRecipeTests.Recipes_RenderWithContentInsideSlideBounds` in the Core
+test project builds all four examples through public commands at both sizes.
+It verifies text read-back, COM text bounds, chart category count, and PNG export.
+All labels and data are authored synthetic examples; no external deck is needed.
+
+On Windows with PowerPoint installed, run from the repository root:
+
+```powershell
+$env:PPTMCP_RECIPE_OUTPUT = Join-Path $env:TEMP 'powerpoint-composition-recipes'
+try {
+    dotnet test tests/PowerPointMcp.Core.Tests -c Release --filter 'FullyQualifiedName~CompositionRecipeTests' --blame-hang-timeout 5m
+} finally {
+    Remove-Item Env:PPTMCP_RECIPE_OUTPUT
+}
+```
+
+The output contains `720x540` and `960x540` folders, each with `recipe-1.png`
+through `recipe-4.png` in the order above. Without the environment variable,
+the test deletes its temporary exports. Inspect all eight images after changing
+fonts, content, or geometry. Passing bounds checks alone is not a visual review.

--- a/skills/shared/deck-builder.md
+++ b/skills/shared/deck-builder.md
@@ -36,6 +36,10 @@ PowerPoint's placeholder scaffolding, not what you add via shapes.
 
 ## Layout Variety
 
+For concrete geometry and content limits, see [Composition Recipes](composition-recipes.md):
+comparison, chart and insight, three-step timeline, and metric callout, with reproducible
+16:9 and 4:3 examples.
+
 Don't build every slide the same way. Vary the composition to match content:
 
 | Content type | Suggested composition |

--- a/tests/PowerPointMcp.Core.Tests/CompositionRecipeTests.cs
+++ b/tests/PowerPointMcp.Core.Tests/CompositionRecipeTests.cs
@@ -1,0 +1,167 @@
+using Sbroenne.PowerPointMcp.ComInterop;
+using Sbroenne.PowerPointMcp.Core.Chart;
+using Sbroenne.PowerPointMcp.Core.Export;
+using Sbroenne.PowerPointMcp.Core.Notes;
+using Sbroenne.PowerPointMcp.Core.PageSetup;
+using Sbroenne.PowerPointMcp.Core.Shape;
+using Sbroenne.PowerPointMcp.Core.Slide;
+using Sbroenne.PowerPointMcp.Core.TextFrame;
+using Xunit.Abstractions;
+using PowerPoint = Microsoft.Office.Interop.PowerPoint;
+
+namespace Sbroenne.PowerPointMcp.Core.Tests;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "Composition")]
+public sealed class CompositionRecipeTests(SharedPresentationFixture fixture, ITestOutputHelper output)
+    : IClassFixture<SharedPresentationFixture>
+{
+    private readonly ShapeCommands _shapes = new();
+    private readonly TextFrameCommands _text = new();
+
+    [Theory]
+    [InlineData(960)]
+    [InlineData(720)]
+    public void Recipes_RenderWithContentInsideSlideBounds(int slideWidth)
+    {
+        fixture.CreateFreshPresentation();
+        var batch = fixture.Batch;
+        var size = new PageSetupCommands().SetSize(batch, slideWidth, 540);
+        Assert.True(size.Success, size.ErrorMessage);
+        float margin = slideWidth * 0.055f;
+        float contentWidth = slideWidth * 0.89f;
+        float columnWidth = slideWidth * 0.42f;
+        var slides = new SlideCommands();
+        for (int slideIndex = 2; slideIndex <= 4; slideIndex++)
+        {
+            Assert.True(slides.AddBlank(batch).Success);
+        }
+
+        AddText(1, margin, 40, contentWidth, 75, "Choose the delivery model", 32, true);
+        AddText(1, margin, 150, columnWidth, 50, "Shared service", 26, true);
+        AddText(1, slideWidth * 0.525f, 150, columnWidth, 50, "Dedicated team", 26, true);
+        AddBar(1, margin, 211, columnWidth, 4);
+        AddBar(1, slideWidth * 0.525f, 211, columnWidth, 4);
+        AddText(1, margin, 245, columnWidth, 175, "Start: 2 weeks\nCapacity: shared\nBest for: steady demand", 22);
+        AddText(1, slideWidth * 0.525f, 245, columnWidth, 175, "Start: 6 weeks\nCapacity: reserved\nBest for: rapid iteration", 22);
+        AddText(1, margin, 455, contentWidth, 45, "Decision: match the model to the workload.", 18);
+
+        AddText(2, margin, 40, contentWidth, 75, "Adoption grows each quarter", 32, true);
+        var charts = new ChartCommands();
+        var chart = charts.AddChart(batch, 2, "bar", margin, 145, slideWidth * 0.57f, 285,
+            ["Q1", "Q2", "Q3", "Q4"], "Active teams", [12, 18, 25, 34]);
+        Assert.True(chart.Success, chart.ErrorMessage);
+        Assert.True(charts.SetChartTitle(batch, 2, chart.ShapeIndex!.Value, "Active teams").Success);
+        Assert.True(charts.SetLegendVisibility(batch, 2, chart.ShapeIndex.Value, false).Success);
+        var data = charts.GetChartData(batch, 2, chart.ShapeIndex.Value);
+        Assert.True(data.Success, data.ErrorMessage);
+        Assert.Equal(4, data.CategoryCount);
+        AddText(2, slideWidth * 0.65f, 165, slideWidth * 0.295f, 75, "+22 teams", 28, true);
+        AddText(2, slideWidth * 0.65f, 255, slideWidth * 0.295f, 150,
+            "Growth continues.\nNext: verify retention.", 22);
+        AddText(2, margin, 455, contentWidth, 45, "Synthetic example. Quarterly active-team counts.", 16);
+
+        AddText(3, margin, 40, contentWidth, 75, "Three steps to launch", 32, true);
+        string[] periods = ["Weeks 1-2", "Weeks 3-4", "Week 5"];
+        string[] milestones = ["Discover", "Pilot", "Launch"];
+        string[] outcomes = ["Confirm the need", "Validate with users", "Release and monitor"];
+        for (int step = 0; step < 3; step++)
+        {
+            float left = margin + step * slideWidth * 0.305f;
+            float width = slideWidth * 0.28f;
+            AddText(3, left, 160, width, 60, periods[step], 22);
+            AddBar(3, left, 235, width, 5);
+            AddText(3, left, 265, width, 60, milestones[step], 26, true);
+            AddText(3, left, 335, width, 100, outcomes[step], 20);
+        }
+        AddText(3, margin, 455, contentWidth, 45, "Milestone sequence; spacing is not elapsed time.", 16);
+
+        AddText(4, margin, 40, contentWidth, 75, "Faster time to value", 32, true);
+        AddText(4, margin, 150, contentWidth, 120, "18 days", 78, true);
+        AddText(4, margin, 290, contentWidth, 65, "Median time to first result", 28);
+        AddBar(4, margin, 380, contentWidth, 4);
+        AddText(4, margin, 410, contentWidth, 70, "Previously 24 days.\nSynthetic cohort: 40 teams, last quarter.", 20);
+
+        string? requestedOutput = Environment.GetEnvironmentVariable("PPTMCP_RECIPE_OUTPUT");
+        string directory = Path.Combine(requestedOutput ?? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")),
+            $"{slideWidth}x540");
+        try
+        {
+            for (int slideIndex = 1; slideIndex <= 4; slideIndex++)
+            {
+                var notes = new NotesCommands().SetNotesText(batch, slideIndex,
+                    "Synthetic composition example. All labels and data are illustrative, not customer material.");
+                Assert.True(notes.Success, notes.ErrorMessage);
+                string image = Path.Combine(directory, $"recipe-{slideIndex}.png");
+                var exported = new ExportCommands().ExportSlideToImage(batch, slideIndex, image,
+                    width: slideWidth, height: 540);
+                Assert.True(exported.Success, exported.ErrorMessage);
+                Assert.True(new FileInfo(image).Length > 1000);
+            }
+            output.WriteLine($"Recipe images: {directory}");
+        }
+        finally
+        {
+            if (requestedOutput is null && Directory.Exists(directory))
+            {
+                Directory.Delete(Path.GetDirectoryName(directory)!, recursive: true);
+            }
+        }
+    }
+
+    private void AddBar(int slideIndex, float left, float top, float width, float height)
+    {
+        var result = _shapes.AddRectangle(fixture.Batch, slideIndex, left, top, width, height);
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(_shapes.SetFill(fixture.Batch, slideIndex, result.ShapeIndex!.Value, 0, 115, 110).Success);
+        Assert.True(_shapes.SetLine(fixture.Batch, slideIndex, result.ShapeIndex.Value, visible: false).Success);
+    }
+
+    private void AddText(int slideIndex, float left, float top, float width, float height,
+        string text, float fontSize, bool bold = false)
+    {
+        var batch = fixture.Batch;
+        var result = _shapes.AddTextBox(batch, slideIndex, left, top, width, height, text);
+        Assert.True(result.Success, result.ErrorMessage);
+        int shapeIndex = result.ShapeIndex!.Value;
+        Assert.True(_text.SetFontName(batch, slideIndex, shapeIndex, "Aptos").Success);
+        Assert.True(_text.SetFontSize(batch, slideIndex, shapeIndex, fontSize).Success);
+        Assert.True(_text.SetBold(batch, slideIndex, shapeIndex, bold).Success);
+        Assert.True(_text.SetFontColor(batch, slideIndex, shapeIndex, 28, 35, 40).Success);
+        var readBack = _text.GetText(batch, slideIndex, shapeIndex);
+        Assert.True(readBack.Success, readBack.ErrorMessage);
+        Assert.Equal(text, readBack.Text);
+        batch.Execute((ctx, ct) =>
+        {
+            PowerPoint.Slides? slides = null;
+            PowerPoint.Slide? slide = null;
+            PowerPoint.Shapes? shapes = null;
+            PowerPoint.Shape? shape = null;
+            PowerPoint.TextFrame? frame = null;
+            PowerPoint.TextRange? range = null;
+            try
+            {
+                slides = ctx.Presentation.Slides;
+                slide = slides[slideIndex];
+                shapes = slide.Shapes;
+                shape = shapes[shapeIndex];
+                frame = shape.TextFrame;
+                range = frame.TextRange;
+                Assert.True(range.BoundWidth <= width + 1, $"Text too wide: {text}");
+                Assert.True(range.BoundHeight <= height + 1, $"Text too tall: {text}");
+                Assert.True(range.BoundLeft >= left - 1 && range.BoundTop >= top - 1);
+                Assert.True(range.BoundLeft + range.BoundWidth <= left + width + 1, text);
+                Assert.True(range.BoundTop + range.BoundHeight <= top + height + 1, text);
+            }
+            finally
+            {
+                ComUtilities.Release(ref range);
+                ComUtilities.Release(ref frame);
+                ComUtilities.Release(ref shape);
+                ComUtilities.Release(ref shapes);
+                ComUtilities.Release(ref slide);
+                ComUtilities.Release(ref slides);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Add four bounded, editable slide-composition recipes to the shared agent guidance:
- Two-option comparison with matching criteria.
- Native chart plus a supported numeric takeaway.
- Three-step milestone timeline, explicitly not duration-scaled.
- Metric callout with definition, baseline, cohort, and period.

Each recipe includes geometry, content limits, and cases where it should not be used. Deck Builder links to the canonical guide, both CLI/MCP skill packages contain it, and the site publishes it through the existing mirrored-reference mechanism. Includes a minor changeset for the shipped guidance.

## Reproducible Examples
A real-PowerPoint integration test constructs all four examples using existing public commands at 960x540 and 720x540. It checks text read-back and COM text bounds, native chart category count, and PNG export. Set `PPTMCP_RECIPE_OUTPUT` to retain all eight images; the guide includes the focused test command.

Examples are synthetic and authored for this contribution. No private decks, screenshots from external presentations, or new runtime dependencies are included. These are constrained starting layouts, not an automatic layout engine or a claim of measured LLM-quality improvement.

## Validation
Run locally on Windows with PowerPoint in an isolated branch based on main after #75:
- Recipe integration tests: 2/2 passed, covering all four examples in both aspect ratios.
- Eight example renders visually reviewed during implementation, with isolated-branch chart/timeline spot checks after rebasing onto current main.
- Release solution build: 0 warnings, 0 errors.
- Full MCP suite: 41/41; release/skill packaging: 65/65.
- Unchanged pre-commit gate passed. It does not select this new test-only Core class, so the recipe test was explicitly run separately.
- Strict MkDocs build, 36-page site audit, and 23-source deploy coverage passed.

No test-discovery override is needed. Test runners were bounded and no timeout kill was needed. This PR is independent of the palette feature (#76) and does not modify production runtime or startup code.