### PR TITLE
Streamline shared agent configuration and preserve development guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,268 +1,66 @@
-# Project Instructions — PowerPointMcp
+# PowerPointMcp repository rules
 
-## Critical Files (Read These First)
+GitHub Copilot is the primary coding agent, locally and on GitHub. Use Windows,
+PowerShell, and the SDK selected by `global.json`. Desktop PowerPoint is required
+for COM tests; GitHub-hosted runners do not have it.
 
-**ALWAYS read when working on code:**
-- [Critical Rules](instructions/critical-rules.instructions.md) - mandatory rules (Success flag, COM cleanup, TDD, session lifecycle)
-- [Architecture Patterns](instructions/architecture-patterns.instructions.md) - layered architecture, command pattern, resource management
+MCP Server and `pptcli` are equal entry points: behavior, defaults, validation,
+results, and documentation must agree. Read
+[critical rules](instructions/critical-rules.instructions.md) for every change.
+Read only the additional instructions matching the work:
 
-**Read based on task type:**
-- Adding/fixing Core commands or COM interop → [Architecture Patterns](instructions/architecture-patterns.instructions.md)
-- Writing tests → [Testing Strategy](instructions/testing-strategy.instructions.md)
-- MCP Server tool work → [MCP Server Guide](instructions/mcp-server-guide.instructions.md)
+| Work | Instructions |
+| --- | --- |
+| Runtime, contracts, generators | [Architecture](instructions/architecture-patterns.instructions.md) |
+| MCP tools, schemas, MCP generators | [MCP guide](instructions/mcp-server-guide.instructions.md) |
+| Tests or behavior changes | [Testing](instructions/testing-strategy.instructions.md) |
+| Builds, scripts, workflows, releases | [Development workflow](instructions/development-workflow.instructions.md) |
+| Agent instructions | [Instruction maintenance](instructions/meta.instructions.md) |
+| Skills | `skills/CLAUDE.md` and `skills/README.md` |
 
-## Sister Projects
+## Implementation
 
-PowerPointMcp is one of a family of Windows-only, COM-interop MCP-server repos maintained by the
-same author (`sbroenne`). The family currently includes:
+- Core `[ServiceCategory]` interfaces drive generated routing. Change contracts
+  and generators, not emitted code. Follow changes through both entry points,
+  tests, help, and shared guidance.
+- `sbroenne/mcp-server-excel` is the architectural reference. Before architectural
+  changes, check its existing solution. Preserve PowerPoint-specific differences
+  such as PIA embedding and the absence of `Application.ScreenUpdating`.
+  Flag shared bugs for Excel or `mcp-windows` without changing those repos.
+- Keep rules in their linked files, not duplicated here. Tool and operation
+  counts come from the generated skill manifest, `PresentationToolAction`, and
+  `McpProtocolTests.ExpectedToolNames`, not remembered inventories.
 
-- **`mcp-server-excel`** (`sbroenne/mcp-server-excel`) — **the authoritative architectural
-  template for this entire family.** Its layering (ComInterop → Core → Service → CLI/MCP Server),
-  Unified Service Architecture, generator design, hand-written vs. generated tool split, COM
-  cleanup discipline (Rule 22: every `dynamic` COM object released via `ComUtilities.Release` in a
-  `finally` block), support/audit scripts (`scripts/*.ps1`), and CI Gate workflow are the reference
-  design. When PowerPointMcp diverges from Excel, treat the divergence as a bug to fix **unless**
-  there is a concrete, documented reason the underlying Office object model differs (e.g. Excel's
-  `Application.ScreenUpdating` has no PowerPoint equivalent — that divergence is legitimate and
-  intentionally NOT ported).
-- **`mcp-server-powerpoint`** (this repo) — PowerPoint automation, structurally mirrors Excel's
-  10-project layout and Unified Service Architecture.
-- **`mcp-windows`** — a sister Windows-automation MCP server project.
-
-**When making architectural changes here, check whether Excel already solved the same problem —
-port its pattern rather than inventing a new one.** Likewise, if you fix a real bug or close a gap
-here that also exists in Excel or `mcp-windows`, flag it so the same fix can be ported there.
-
-## What is PowerPointMcp?
-
-**PowerPointMcp** is a Windows-only toolset for programmatic PowerPoint automation via COM
-interop, designed for coding agents and automation scripts. It drives a **live PowerPoint desktop
-instance** through the official `Microsoft.Office.Interop.PowerPoint` PIA (embedded via
-`ForceEmbedPowerPointInteropTypes` — no runtime assembly-resolver needed, unlike Excel).
-
-The project ships **two equal, first-class entry points** — an MCP Server and a CLI — that share
-one `Core` codebase and are kept in parity by source generators, mirroring `mcp-server-excel`'s
-Unified Service Architecture.
-
-**Core Layers:**
-1. **ComInterop** (`src/PowerPointMcp.ComInterop`) - STA thread + OLE message filter + channel-based
-   work queue (`PresentationBatch`), ported from `mcp-server-excel`'s `ExcelBatch` pattern.
-2. **Core** (`src/PowerPointMcp.Core`) - PowerPoint domain commands, one folder per domain
-   (Presentation, Slide, Shape, TextFrame, Table, Notes, Layout, Master, Animation, Image, Media, Chart,
-   Export). Domains other than Presentation carry a `[ServiceCategory]` marker attribute that the
-   generators discover.
-3. **Generators** (`src/PowerPointMcp.Generators.Mcp`, `src/PowerPointMcp.Generators.Cli`,
-   `src/PowerPointMcp.Generators.Shared`) - Roslyn source generators that read `[ServiceCategory]`
-   Core interfaces and emit one **action-dispatch tool per domain** for the MCP surface (e.g.
-   `slide`, `shape`, `chart`, each taking an `action` parameter like `"add-chart"`) and one
-   `pptcli {category} {action}` command per operation for the CLI. `Presentation` is also a
-   hand-written action-dispatch tool (`PresentationTools.cs`) so session lifecycle, template work,
-   and document properties live under the single `presentation` MCP tool.
-4. **Service** (`src/PowerPointMcp.Service`) - `PowerPointMcpService`: the shared session registry
-   + dispatch layer both entry points call into. **McpServer** hosts it **in-process** (no pipe,
-   via `ServiceBridge.ForwardToService`); **CLI** (`pptcli`) talks to it via a **separate
-   background daemon process** over a named pipe (`ServiceClient`/`IPowerPointDaemonRpc`,
-   auto-started on first `session open`/`session create`), so sessions persist across CLI
-   invocations without paying PowerPoint's ~90-150s launch cost every command.
-5. **McpServer** (`src/PowerPointMcp.McpServer`) - Model Context Protocol stdio host. 16 tools
-   total: one hand-written `presentation` action-dispatch tool plus 15 generated action-dispatch
-   tools (`slide`, `shape`, `textframe`, `table`, `notes`, `layout`, `master`, `animation`,
-  `image`, `media`, `chart`, `smartart`, `export`, `pagesetup`, `accessibility`), covering 187 operations
-   across 16 domains. See
-   `tests/PowerPointMcp.McpServer.Tests/Integration/McpProtocolTests.cs`'s `ExpectedToolNames` for
-   the ground-truth tool list.
-6. **CLI** (`src/PowerPointMcp.CLI`) - `pptcli`, built on the same generators as the MCP surface
-   (`CliCommandRegistration.RegisterCommands`) plus hand-written `session`/`service` command
-   branches for daemon lifecycle. Full parity with the MCP surface (Export is exposed here too).
-
-MCP Server and CLI run as **separate processes**, each managing its own PowerPoint instance — they
-do **not** share live sessions with each other, only the same `Core`/`Service` codebase.
-
-## Session Model (MCP Server)
-
-```
-presentation(action="create", filePath) OR presentation(action="open", filePath) → sessionId
-... other domain tools take session_id; presentation lifecycle/property actions take sessionId ...
-presentation(action="test", filePath) → validates PowerPoint can open the file; no session retained
-presentation(action="close", sessionId, save=true) → optionally saves, removes from registry
-                                                      immediately, then disposes the batch (and its
-                                                      PowerPoint process) on a background task.
-```
-
-`presentation(action="create", ...)` creates + saves the file and leaves the new session open.
-Callers should reuse the returned `sessionId` instead of opening the same file again.
-
-Host shutdown (`Ctrl+C`, stdin EOF, or normal exit) MUST dispose every open batch via
-`PresentationSessionRegistry.DisposeAll()` — two-layered: an `IHostedService` on `StopAsync`, plus
-a backstop in `Main`'s `finally`. Never let a PowerPoint process leak past MCP host shutdown.
-
-## 1-Based Indexing (CRITICAL)
-
-`slideIndex`, `shapeIndex`, and table `row`/`column` are 1-based everywhere in Core and the MCP
-surface, matching PowerPoint's native COM object model (`Slides(1)` is the first slide). Do not
-introduce 0-based indexing anywhere in Core, the MCP tools, or tests.
-
-## PIA-First COM Access (CRITICAL)
-
-All PowerPoint COM operations must use strongly typed members from the embedded
-`Microsoft.Office.Interop.PowerPoint` PIA whenever the restored PIA exposes the required API.
-Use typed Office/PowerPoint enums instead of raw integer constants.
-
-Only use `dynamic`, reflection, raw dispatch, or numeric COM enum values after confirming from the
-restored interop metadata that no typed PIA member/type exists. Keep such exceptions narrowly
-scoped, document the missing PIA surface in code, and cover the behavior with a real-COM
-integration test. Convenience is never a reason to bypass the PIA.
-
-## Rule 1 / 1b — Success/ErrorMessage Invariant (CRITICAL)
-
-Core commands return `{Domain}OperationResult` with `Success`/`ErrorMessage`:
-
-- **Rule 1:** `Success == true` implies `ErrorMessage == null`. Never both.
-- **Rule 1b:** Never wrap `batch.Execute()` in a try-catch that swallows exceptions and returns an
-  error result. Let exceptions propagate naturally out of Core — `batch.Execute()`'s
-  `TaskCompletionSource` plumbing handles them. Only the MCP tool boundary
-  (`PowerPointToolsBase.ExecuteToolAction`) catches unexpected exceptions, logs the HResult to
-  stderr, and serializes a structured error — this is the ONLY place a catch-all belongs.
-
-Expected, caller-correctable failures (bad index, missing file, unknown session) are validated
-BEFORE calling Core and returned as `Success=false` payloads — never thrown as exceptions.
-
-```csharp
-// Core: let exceptions propagate
-public ShapeOperationResult AddRectangle(IPresentationBatch batch, int slideIndex, ...)
-{
-    return batch.Execute((ctx, ct) => {
-        // COM object access; exceptions bubble up naturally
-    });
-}
-
-// MCP Tool: validate expected bad input first, don't throw
-if (!registry.TryGet(sessionId, out var batch))
-{
-    return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
-}
-```
-
-## Rule 30 — Real-COM Integration Tests Only (CRITICAL)
-
-**NEVER write unit tests with mocked COM objects.** All Core tests are real-COM integration tests
-against a real PowerPoint instance, following strict TDD (red → green): write a failing test
-first, watch it fail, implement, watch it pass.
-
-- Tests are serialized via `xunit.runner.json` (`maxParallelThreads: 1`) — concurrent PowerPoint
-  launches are not supported.
-- Tests are tagged `[Trait("Category", "Integration")]` + `[Trait("Feature", "<Domain>")]` (e.g.
-  `Feature=Shape`, `Feature=Chart`) for surgical `dotnet test --filter` runs.
-- MCP-layer tests (`tests/PowerPointMcp.McpServer.Tests`) use the SDK's in-memory pipe transport
-  (`Program.ConfigureTestTransport`) for protocol-level assertions (tools/list, schema, error
-  envelope) WITHOUT launching PowerPoint; only the session-lifecycle round-trip tests touch real
-  COM. Do not re-test Core COM behavior at the MCP layer — MCP tests assert wiring + serialization
-  + session mapping only.
-- Office's own post-Quit cleanup can take up to ~90-200+ seconds after
-  `presentation(action="close", sessionId=...)` / session disposal — this is documented, benign
-  Office behavior. Do NOT add force-kill on the happy path.
-
-### Test Commands
+## Build and validation
 
 ```powershell
-# Full Core test suite (real COM, serialized — slower than a typical unit-test suite)
-dotnet test tests\PowerPointMcp.Core.Tests
-
-# Surgical: one domain only
-dotnet test tests\PowerPointMcp.Core.Tests --filter "Feature=Shape"
-dotnet test tests\PowerPointMcp.Core.Tests --filter "Feature=Chart"
-
-# MCP transport/protocol tests
-dotnet test tests\PowerPointMcp.McpServer.Tests
+dotnet restore Sbroenne.PowerPointMcp.slnx
+dotnet build Sbroenne.PowerPointMcp.slnx -c Release --no-restore
 ```
 
-Always run tests with an explicit timeout in the terminal/tooling layer — never leave a COM test
-run open-ended; fail fast if PowerPoint stalls.
+Build with zero warnings. Run focused checks from the
+[testing strategy](instructions/testing-strategy.instructions.md) and existing
+gates in `scripts/pre-commit.ps1` / `.github/workflows/ci.yml`; do not invent
+replacement audits. `scripts/check-doc-counts.ps1` needs a current Release build
+in this worktree. Documentation/configuration-only changes do not need synthetic
+tests or PowerPoint launches; validate their links, syntax, and affected behavior.
+Report unavailable COM checks as not run, never as passed.
 
-## Quick Reference
+## Git and release
 
-### Tool Selection
-- Code changes → targeted `edit`/`replace_string_in_file` (small, precise context)
-- Find code → `grep`/code search over PowerShell text scraping
-- Build/test/git → `dotnet build`/`dotnet test`/`git` via the terminal tool
+- Never commit to `main`, force-push, or bypass hooks. Report hook blockers.
+- Commit/push only when explicitly authorized. A GitHub coding-agent assignment
+  explicitly requesting a PR authorizes its delivery commits and PR, not merging
+  or publishing. Local edits alone do not authorize commits.
+- Verify `gh auth status` uses the personal `sbroenne` account for this namespace.
+  An inherited `GH_TOKEN` can override the stored account; never print tokens.
+- User-visible changes need a changeset. Internal/docs/tests/CI changes use the
+  `skip-changelog` PR label. Versions and `CHANGELOG.md` are release-generated.
+- Plugin publication follows
+  [the publication guide](workflows/docs/publish-plugins-setup.md);
+  the published repository is output-only.
 
-### GitHub Auth Rule for This Repo
-
-When using `gh` against `sbroenne/mcp-server-powerpoint` (issues, PRs, comments, merges), verify
-`gh auth status` shows the personal `sbroenne` account as ACTIVE, not an EMU
-(`stbrnner_microsoft`) account — EMU accounts cannot create/push to this namespace. Run
-`gh auth switch --user sbroenne` if needed.
-
-## Key Lessons (Update After Major Work)
-
-**Success Flag:** NEVER `Success = true` with `ErrorMessage`. Set `Success` in the success path
-only; catch-free in Core (see Rule 1/1b above).
-
-**Session Registry / Service DI:** The DI-injected `PresentationSessionRegistry registry` parameter
-(hand-written session-lifecycle tools) and `PowerPointMcpService service` parameter (generated
-action-dispatch tools) are both correctly EXCLUDED from the MCP JSON schema by SDK 1.3.0 —
-verified via `tools/list`. Don't add manual schema suppression for either.
-
-**Two-Layer Shutdown:** `PresentationSessionShutdownService : IHostedService` disposes batches on
-host `StopAsync`, AND `Main`'s `finally` calls `registry.DisposeAll()` as an idempotent backstop.
-Both layers must stay in sync if session lifecycle changes.
-
-**No CLI/MCP Parity Gaps:** Both entry points are built from the same generators against the same
-`[ServiceCategory]` Core interfaces, so a new Core operation is automatically available on both
-surfaces once its domain's generator runs — there is no placeholder/parity-gap state to track
-anymore. Export is exposed identically on both.
-
-**Generators Are Live:** `PowerPointMcp.Generators.Mcp`/`PowerPointMcp.Generators.Cli` (mirroring
-`ExcelMcp.Generators.Mcp`/`.Cli`) read `[ServiceCategory]`-attributed Core interfaces and emit the
-action-dispatch MCP tools and `pptcli` commands. Adding a new domain means adding the
-`[ServiceCategory]` attribute + interface/implementation to Core — the generators pick it up
-automatically; do not hand-write a new tool class for it.
-
-**Export Domain:** `ExportSlideToImage`/`ExportAllSlidesToImages` use PowerPoint's native
-`Presentation.Export`/`Slide.Export` COM calls — prefer the single multi-slide `Export` call over
-a per-slide loop when exporting everything.
-
-## How Path-Specific Instructions Work
-
-GitHub Copilot auto-loads instructions based on files you're editing:
-
-- `tests/**/*.cs` → [Testing Strategy](instructions/testing-strategy.instructions.md)
-- `src/PowerPointMcp.Core/**/*.cs`, `src/PowerPointMcp.ComInterop/**/*.cs` → [Architecture Patterns](instructions/architecture-patterns.instructions.md)
-- `src/PowerPointMcp.McpServer/**/*.cs` → [MCP Server Guide](instructions/mcp-server-guide.instructions.md)
-- `**` (all files) → [Critical Rules](instructions/critical-rules.instructions.md)
-
-## Agent Skills (`skills/`)
-
-| Skill | File | Target | Best For |
-|-------|------|--------|----------|
-| **powerpoint-mcp** | `skills/powerpoint-mcp/SKILL.md` | MCP Server | Conversational AI (rich tool schemas) |
-
-**Guidance architecture (single source of truth):**
-- `skills/shared/*.md` → manually copied into `skills/powerpoint-mcp/references/` (no build-time
-  sync step exists yet — add one before this drifts; see `skills/README.md`).
-- NEVER create separate prompt content for guidance that belongs in `skills/shared/`.
-
-## Pre-Commit Hook
-
-Pre-commit runs `scripts/pre-commit.ps1`, which blocks commits if any check fails:
-
-| # | Check | What It Validates |
-|---|-------|--------------------|
-| 1 | Branch | Never commit to `main` directly |
-| 2 | Success Flag | Rule 1: never `Success=true` with `ErrorMessage` |
-| 3 | Build | `dotnet build Sbroenne.PowerPointMcp.slnx` succeeds, 0 warnings/errors |
-| 4 | Core Tests | Surgical `Feature=`-filtered real-COM integration tests for touched domains |
-| 5 | MCP Protocol Tests | `dotnet test tests\PowerPointMcp.McpServer.Tests` (in-memory transport, no COM needed for most cases) |
-| 6 | TODO/FIXME Scan | No unresolved `TODO`/`FIXME`/`HACK` markers in changed files |
-
-**Install hook:**
-```powershell
-# From repo root
-Copy-Item scripts\pre-commit.ps1 .git\hooks\pre-commit
-```
-
-## No Confidential Information in Commits/PRs
-
-Never include confidential project names, customer names, or internal references in commit
-messages, PR descriptions, or issue text. Use generic descriptions ("a PowerPoint deck", "a chart
-shape") instead.
+Agent setup and local/GitHub limitations:
+[docs/AGENT-CONFIGURATION.md](../docs/AGENT-CONFIGURATION.md).
+Background, examples, hook setup, and the guidance migration map:
+[development guide](../docs/DEVELOPMENT-GUIDE.md).

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,7 @@
+scripts:
+  - name: Build (Release, no process cleanup)
+    command: dotnet build Sbroenne.PowerPointMcp.slnx -c Release -p:PowerPointMcpSkipCleanup=true
+  - name: MCP tests (no PowerPoint)
+    command: dotnet test tests\PowerPointMcp.McpServer.Tests -c Release --filter "RequiresPowerPoint!=true" --blame-hang-timeout 5m -p:PowerPointMcpSkipCleanup=true
+  - name: Packaging tests (no PowerPoint)
+    command: dotnet test tests\PowerPointMcp.SkillGeneration.Tests -c Release --blame-hang-timeout 5m -p:PowerPointMcpSkipCleanup=true

--- a/.github/instructions/architecture-patterns.instructions.md
+++ b/.github/instructions/architecture-patterns.instructions.md
@@ -1,5 +1,6 @@
 ---
 applyTo: "src/**/*.cs"
+excludeAgent: "code-review"
 ---
 
 # Architecture Patterns
@@ -41,9 +42,9 @@ McpServer (in-process, ServiceBridge)        CLI / pptcli (named-pipe daemon, Se
   Both entry points call into this same dispatch logic (`ServiceRegistry.{Category}.RouteAction`)
   — MCP in-process via `ServiceBridge.ForwardToService`, CLI over a named pipe via
   `ServiceClient`/`IPowerPointDaemonRpc`.
-- **McpServer** tools are thin either way: the 7 hand-written session/template tools
-  (`PresentationTools.cs`) resolve `sessionId` → batch directly via
-  `PresentationSessionRegistry.TryGet`; the 11 generated action-dispatch tools
+- **McpServer** tools are thin either way: the single hand-written `presentation` tool
+  (`PresentationTools.cs`) handles session/template/property operations via
+  `PresentationSessionRegistry`; the generated action-dispatch tools
   (`slide`/`shape`/`chart`/etc., one per `[ServiceCategory]` domain) forward straight to the
   shared `PowerPointMcpService`. No domain logic lives in either.
 
@@ -84,21 +85,16 @@ public interface IShapeCommands
 All direct COM object access happens inside a `batch.Execute((ctx, ct) => { ... })` callback on
 the `PresentationBatch`'s dedicated STA thread — never access
 `Microsoft.Office.Interop.PowerPoint` types from arbitrary threads. Release any manually-obtained
-COM references in a `finally` block if the Core command holds intermediate `dynamic`/typed COM
-objects beyond what the PIA's NoPIA embedding already manages for you.
+COM references in a `finally` block, including intermediate typed COM objects.
+NoPIA embedding removes the runtime PIA assembly dependency; it does not manage
+COM reference lifetimes.
 
 ### PIA-First Interop (MANDATORY)
 
-Use strongly typed `Microsoft.Office.Interop.PowerPoint` PIA objects, properties, methods, and
-enums throughout ComInterop and Core. Do not use `dynamic`, reflection, raw `IDispatch`, or integer
-enum constants when the restored PIA exposes a typed equivalent.
-
-Late binding is an exception, not a compatibility default. Before using it:
-
-1. Inspect the restored interop assembly metadata and confirm the required member/type is absent.
-2. Keep the late-bound call as narrow as possible inside the STA `batch.Execute` callback.
-3. Add a concise comment naming the missing PIA surface and why late binding is required.
-4. Prove the behavior with a real-PowerPoint COM integration test.
+Follow the typed-access and late-binding requirements in
+[critical rules](critical-rules.instructions.md). The
+`ForceEmbedPowerPointInteropTypes` target embeds the PowerPoint and Office PIAs;
+do not port Excel's runtime assembly resolver here.
 
 If a typed Office enum is unavailable because only the PowerPoint PIA is embedded, prefer adding
 the appropriate PIA/reference support over replacing the enum with an unexplained integer.
@@ -106,8 +102,9 @@ the appropriate PIA/reference support over replacing the enum with an unexplaine
 ## Exception Propagation Pattern (CRITICAL)
 
 **Core Commands: let exceptions propagate naturally** — do not suppress with a catch block that
-returns an error result. See `critical-rules.instructions.md` Rule 1b for the full rationale and
-example.
+returns an error result. See `critical-rules.instructions.md` Rule 1b for the
+requirements, and the [development guide](../../docs/DEVELOPMENT-GUIDE.md)
+for the rationale and validation example.
 
 ## Session Ownership (Service-Backed Registry, Two Entry Points)
 
@@ -125,3 +122,12 @@ both entry points use — mirroring `mcp-server-excel`'s `ExcelMcp.Service` + `S
 
 The two entry points run as **separate processes** with **separate PowerPoint instances** and do
 **not** share live sessions with each other — only the same `Core`/`Service` codebase.
+
+`presentation(action="create", filePath)` creates and saves the file and returns
+an open session. Reuse that `sessionId`, rather than opening the file again.
+`presentation(action="test", filePath)` validates that PowerPoint can open the
+file without retaining a session. Presentation actions take `sessionId`;
+generated domain tools take `session_id`.
+
+For all-slide image export, prefer PowerPoint's single `Presentation.Export`
+call over a loop of `Slide.Export` calls.

--- a/.github/instructions/critical-rules.instructions.md
+++ b/.github/instructions/critical-rules.instructions.md
@@ -1,134 +1,59 @@
 ---
 applyTo: "**"
+excludeAgent: "code-review"
 ---
 
-# CRITICAL RULES - MUST FOLLOW
+# Critical rules
 
-> **NON-NEGOTIABLE rules for all PowerPointMcp development**
+## Rule 1: Success and errors
 
-## Rule 1: Success/ErrorMessage Invariant
+`Success == true` requires `ErrorMessage == null`. Set success only on the
+success path. Expected caller-correctable failures (bad indices, missing files,
+unknown sessions) return `Success=false`; validate before the failing COM call.
 
-**NEVER `Success = true` with a non-null `ErrorMessage`.** Set `Success` only in the success path;
-the field defaults to `false` (or is set explicitly `false`) alongside `ErrorMessage` on every
-failure path.
+## Rule 1b: Exception propagation
 
-**Why Critical:** Confuses LLM callers and downstream consumers of the MCP JSON payload — a
-non-null error message on a "successful" result is silently ignored by most clients.
+Never catch exceptions from `batch.Execute()` in Core and turn them into error
+results. Unexpected COM/runtime exceptions propagate through the batch.
+`PowerPointToolsBase.ExecuteToolAction` is the MCP catch-all boundary: it logs
+the HResult to stderr and returns a structured error. Do not add another
+catch-all in individual tools. MCP stdout is reserved for JSON-RPC.
 
-## Rule 1b: No Exception Suppression in Core
+## COM access and ownership
 
-**NEVER wrap `batch.Execute()` in a try-catch that swallows the exception and returns an error
-result.** Let exceptions propagate naturally out of Core commands — `IPresentationBatch.Execute`'s
-underlying `TaskCompletionSource` plumbing (in `PresentationBatch`, ComInterop layer) already
-surfaces them to the caller.
+- All PowerPoint access runs inside `batch.Execute` on its STA thread.
+- Use typed PowerPoint/Office PIA members and enums. Before using `dynamic`,
+  reflection, raw dispatch, or numeric enum values, confirm that the restored
+  interop metadata lacks the typed API, document the missing surface, and cover
+  the exception with a real-COM test. Convenience is not an exception.
+- Release every manually acquired COM reference in `finally`, including typed
+  references. Embedded PIA types do not manage COM reference lifetimes.
+- Slide, shape, row, and column indices are 1-based. Zero and negative values
+  are validation failures, not alternative indexing.
 
-The **only** place a catch-all belongs is the MCP tool boundary
-(`PowerPointToolsBase.ExecuteToolAction` in `src/PowerPointMcp.McpServer/Tools/`), which logs the
-HResult to stderr and serializes a structured error so the MCP host never crashes.
+## Rule 30: Behavior changes need real evidence
 
-```csharp
-// CORRECT — Core: exceptions propagate
-public ShapeOperationResult AddRectangle(IPresentationBatch batch, int slideIndex, ...)
-{
-    return batch.Execute((ctx, ct) => {
-        // COM access — no try/catch here
-    });
-}
+Write a focused failing regression test, observe the expected failure, then
+implement and rerun it. Never mock COM for Core commands: use real PowerPoint.
+Keep COM tests serialized and use explicit execution timeouts.
+Protocol-only MCP tests may use the SDK in-memory transport.
+See [testing strategy](testing-strategy.instructions.md) for filters and scope.
 
-// WRONG — Core: swallowing and returning a fabricated error result
-public ShapeOperationResult AddRectangle(IPresentationBatch batch, int slideIndex, ...)
-{
-    try { return batch.Execute(...); }
-    catch (Exception ex) { return new ShapeOperationResult { Success = false, ErrorMessage = ex.Message }; }
-}
-```
+## Session lifecycle
 
-**Expected, caller-correctable failures ARE validated up front and returned as `Success=false`**
-without throwing — e.g. an out-of-range `slideIndex`, a missing file, or an unknown `sessionId`.
-The distinction: validation failures are known preconditions checked BEFORE touching COM;
-unexpected COM/runtime exceptions are allowed to propagate and are only ever caught at the MCP
-tool boundary.
+- Track every live session in `PresentationSessionRegistry`. On host shutdown,
+  both `PresentationSessionShutdownService.StopAsync` and `Main`'s `finally`
+  call the idempotent `DisposeAll()` backstop.
+- Close removes a session immediately and disposes its batch in the background;
+  do not block close on process exit. PowerPoint may take minutes to exit after
+  Quit. Do not force-kill on the happy path.
+- Cleanup targets only proven process ownership (PID plus start time), never
+  process names, window-title matches, or another user's PowerPoint.
 
-## Rule 30: Real-COM Integration Tests Only, Strict TDD
+## Data and authorization
 
-**NEVER write unit tests with mocked COM objects for Core commands.** Every Core test drives a
-real PowerPoint desktop instance via `PresentationSession.BeginBatch`/`CreateNew`. Follow strict
-TDD: write a failing test first (red), watch it fail for the right reason, implement the minimal
-fix (green), then verify.
-
-**Enforcement:**
-- Tests are tagged `[Trait("Category", "Integration")]` + `[Trait("Feature", "<Domain>")]`.
-- Tests run serialized: `xunit.runner.json` sets `maxParallelThreads: 1` — concurrent PowerPoint
-  process launches are not supported and will cause flaky failures or hangs.
-- Use `--filter "Feature=<Domain>"` for surgical, fast feedback instead of running the whole suite
-  after every small change.
-- MCP transport tests (`tests/PowerPointMcp.McpServer.Tests`) may use the SDK's in-memory pipe
-  transport for protocol-only assertions (no COM launch) — only session-lifecycle round-trip
-  tests need real COM at the MCP layer.
-
-## Rule: 1-Based Indexing Everywhere
-
-`slideIndex`, `shapeIndex`, and table `row`/`column` are 1-based throughout Core, the MCP tool
-surface, and tests — matching PowerPoint's native COM object model. Never introduce 0-based
-indexing in new code; a 0 or negative index is an expected validation failure
-(`Success=false`), not something to special-case as valid.
-
-## Rule: PIA-First COM Access
-
-**Always use strongly typed members from the embedded `Microsoft.Office.Interop.PowerPoint` PIA
-for PowerPoint COM access.** Use the corresponding typed Office/PowerPoint enum instead of raw
-integer constants whenever the referenced PIA exposes it.
-
-`dynamic`, reflection, raw dispatch, or numeric COM enum values are allowed only when the actual
-restored PIA does not expose the required member or type. Every exception must:
-
-1. Be confirmed against the restored interop metadata, not assumed from a web example.
-2. Include a concise code comment explaining the missing PIA surface.
-3. Have real-COM test coverage for the late-bound behavior.
-
-Convenience or shorter syntax is never sufficient justification for bypassing the PIA.
-
-## Rule: Session Lifecycle Discipline
-
-- Every session (`PresentationSessionRegistry` entry) MUST be reachable from
-  `PresentationSessionRegistry.DisposeAll()` at host shutdown — never create a code path that
-  starts a `PresentationBatch` outside the registry's tracking.
-- `presentation(action: "close", sessionId: ...)` is asynchronous by design: it removes the
-  session from the registry immediately and disposes the batch (and its PowerPoint process) on a
-  background task. Do not make it block on process exit — Office's own cleanup can legitimately
-  take minutes.
-
-## Rule: No Confidential Information in Commits/PRs/Issues
-
-Never include confidential project names, customer names, or internal file paths that identify a
-specific customer engagement in commit messages, PR descriptions, or issue text. Use generic
-descriptions ("a PowerPoint deck", "a chart shape") instead.
-
-## Rule: Never Commit Automatically
-
-Never commit, push, or merge without explicit user approval. No background or silent commits.
-
-## Quick Reference (Grouped by Context)
-
-**Every Edit:**
-| Rule | Action | Why Critical |
-|------|--------|---------------|
-| Success flag | NEVER `Success=true` with `ErrorMessage` | Confuses callers, silent failures |
-| No exception wrapping | Never catch-and-return-error inside Core | Preserves stack context, avoids double-wrapping |
-| 1-based indexing | Never introduce 0-based indices | Matches COM object model, avoids silent bugs |
-| PIA-first COM | Use typed PIA members/enums; late-bind only when the restored PIA lacks the API | Preserves compile-time safety and discoverability |
-
-**When Writing Code:**
-| Rule | Action | Why Critical |
-|------|--------|---------------|
-| TDD | Write the failing test FIRST → red → implement → green | Proves the test actually catches the bug |
-| Integration tests only | NEVER mock COM — real PowerPoint only | Unit tests prove nothing for COM interop |
-| COM cleanup | Use try/finally for any manually-acquired COM object refs | Prevents leaks |
-
-**Before Commit:**
-| Rule | Action |
-|------|--------|
-| Build | `dotnet build Sbroenne.PowerPointMcp.slnx` — 0 warnings, 0 errors |
-| Tests | Run `Feature=`-filtered tests for the domain(s) you touched |
-| Pre-commit hook | `scripts/pre-commit.ps1` must pass |
-| No confidential info | Scrub commit messages/PR text before submitting |
+Keep customer names, presentation contents, credentials, and private paths out
+of commits, PRs, issues, logs, and other public artifacts. Use generic examples.
+Keep temporary notes outside the repository. Never commit, push, merge, or
+publish without explicit user authorization; see the root Git guidance for
+GitHub PR assignments.

--- a/.github/instructions/development-workflow.instructions.md
+++ b/.github/instructions/development-workflow.instructions.md
@@ -1,0 +1,28 @@
+---
+applyTo: ".github/workflows/**,.github/github-app.yml,**/*.csproj,global.json,Directory.Build.*,Directory.Packages.props,scripts/**/*.ps1"
+excludeAgent: "code-review"
+---
+
+# Build and release constraints
+
+- Keep SDK setup compatible with `global.json`; preserve warnings-as-errors and
+  analyzers. Use existing CI and pre-commit checks, not substitute scripts.
+- `ci.yml` runs without PowerPoint. Real-COM tests stay local on Windows with
+  desktop PowerPoint. Do not remove that coverage or pretend a build covers COM.
+- Preserve pre-commit selection of docs-only, tooling, and runtime changes.
+  MCP tests marked `RequiresPowerPoint=true` need PowerPoint even though most
+  MCP protocol tests do not.
+- Local builds call `scripts/Stop-PowerPointMcpProcesses.ps1`. Preserve tracked
+  PID-plus-start-time ownership. In shared environments, use
+  `-p:PowerPointMcpSkipCleanup=true` to avoid build-triggered cleanup; this is not
+  permission to bypass hooks or disable test cleanup.
+- `release.yml` owns versions, changelog generation, and publication. Never
+  dispatch it as a test.
+- Skill guidance belongs in `skills/shared/`. `scripts/Build-AgentSkills.ps1`
+  synchronizes references into both skill packages; follow `skills/README.md`.
+  Do not edit copies alone or assume an ordinary solution build packages skills.
+
+Procedures: [release strategy](../../docs/RELEASE-STRATEGY.md),
+[plugin publication](../workflows/docs/publish-plugins-setup.md), and
+[agent setup](../../docs/AGENT-CONFIGURATION.md).
+Hook setup and check selection: [development guide](../../docs/DEVELOPMENT-GUIDE.md).

--- a/.github/instructions/mcp-server-guide.instructions.md
+++ b/.github/instructions/mcp-server-guide.instructions.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "src/PowerPointMcp.McpServer/**/*.cs"
+applyTo: "src/PowerPointMcp.McpServer/**/*.cs,src/PowerPointMcp.Generators.Mcp/**/*.cs,src/PowerPointMcp.Generators.Shared/**/*.cs"
+excludeAgent: "code-review"
 ---
 
 # MCP Server Development Guide
@@ -31,7 +32,8 @@ Most of the MCP tool surface is **generated**, not hand-written. Before editing 
   action-dispatch like Excel's file tool, but stays hand-written because create/open/list/close
   need custom session-registry behavior and optional `sessionId`.
 - **Generated** (everything else — `slide`, `shape`, `textframe`, `table`, `notes`, `layout`,
-  `master`, `animation`, `image`, `media`, `chart`, `smartart`, `export`): one action-dispatch tool per
+  `master`, `animation`, `image`, `media`, `chart`, `smartart`, `export`, `pagesetup`,
+  `accessibility`): one action-dispatch tool per
   `[ServiceCategory]` Core domain, emitted by `PowerPointMcp.Generators.Mcp` from the Core
   interface's `[ServiceCategory]`/`[McpTool]` attributes and XML doc comments. **Never hand-write a
   new tool class for one of these domains** — add the operation to the Core interface (with XML

--- a/.github/instructions/meta.instructions.md
+++ b/.github/instructions/meta.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "AGENTS.md,CLAUDE.md,.github/copilot-instructions.md,.github/instructions/**,.github/github-app.yml,docs/AGENT-CONFIGURATION.md"
+excludeAgent: "code-review"
+---
+
+# Instruction maintenance
+
+- Keep always-loaded guidance short: repository constraints, required checks,
+  non-obvious pitfalls, and source pointers. Avoid tutorials and inventories.
+- Give each rule one authoritative home. Put task-specific details in scoped
+  `*.instructions.md` files with quoted `applyTo`; link them from the root.
+- Agent-specific entry points only import or link shared guidance. Document
+  client-specific loading differences instead of maintaining separate rules.
+- Include owning generators in scope when generated behavior is involved.
+  Implementation instructions exclude `code-review`; review instructions
+  exclude `cloud-agent` and keep the essential review checks independently.
+- Preserve unique safeguards and update inbound links when consolidating.
+  Compare removed content against its destination. Move useful explanations,
+  examples, and procedures to linked docs rather than dropping them; document
+  corrections to obsolete claims. Keep the migration map in
+  `docs/DEVELOPMENT-GUIDE.md` current and agent setup in
+  `docs/AGENT-CONFIGURATION.md`.
+- Use `.github/github-app.yml` for app settings, not duplicate instructions or
+  an unrequested model override. Keep scripts manual unless startup behavior is
+  explicitly needed. Do not change account permissions or firewall settings.

--- a/.github/instructions/testing-strategy.instructions.md
+++ b/.github/instructions/testing-strategy.instructions.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "tests/**/*.cs"
+applyTo: "tests/**,src/PowerPointMcp.Core/**/*.cs,src/PowerPointMcp.ComInterop/**/*.cs"
+excludeAgent: "code-review"
 ---
 
 # Testing Strategy
@@ -68,7 +69,10 @@ dotnet test tests\PowerPointMcp.Core.Tests --filter "Feature=Shape"
 # Full Core suite (real COM, serialized — slower)
 dotnet test tests\PowerPointMcp.Core.Tests
 
-# MCP protocol + round-trip suite
+# MCP protocol tests without PowerPoint (exclude all marked lifecycle tests)
+dotnet test tests\PowerPointMcp.McpServer.Tests --filter "RequiresPowerPoint!=true"
+
+# MCP protocol + round-trip suite (requires PowerPoint)
 dotnet test tests\PowerPointMcp.McpServer.Tests
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #
 # It ports the PowerPoint-free pre-commit gates (scripts/pre-commit.ps1) into CI so
 # that the correctness checks are enforced server-side even if a contributor
-# bypasses the local hook (see Rule 31 in .github/copilot-instructions.md). The
+# bypasses the local hook. The
 # PowerPoint-dependent gates — the Core Feature tests and the MCP Server's real-COM
 # session tests — are intentionally NOT run here: GitHub-hosted runners do not
 # have Microsoft PowerPoint installed, so those remain local-only (pre-commit) and

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            vscode-extension/package-lock.json
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: gh-pages/requirements.txt
+
+      - name: Restore .NET dependencies
+        run: dotnet restore Sbroenne.PowerPointMcp.slnx
+
+      - name: Install repository tooling
+        run: npm ci
+
+      - name: Install VS Code extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
+
+      - name: Install documentation dependencies
+        run: python -m pip install -r gh-pages/requirements.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Coding agents
+
+Follow [.github/copilot-instructions.md](.github/copilot-instructions.md) and its
+task-specific instruction links. These are the shared rules for Copilot locally
+and on GitHub, and for other agents that read `AGENTS.md`, including Codex.
+Read the linked task-specific files explicitly when your client does not support
+GitHub's `applyTo` metadata. Do not duplicate rules in agent-specific files.
+
+Read the [architecture guide](.github/instructions/architecture-patterns.instructions.md)
+before runtime changes. For skills, also read [skills/CLAUDE.md](skills/CLAUDE.md).
+Setup details: [docs/AGENT-CONFIGURATION.md](docs/AGENT-CONFIGURATION.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Code
+
+Use the shared repository rules:
+
+@.github/copilot-instructions.md
+@.github/instructions/critical-rules.instructions.md
+
+Read the task-specific files linked by those rules before editing the relevant
+area; do not assume GitHub's `applyTo` metadata loads them in Claude Code.

--- a/docs/AGENT-CONFIGURATION.md
+++ b/docs/AGENT-CONFIGURATION.md
@@ -1,0 +1,84 @@
+# Copilot configuration
+
+GitHub Copilot is the primary coding agent locally and on GitHub. Both use
+[the repository instructions](../.github/copilot-instructions.md).
+[AGENTS.md](../AGENTS.md) provides the same entry point to tools that discover
+that filename, including Codex. [CLAUDE.md](../CLAUDE.md) imports the shared root
+and critical rules for Claude Code. No custom agent or fixed model is required.
+
+## Other agents
+
+| Client | Entry point | Task-specific rules |
+| --- | --- | --- |
+| Copilot locally and on GitHub | `.github/copilot-instructions.md` | Scoped instruction files plus root links |
+| Codex and other `AGENTS.md` readers | `AGENTS.md` | Follow the shared root's task links |
+| Claude Code | `CLAUDE.md` imports | Follow the shared root's task links |
+| Clients with another instruction format | Point their project guidance at `AGENTS.md` | Read the linked files explicitly |
+
+GitHub's `applyTo` and `excludeAgent` metadata is not portable to every client.
+The shared entry points therefore instruct agents to read relevant files, rather
+than assuming automatic loading. The app commands and cloud setup workflow below
+are Copilot-specific; other agents use their own environment setup. These files
+provide guidance, not tool permissions or a guarantee that a client obeys it.
+
+## Where guidance belongs
+
+- `.github/copilot-instructions.md`: short shared entry point and task links.
+- `.github/instructions/critical-rules.instructions.md`: always-needed safety rules.
+- Other `.github/instructions/*.instructions.md`: task-specific guidance selected
+  by file path. Root links also make it available when a client does not load
+  path-specific files automatically.
+- `code-review.instructions.md`: independent review checks, not implementation
+  procedures. Implementation files exclude code review to avoid duplicate advice.
+- `.github/github-app.yml`: local app commands, without another copy of the rules.
+- `.github/workflows/copilot-setup-steps.yml`: GitHub coding-agent environment setup.
+
+This follows the instruction structure in `sbroenne/mcp-server-excel`, adapted
+for PowerPoint's PIA embedding, process ownership, and existing test filters.
+Keep detailed architecture in its scoped guide rather than growing the root
+prompt with operation counts or repeated examples.
+The [development guide](DEVELOPMENT-GUIDE.md) preserves the supporting
+explanations, procedures, and a section-by-section map of the former guidance.
+
+## Local app
+
+Review and accept `.github/github-app.yml` when prompted by the Copilot app.
+Repository configuration changes are not applied until accepted. The commands
+are manual: opening a session does not start builds, install dependencies, launch
+PowerPoint, or terminate processes.
+
+The build and PowerPoint-free test commands disable build-triggered process
+cleanup so they do not interrupt other live sessions. Test hang detection is a
+backstop; agent-driven test runs must also have an overall execution timeout.
+For Core/COM work, run the focused real-PowerPoint tests described in
+[the testing strategy](../.github/instructions/testing-strategy.instructions.md).
+The normal pre-commit hook remains authoritative; these commands do not replace it.
+
+## GitHub coding agent
+
+The setup workflow takes effect for agent sessions after it reaches the default
+branch. It can also be run manually or checked on a PR changing that workflow.
+It prepares Windows, the SDK from `global.json`, Node.js, Python, and dependencies
+for the solution, extension, and documentation. It does not install PowerPoint.
+
+Windows coding-agent environments do not support Copilot's integrated firewall.
+Before using this workflow for cloud sessions, the repository administrator must
+review runner availability and network controls. GitHub recommends a self-hosted
+or larger Windows runner with appropriate network controls. If required, replace
+`runs-on` with the approved Windows runner label and configure the repository
+settings separately. This change does not provision runners, change permissions,
+or disable the firewall.
+
+On a Windows runner without PowerPoint, builds, static audits, packaging tests,
+and MCP tests filtered with `RequiresPowerPoint!=true` can run. Core and
+PowerPoint-dependent lifecycle tests require local desktop PowerPoint; report
+them as not run when unavailable. Do not replace them with mocked COM tests.
+Use the existing [CI Gate](../.github/workflows/ci.yml) as the build/check reference.
+
+Setup failures are visible in the workflow logs; the agent may start with only
+part of the environment ready. Check the actual tool availability rather than
+assuming setup succeeded.
+
+References:
+[app configuration](https://docs.github.com/en/copilot/reference/github-copilot-app-reference/repository-configuration)
+and [cloud environment setup](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/customize-the-agent-environment).

--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -1,0 +1,237 @@
+# Development guide
+
+This is the explanatory companion to the short
+[repository instructions](../.github/copilot-instructions.md). It preserves
+background, examples, and procedures moved out of the always-loaded agent
+guidance. Mandatory rules remain in the linked instruction files.
+
+## System map and sister projects
+
+PowerPointMcp automates a live desktop PowerPoint instance on Windows through
+the official PowerPoint Primary Interop Assembly (PIA). It serves both coding
+agents and automation scripts through two equal entry points: MCP and `pptcli`.
+
+| Area | Responsibility |
+| --- | --- |
+| `src/PowerPointMcp.ComInterop` | Dedicated STA thread, OLE message filter, and channel-based work queue in `PresentationBatch` |
+| `src/PowerPointMcp.Core` | Domain command interfaces, implementations, and result objects |
+| `src/PowerPointMcp.Generators` | Shared service dispatch and skill manifest generation from Core contracts |
+| `src/PowerPointMcp.Generators.Mcp` | MCP action-dispatch tools |
+| `src/PowerPointMcp.Generators.Cli` | CLI settings and command registration |
+| `src/PowerPointMcp.Generators.Shared` | Metadata and helpers shared by generators |
+| `src/PowerPointMcp.Service` | Session registry and shared command dispatch |
+| `src/PowerPointMcp.McpServer` | JSON-RPC stdio host with the service in-process |
+| `src/PowerPointMcp.CLI` | `pptcli`, communicating with a persistent service process over a named pipe |
+
+Excel's repository, `sbroenne/mcp-server-excel`, is the architectural reference:
+layering, the unified service design, generators, hand-written versus generated
+tools, COM cleanup, support scripts, and CI checks. Its `ExcelBatch` design is
+the reference for `PresentationBatch`. Investigate differences rather than
+assuming a new PowerPoint-specific design is necessary. `mcp-windows` is the
+related Windows automation project; flag shared defects without changing it as
+part of a PowerPoint task.
+
+Some differences are intentional. PowerPoint has no
+`Application.ScreenUpdating`. `ForceEmbedPowerPointInteropTypes` in
+`Directory.Build.targets` embeds the PowerPoint and Office interop types, so
+there is no equivalent runtime PIA assembly resolver to copy from Excel.
+Embedding types removes an assembly dependency, not the need to release COM
+references.
+
+See [architecture patterns](../.github/instructions/architecture-patterns.instructions.md)
+for class organization, the command interface example, and resource ownership.
+
+## Following an operation through both entry points
+
+Core domains marked `[ServiceCategory]` supply the contract read by the
+generators. The MCP surface is one tool per domain with an `action` argument,
+not one hand-written tool per operation. CLI registration is generated through
+`CliCommandRegistration.RegisterCommands`. Both entry points reach the same
+service dispatch and Core command implementations.
+
+`PresentationTools.cs` is the hand-written `presentation` action-dispatch tool.
+Its lifecycle, template, and document-property behavior needs special session
+handling. Export is available on both entry points; it is not a CLI parity gap.
+Adding a generated operation means changing the Core contract and implementation,
+not editing generated output or adding a parallel hand-written MCP tool.
+
+The old instruction inventories mixed different generations of tool counts.
+Use these sources rather than retaining a snapshot of those numbers:
+
+- The generated `_SkillManifest.g.cs` lists generated domains and operations.
+- `PresentationToolAction` supplies the hand-written presentation actions.
+- `McpProtocolTests.ExpectedToolNames` defines the expected MCP tool list.
+- `scripts/check-doc-counts.ps1` checks advertised counts after a current Release build.
+
+The MCP SDK resolves `PresentationSessionRegistry registry` and
+`PowerPointMcpService service` from dependency injection rather than exposing
+them as caller arguments. Protocol tests verify this through `tools/list`;
+do not add manual schema suppression for these parameters.
+See the [MCP guide](../.github/instructions/mcp-server-guide.instructions.md)
+for dispatch, validation, serialization, and schema examples.
+
+## Sessions and why they persist
+
+The MCP host is already long-lived, so it hosts the service in-process via
+`ServiceBridge.ForwardToService`. CLI invocations are short-lived, so
+`ServiceClient` and `IPowerPointDaemonRpc` communicate with a separate background
+service using StreamJsonRpc over a named pipe. This preserves CLI sessions and
+avoids paying PowerPoint's substantial startup cost on every command. Earlier
+guidance observed roughly 90-150 seconds for startup; treat this as an observation,
+not a guaranteed timing contract.
+
+MCP and CLI share code, not live sessions or PowerPoint instances.
+The MCP lifecycle is:
+
+```text
+presentation(action="create", filePath) -> saved file and open sessionId
+presentation(action="open", filePath)   -> open sessionId
+domain(action=..., session_id=...)     -> operate on the existing session
+presentation(action="test", filePath)  -> validate opening; retain no session
+presentation(action="close", sessionId, save=true)
+                                      -> save, remove session, dispose in background
+```
+
+Reuse the session returned by create instead of opening the same file again.
+The close call returns without waiting for the PowerPoint process to exit.
+Office may take minutes to finish post-Quit cleanup; that delay alone does not
+prove a leak or justify force-killing it.
+
+Host shutdown through Ctrl+C, stdin EOF, or normal exit has two cleanup layers:
+`PresentationSessionShutdownService.StopAsync` and the `Main` finally block both
+call the registry's idempotent `DisposeAll()`. The
+[critical rules](../.github/instructions/critical-rules.instructions.md)
+define the required tracking and process-ownership safeguards.
+
+For exporting every slide to an image, the architecture guide retains the
+preference for one native `Presentation.Export` call over a per-slide loop.
+
+## Why success and exception handling are separate rules
+
+A result reporting success alongside an error message can cause agents and
+other callers to ignore the error. Set success only when the operation really
+completed; do not initialize it optimistically and then attach an error.
+
+Expected invalid input is different from an unexpected COM failure. Validate
+known preconditions before the failing COM call and return an error result.
+Unknown-session validation at the MCP boundary, for example, follows this shape:
+
+```csharp
+if (!registry.TryGet(sessionId, out var batch))
+{
+    return PowerPointToolsBase.ValidationError($"Unknown sessionId: {sessionId}");
+}
+```
+
+In Core, return `batch.Execute(...)` directly rather than wrapping it in a
+catch that manufactures an error result. The batch's `TaskCompletionSource`
+already carries unexpected exceptions back from the STA thread. Swallowing
+them in Core loses diagnostic context and introduces a second error boundary.
+`PowerPointToolsBase.ExecuteToolAction` is the MCP boundary that logs the HResult
+to stderr and returns a structured error. Stdout is reserved for JSON-RPC.
+
+The [critical rules](../.github/instructions/critical-rules.instructions.md)
+retain the success invariant, typed PIA requirements, 1-based indices, and
+real-COM regression-test requirement. The
+[testing strategy](../.github/instructions/testing-strategy.instructions.md)
+retains the red/green sequence, test traits and filters, serialization,
+fixture pitfalls, shutdown observations, and protocol-versus-COM distinction.
+
+## Build, checks, and hooks
+
+Use the build commands in the root instructions and targeted tests in the
+testing strategy. Use precise file edits and code search for source changes;
+PowerShell is appropriate for `dotnet`, Git, and repository scripts. Tool names
+vary between agents, so the old editor-specific tool names are not requirements.
+
+The [pre-commit script](../scripts/pre-commit.ps1) is the executable reference
+for local checks. Its checks include:
+
+| Check | Selection and purpose |
+| --- | --- |
+| Branch guard | Blocks direct commits to `main` |
+| Process cleanup | Stops owned daemon processes and shuts down build servers |
+| Success flag audit | Checks the success/error invariant |
+| COM leak, dynamic cast, and interface audits | Run for non-docs changes |
+| Release build | Runs for non-docs changes with warnings treated as errors |
+| Documentation counts | Always runs; creates a manifest with a one-time build if missing |
+| Core tests | Selects `Feature=` tests for changed Core domains |
+| MCP tests | Full suite for runtime changes, PowerPoint-free subset for tooling, skipped for docs-only changes |
+| Release and skill packaging tests | Runs for non-docs changes |
+| Unresolved-marker scan | Scans eligible changed files |
+
+Even a docs-only commit can invoke process cleanup and a first build when the
+manifest is absent. Do not confuse manual app commands with the full hook.
+The [CI Gate](../.github/workflows/ci.yml) is the server-side reference; it cannot
+replace local PowerPoint-dependent checks.
+
+### Installing a hook in a normal checkout or worktree
+
+First inspect `git config --get core.hooksPath` and
+`git rev-parse --git-path hooks/pre-commit` from the working checkout.
+An unset `core.hooksPath` is normal. Respect any existing hook or hook manager;
+do not overwrite it. Worktrees commonly use a `.git` file, not a `.git`
+directory, and may share hook storage with another checkout.
+
+Git needs an executable hook launcher. A launcher can invoke the checked-in
+PowerShell script using this content:
+
+```sh
+#!/bin/sh
+exec pwsh -NoProfile -File scripts/pre-commit.ps1
+```
+
+Install it at the resolved hook path only after reviewing any existing hook,
+and keep it executable where the platform requires that. The old
+`Copy-Item scripts\pre-commit.ps1 .git\hooks\pre-commit` shortcut is not reliable
+for worktrees or Git's hook interpreter. Do not bypass a failing hook.
+
+### GitHub account selection
+
+For this repository's namespace, verify that `gh auth status` reports the
+personal `sbroenne` account as active. If an inherited `GH_TOKEN` selects a
+different account, remove that override only in the command's process before
+using `gh auth switch --hostname github.com --user sbroenne`, then recheck.
+Never print token values or store them in repository files. Switching accounts
+does not authorize committing, pushing, merging, or publishing.
+
+## Authoring skills and shared guidance
+
+The [skills README](../skills/README.md) describes both `powerpoint-mcp` and
+`powerpoint-cli`, their distribution, and their build procedure. The former
+uses rich MCP schemas; the latter provides a compact command surface for agents
+and scripts.
+
+`skills/shared/` is the authoring source of truth. `Build-AgentSkills.ps1`
+synchronizes shared references into both skill packages and generates the CLI
+command reference from live help. Edit the source, not only a copied reference.
+Read [skills/CLAUDE.md](../skills/CLAUDE.md) before changing that area.
+An ordinary solution build is not a substitute for the skill packaging procedure.
+The old statement that no synchronization tooling exists is obsolete.
+
+## Where the former root guidance went
+
+This map records the consolidation so that shortening the agent prompt does not
+hide the information from contributors.
+
+| Former section or lesson | Current home |
+| --- | --- |
+| Critical files and path-specific loading | Root task table and [agent configuration](AGENT-CONFIGURATION.md) |
+| Sister projects and PowerPoint overview | System map above and architecture guide |
+| Layer responsibilities, generators, CLI daemon | System map and operation/session explanations above |
+| Fixed tool, operation, and project counts | Code-derived sources above; stale inventories replaced |
+| Session model and create/test/close behavior | Sessions above and architecture guide |
+| 1-based indexing and PIA-first access | Critical rules; resource-management details in architecture guide |
+| Rule 1/1b, rationale, and examples | Critical rules, explanation above, and MCP guide |
+| Rule 30 and test commands | Testing strategy, including focused filters and actual PowerPoint requirements |
+| Tool-selection quick reference | Build section above without agent-specific tool names |
+| GitHub account rule | Account-selection procedure above and root authorization rules |
+| DI/schema, shutdown, parity, live generators, export lessons | Operation/session sections above, MCP guide, and architecture guide |
+| Skills and shared guidance | Skills section above and skills README; obsolete manual-only sync claim corrected |
+| Pre-commit table and installation | Hook section above and executable script |
+| Confidentiality and commit approval | Critical rules and root Git/release section |
+
+Repeated summaries were consolidated, not treated as separate rules. Incorrect
+claims were corrected rather than archived as active instructions: generated
+tool counts, PIA embedding managing COM lifetimes, missing skill synchronization,
+and the worktree-incompatible hook installation shortcut.

--- a/scripts/pre-commit.ps1
+++ b/scripts/pre-commit.ps1
@@ -7,7 +7,7 @@
 
 .DESCRIPTION
     Runs checks before allowing commits (ported and adapted from mcp-server-excel's
-    scripts/pre-commit.ps1 — see .github/copilot-instructions.md for the full gate table):
+    scripts/pre-commit.ps1 — the gate list below is authoritative):
 
     0. Process cleanup   - stops only processes proven to belong to the CLI daemon
     1. Branch guard      - never commit directly to 'main'


### PR DESCRIPTION
## Summary

Make Copilot the primary coding agent locally and on GitHub while retaining shared support for Codex and Claude Code. Reduce repeated instructions without losing development information.

## Changes

- Short shared instructions with task-specific guidance and AGENTS.md / CLAUDE.md entry points.
- Preserve explanations, examples, hook procedures, and a section-by-section migration map in docs/DEVELOPMENT-GUIDE.md.
- Correct outdated claims about interop cleanup, tool counts, hook installation, and skill synchronization.
- Add manual app commands and Windows Copilot setup using global.json.
- Document cloud runner/network review and local PowerPoint testing requirements; no permissions or firewall changes.

## Testing

Normal pre-commit hook passed: Release build with zero warnings/errors, 37 MCP protocol tests, 66 packaging tests, and existing static audits and documentation count checks. Markdown links, Claude imports, YAML, PowerShell syntax, and whitespace checked. Real-PowerPoint tests not run because this changes configuration/docs only. Cloud setup is exercised by the PR workflow.

## Changelog

- [ ] Added a user-visible product changeset.
- [x] No product changelog required; apply `skip-changelog` for configuration/docs/CI.